### PR TITLE
Attack Damage on Weapons instead of weired 1.9 stuff

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/ItemRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/ItemRewriter.java
@@ -1,6 +1,7 @@
 package us.myles.ViaVersion.protocols.protocol1_9to1_8;
 
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
+import com.github.steveice10.opennbt.tag.builtin.IntTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import com.github.steveice10.opennbt.tag.builtin.Tag;
@@ -16,6 +17,8 @@ public class ItemRewriter {
     private static final Map<Integer, String> ENTTIY_ID_TO_NAME = new HashMap<>();
     private static final Map<String, Integer> POTION_NAME_TO_ID = new HashMap<>();
     private static final Map<Integer, String> POTION_ID_TO_NAME = new HashMap<>();
+
+    private static final Map<Integer, Double> WEAPON_DAMAGES = new HashMap<>();
 
     private static final Map<Integer, Integer> POTION_INDEX = new HashMap<>();
 
@@ -135,6 +138,37 @@ public class ItemRewriter {
         registerPotion(8200, "weakness");
         registerPotion(8264, "long_weakness");
 
+        /* Weapons*/
+        WEAPON_DAMAGES.put(276, 7.0);
+        WEAPON_DAMAGES.put(267, 6.0);
+        WEAPON_DAMAGES.put(272, 5.0);
+        WEAPON_DAMAGES.put(283, 4.0);
+        WEAPON_DAMAGES.put(268, 4.0);
+
+        WEAPON_DAMAGES.put(278, 5.0);
+        WEAPON_DAMAGES.put(257, 4.0);
+        WEAPON_DAMAGES.put(274, 3.0);
+        WEAPON_DAMAGES.put(270, 2.0);
+        WEAPON_DAMAGES.put(285, 2.0);
+
+        WEAPON_DAMAGES.put(279, 6.0);
+        WEAPON_DAMAGES.put(258, 5.0);
+        WEAPON_DAMAGES.put(275, 4.0);
+        WEAPON_DAMAGES.put(271, 3.0);
+        WEAPON_DAMAGES.put(286, 3.0);
+
+        WEAPON_DAMAGES.put(277, 4.0);
+        WEAPON_DAMAGES.put(256, 3.0);
+        WEAPON_DAMAGES.put(273, 2.0);
+        WEAPON_DAMAGES.put(269, 1.0);
+        WEAPON_DAMAGES.put(284, 1.0);
+
+        WEAPON_DAMAGES.put(293, 1.0);
+        WEAPON_DAMAGES.put(292, 1.0);
+        WEAPON_DAMAGES.put(291, 1.0);
+        WEAPON_DAMAGES.put(290, 1.0);
+        WEAPON_DAMAGES.put(294, 1.0);
+
     }
 
     public static void toServer(Item item) {
@@ -168,8 +202,7 @@ public class ItemRewriter {
                 item.setTag(tag);
                 item.setData((short) data);
             }
-            // Splash potion
-            if (item.getId() == 438) {
+            if (item.getId() == 438) { // Splash potion
                 CompoundTag tag = item.getTag();
                 int data = 0;
                 item.setId((short) 373); // Potion
@@ -184,6 +217,7 @@ public class ItemRewriter {
                 item.setTag(tag);
                 item.setData((short) data);
             }
+            fixWeaponToServer(item); //Weapons
         }
     }
     
@@ -274,7 +308,88 @@ public class ItemRewriter {
                 }
                 item.setTag(tag);
             }
+            fixWeaponToClient(item); //Weapons
         }
+    }
+
+    public static void fixWeaponToServer(Item item) {
+        if (!WEAPON_DAMAGES.containsKey((int)item.getId())) return;
+
+        CompoundTag tag = item.getTag();
+
+        if (tag==null) return;
+
+        if (!tag.contains("HideFlags") || (((int)tag.get("HideFlags").getValue()) & 2) != 2) return;
+
+        CompoundTag display = tag.get("display");
+        if (display==null || !display.contains("Lore")) return;
+
+        ListTag lore = display.get("Lore");
+        if (lore.size()<2 || !((String)lore.get(lore.size()-1).getValue()).endsWith("Attack Damage")) return;
+
+        lore.remove(lore.get(lore.size()-1));
+        lore.remove(lore.get(lore.size()-1));
+        if (lore.size()==0) {
+            display.remove("Lore");
+            if (display.isEmpty()) tag.remove("display");
+        }
+
+        IntTag hideFlags = tag.get("HideFlags");
+        hideFlags.setValue(hideFlags.getValue() ^ 2);
+        if (hideFlags.getValue()==0) tag.remove("HideFlags");
+
+        if (tag.isEmpty()) item.setTag(null);
+    }
+
+    public static void fixWeaponToClient(Item item) {
+        if (!WEAPON_DAMAGES.containsKey((int)item.getId())) return;
+
+        CompoundTag tag = item.getTag();
+
+        if (tag!=null && tag.contains("HideFlags") && (((int)tag.get("HideFlags").getValue()) & 2) == 2) return;
+
+        if (tag==null) {
+            tag = new CompoundTag("");
+            item.setTag(tag);
+        }
+
+        if (tag.contains("HideFlags")) {
+            IntTag hideFlags = tag.get("HideFlags");
+            hideFlags.setValue(hideFlags.getValue() ^ 2);
+        } else {
+            tag.put(new IntTag("HideFlags", 2));
+        }
+
+        double damage = getWeaponDamage(item);
+        if (damage<=1) return;
+        String damageString = "§9+" + damage + " Attack Damage";
+
+        CompoundTag display = tag.get("display");
+        if (display==null)
+            tag.put(display = new CompoundTag("display"));
+
+        ListTag lore = display.get("Lore");
+        if (lore==null)
+            display.put(lore = new ListTag("Lore", StringTag.class));
+
+        lore.add(new StringTag(null, ""));
+        lore.add(new StringTag(null, damageString));
+    }
+
+    public static double getWeaponDamage(Item item) {
+        double damage = WEAPON_DAMAGES.get((int)item.getId());
+        if (damage<=1) return 1;
+        if (item.getTag()!=null && item.getTag().contains("ench")) {
+            ListTag ench = item.getTag().get("ench");
+            for (int i = 0; i<ench.size(); i++) {
+                CompoundTag tag = ench.get(i);
+                if ((short)tag.get("id").getValue()==(short)16) {
+                    short level = (short)tag.get("lvl").getValue();
+                    return damage + (level >= 1 ? level * 1.25D : 0.0D);
+                }
+            }
+        }
+        return damage;
     }
 
     public static String potionNameFromDamage(short damage) {


### PR DESCRIPTION
In 1.8 Weapons looked like this: https://puu.sh/ynhhE/5f0c5d7f5e.png
In 1.9 Mojang added some weired formatted stuff: https://puu.sh/ynhgN/5f31bb5c15.png

This would be fixed for 1.9+ clients on 1.8 servers by this pull request ;)