### PR TITLE
Add option to truncate edited books with more than 50 pages on 1.14

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaConfig.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaConfig.java
@@ -249,4 +249,9 @@ public class BukkitViaConfig extends Config implements ViaVersionConfig {
     public int get1_13TabCompleteDelay() {
         return getInt("1_13-tab-complete-delay", 0);
     }
+
+    @Override
+    public boolean truncate1_14Books() {
+        return getBoolean("truncate-1_14-books", false);
+    }
 }

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
@@ -302,4 +302,9 @@ public class BungeeViaConfig extends Config implements ViaVersionConfig {
     public int get1_13TabCompleteDelay() {
         return getInt("1_13-tab-complete-delay", 0);
     }
+
+    @Override
+    public boolean truncate1_14Books() {
+        return getBoolean("truncate-1_14-books", false);
+    }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
@@ -305,7 +305,15 @@ public interface ViaVersionConfig {
 
     /**
      * When greater than 0, enables tab complete request delaying by x ticks
+     *
      * @return the delay in ticks
      */
     int get1_13TabCompleteDelay();
+
+    /**
+     * When activated, edited books with more than 50 pages will be shortened to 50.
+     *
+     * @return True if enabled
+     */
+    boolean truncate1_14Books();
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/InventoryPackets.java
@@ -177,7 +177,7 @@ public class InventoryPackets {
                                 wrapper.passthrough(Type.INT); // Maximum number of trade uses
                             }
                         } else if (channel.equals("minecraft:book_open") || channel.equals("book_open")) {
-                            wrapper.passthrough(Type.REMAINING_BYTES);
+                            wrapper.read(Type.REMAINING_BYTES);
                             int hand = wrapper.read(Type.VAR_INT);
                             wrapper.clearPacket();
                             wrapper.setId(0x2C);

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -118,6 +118,8 @@ disable-1_13-auto-complete: false
 1_13-tab-complete-delay: 0
 # For 1.13 clients the smallest (1 layer) snow doesn't have collision, this will send these as 2 snowlayers for 1.13+ clients to prevent them bugging through them
 fix-low-snow-collision: false
+# In 1.14 the client page limit has been upped to 100 (from 50). Some anti-exploit plugins ban when clients go higher than 50. This option cuts edited books to 50 pages.
+truncate-1_14-books: false
 #
 # Enable serverside block-connections for 1.13+ clients
 serverside-blockconnections: false

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
@@ -255,4 +255,9 @@ public class SpongeViaConfig extends Config implements ViaVersionConfig {
     public int get1_13TabCompleteDelay() {
         return getInt("1_13-tab-complete-delay", 0);
     }
+
+    @Override
+    public boolean truncate1_14Books() {
+        return getBoolean("truncate-1_14-books", false);
+    }
 }

--- a/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
+++ b/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
@@ -307,4 +307,9 @@ public class VelocityViaConfig extends Config implements ViaVersionConfig {
     public int get1_13TabCompleteDelay() {
         return getInt("1_13-tab-complete-delay", 0);
     }
+
+    @Override
+    public boolean truncate1_14Books() {
+        return getBoolean("truncate-1_14-books", false);
+    }
 }


### PR DESCRIPTION
When editing a book, the client can write up to 100 pages in 1.14 wheras it was 50 before.
Some anti-exploit plugins ban on that behalf (especially used on 1.8), so I figured an option to truncate that would be useful