### PR TITLE
Chat message changes

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitConfigAPI.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitConfigAPI.java
@@ -161,6 +161,11 @@ public class BukkitConfigAPI extends Config implements ViaVersionConfig {
     }
 
     @Override
+    public String get1_11ChatMsgCharacterLimitAction() {
+        return getString("chat-msg-character-limit-action", "TRUNCATE");
+    }
+    
+    @Override
     public boolean is1_12NBTArrayFix() {
         return getBoolean("chat-nbt-fix", true);
     }

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeConfigAPI.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeConfigAPI.java
@@ -198,6 +198,11 @@ public class BungeeConfigAPI extends Config implements ViaVersionConfig {
     public boolean isForceJsonTransform() {
         return getBoolean("force-json-transform", false);
     }
+    
+    @Override
+    public String get1_11ChatMsgCharacterLimitAction() {
+        return getString("chat-msg-character-limit-action", "TRUNCATE");
+    }
 
     @Override
     public boolean is1_12NBTArrayFix() {

--- a/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
@@ -204,19 +204,27 @@ public interface ViaVersionConfig {
     boolean isForceJsonTransform();
 
     /**
+     * Get settings for what we should do with chat messages 
+     * when they exceed the limit of 100 characters on older servers
+     * 
+     * @return Action for chat messages
+     */
+    String get1_11ChatMsgCharacterLimitAction();
+
+    /**
      * Should we fix nbt array's in json chat messages for 1.12 clients
      *
      * @return True if enabled
      */
     boolean is1_12NBTArrayFix();
-    
+
     /**
      * Should we fix shift quick move action for 1.12 clients
      *
      * @return True if enabled
      */
     boolean is1_12QuickMoveActionFix();
-    
+
     /**
      * Get the blocked protocols
      *

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/Protocol1_11To1_10.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/Protocol1_11To1_10.java
@@ -361,7 +361,9 @@ public class Protocol1_11To1_10 extends Protocol {
                     public void handle(PacketWrapper wrapper) throws Exception {
                         // 100 character limit on older servers
                         String msg = wrapper.get(Type.STRING, 0);
-                        if (msg.length() > 100) {
+                        boolean command = msg.startsWith("/");
+                        System.out.println("received a message command: " + command + " length: " + msg.length());
+                        if (msg.length() > 100) { 
                             wrapper.set(Type.STRING, 0, msg.substring(0, 100));
                         }
                     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/chat/ChatMsgCharacterLimitAction.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/chat/ChatMsgCharacterLimitAction.java
@@ -1,17 +1,11 @@
 package us.myles.ViaVersion.protocols.protocol1_11to1_10.chat;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
-@Getter
 public enum ChatMsgCharacterLimitAction {
-    SPLIT(false),
-    TRUNCATE(false),
-    PASS_THROUGH(false),
-    CANCEL(true);
+    SPLIT,
+    TRUNCATE,
+    PASS_THROUGH,
+    CANCEL;
 
-    private final boolean notify;
     public static final int CHARACTER_LIMIT = 100;
     private static final ChatMsgCharacterLimitAction[] v = values();
 
@@ -29,14 +23,29 @@ public enum ChatMsgCharacterLimitAction {
     }
 
     public static String[] handleChatMessage(String msg, ChatMsgCharacterLimitAction action) {
-        // TODO: MAKE
         switch (action) {
             case SPLIT:
-                return null;
+                if (msg.startsWith("/")) { // this will not work with commands
+                    return handleChatMessage(msg, TRUNCATE);
+                }
+                int length = msg.length();
+                int alength = length / CHARACTER_LIMIT;
+                if (length % CHARACTER_LIMIT != 0) {
+                    alength++;
+                }
+                String[] lines = new String[alength];
+                int index = 0;
+                for (int i = 0; i < length; i += CHARACTER_LIMIT) {
+                    lines[index++] = msg.substring(i, Math.min(length, i + CHARACTER_LIMIT));
+                }
+                return lines;
             case TRUNCATE:
-                return null;
+                if (msg.length() > CHARACTER_LIMIT) {
+                    msg = msg.substring(0, CHARACTER_LIMIT);
+                }
+                return new String[] {msg};
             case PASS_THROUGH:
-                return null;
+                return new String[] {msg};
             case CANCEL:
                 return null;
             default:

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/chat/ChatMsgCharacterLimitAction.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/chat/ChatMsgCharacterLimitAction.java
@@ -1,0 +1,46 @@
+package us.myles.ViaVersion.protocols.protocol1_11to1_10.chat;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ChatMsgCharacterLimitAction {
+    SPLIT(false),
+    TRUNCATE(false),
+    PASS_THROUGH(false),
+    CANCEL(true);
+
+    private final boolean notify;
+    public static final int CHARACTER_LIMIT = 100;
+    private static final ChatMsgCharacterLimitAction[] v = values();
+
+    public static ChatMsgCharacterLimitAction getChatMsgCharacterLimitAction(String actionType) {
+        actionType = actionType.trim();
+        // store the array to a variable so it doesn't allocate a new array
+        // every time this method is called as this method might be called quite frequently.
+        for (ChatMsgCharacterLimitAction action : v) {
+            String name = action.name();
+            if (actionType.equalsIgnoreCase(name)) {
+                return action;
+            }
+        }
+        return TRUNCATE;
+    }
+
+    public static String[] handleChatMessage(String msg, ChatMsgCharacterLimitAction action) {
+        // TODO: MAKE
+        switch (action) {
+            case SPLIT:
+                return null;
+            case TRUNCATE:
+                return null;
+            case PASS_THROUGH:
+                return null;
+            case CANCEL:
+                return null;
+            default:
+                return handleChatMessage(msg, TRUNCATE);
+        }
+    }
+}

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -122,3 +122,13 @@ replace-pistons: false
 replacement-piston-id: 0
 # Force the string -> json transform
 force-json-transform: false
+#----------------------------------------------------------#
+#         NEWER CLIENTS ON 1.8-1.10 SERVERS OPTIONS        #
+#----------------------------------------------------------#
+# Choose the action what we should do when the chat message character limit (100 characters) is exceeded on older servers.
+# Available options: (Default: TRUNCATE)
+# SPLIT (Splits the message into multiple messages (This is NOT supported with commands and they will be TRUNCATED))
+# TRUNCATE (Truncates the chat message if it exceeds 100 characters)
+# PASS_THROUGH [DEVS ONLY] (Passes the chat message and commands throught without touching them. This will REQUIRE custom server software to work!!!)
+# CANCEL (Cancels the chat message & command and sends the player a warning.)
+chat-msg-character-limit-action: DEFAULT

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -86,6 +86,13 @@ piston-animation-patch: false
 chat-nbt-fix: true
 # Experimental - Should we fix shift quick move action for 1.12 clients (causes shift + double click not to work when moving items) (only works on 1.8-1.11.2 bukkit based servers)
 quick-move-action-fix: false
+# Choose the action what we should do when the chat message character limit (100 characters) is exceeded on older (< 1.11) servers.
+# Available options:
+# SPLIT (Commands will be truncated) (This may cause some issues with anticheat plugins)
+# TRUNCATE (Default Option)
+# PASS_THROUGH (Passes the message through. This will REQUIRE custom server software to work!!!)
+# CANCEL (Cancels the message and sends the player a warning.)
+chat-msg-character-limit-action: TRUNCATE
 #
 #----------------------------------------------------------#
 #         1.9 & 1.10 CLIENTS ON 1.8 SERVERS OPTIONS        #
@@ -122,13 +129,3 @@ replace-pistons: false
 replacement-piston-id: 0
 # Force the string -> json transform
 force-json-transform: false
-#----------------------------------------------------------#
-#         NEWER CLIENTS ON 1.8-1.10 SERVERS OPTIONS        #
-#----------------------------------------------------------#
-# Choose the action what we should do when the chat message character limit (100 characters) is exceeded on older servers.
-# Available options: (Default: TRUNCATE)
-# SPLIT (Splits the message into multiple messages (This is NOT supported with commands and they will be TRUNCATED))
-# TRUNCATE (Truncates the chat message if it exceeds 100 characters)
-# PASS_THROUGH [DEVS ONLY] (Passes the chat message and commands throught without touching them. This will REQUIRE custom server software to work!!!)
-# CANCEL (Cancels the chat message & command and sends the player a warning.)
-chat-msg-character-limit-action: DEFAULT

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeConfigAPI.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeConfigAPI.java
@@ -180,6 +180,11 @@ public class SpongeConfigAPI extends Config implements ViaVersionConfig {
     public boolean isForceJsonTransform() {
         return getBoolean("force-json-transform", false);
     }
+    
+    @Override
+    public String get1_11ChatMsgCharacterLimitAction() {
+        return getString("chat-msg-character-limit-action", "TRUNCATE");
+    }
 
     @Override
     public boolean is1_12NBTArrayFix() {


### PR DESCRIPTION
I added some options for how chat messages should be handled on older servers. 
These options are: (Default: TRUNCATE)
+# _SPLIT_
+# _TRUNCATE_ 
+# _PASS_THROUGH_
+# _CANCEL_

I had to edit the code how packets are sent to the server as i couldn't get this to work.                               https://github.com/MylesIsCool/ViaVersion/blob/875e5d725258a16b53180d5d609d82506d9a3d54/common/src/main/java/us/myles/ViaVersion/api/PacketWrapper.java#L480

**[BELOW IS TESTED ON BUKKIT SERVERS]**
I did some testing and as the javadoc says
`A Channel received a message. This will result in having the ChannelInboundHandler.channelRead(ChannelHandlerContext, Object) method called of the next ChannelInboundHandler contained in the ChannelPipeline of the Channel.`
I came to the conclusion that it skips the decoder and will call the next "ChannelInboundHandler" after the decoder which for instance is NetworkManager on bukkit servers.
I don't think this is the intended behavior or am i missing something?

Opinions are welcome.
