### PR TITLE
Use JVM time instead of wall-clock time

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/data/UserConnection.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/data/UserConnection.java
@@ -18,6 +18,7 @@ import us.myles.ViaVersion.util.PipelineUtil;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -137,10 +138,10 @@ public class UserConnection {
      */
     public boolean incrementReceived() {
         // handle stats
-        long diff = System.currentTimeMillis() - startTime;
-        if (diff >= 1000) {
+        long diff = System.nanoTime() - startTime;
+        if (diff >= TimeUnit.SECONDS.toNanos(1)) {
             packetsPerSecond = intervalPackets;
-            startTime = System.currentTimeMillis();
+            startTime = System.nanoTime();
             intervalPackets = 1;
             return true;
         } else {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -38,6 +38,7 @@ import us.myles.ViaVersion.util.GsonUtil;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 // Development of 1.13 support!
 public class Protocol1_13To1_12_2 extends Protocol {
@@ -857,7 +858,7 @@ public class Protocol1_13To1_12_2 extends Protocol {
                         if (!wrapper.isCancelled() && Via.getConfig().get1_13TabCompleteDelay() > 0) {
                             TabCompleteTracker tracker = wrapper.user().get(TabCompleteTracker.class);
                             wrapper.cancel();
-                            tracker.setTimeToSend(System.currentTimeMillis() + Via.getConfig().get1_13TabCompleteDelay() * 50);
+                            tracker.setTimeToSend(System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(Via.getConfig().get1_13TabCompleteDelay() * 50));
                             tracker.setLastTabComplete(wrapper.get(Type.STRING, 0));
                         }
                     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/storage/TabCompleteTracker.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/storage/TabCompleteTracker.java
@@ -21,7 +21,7 @@ public class TabCompleteTracker extends StoredObject {
     }
 
     public void sendPacketToServer() {
-        if (lastTabComplete == null || timeToSend > System.currentTimeMillis()) return;
+        if (lastTabComplete == null || timeToSend > System.nanoTime()) return;
         PacketWrapper wrapper = new PacketWrapper(0x01, null, getUser());
         wrapper.write(Type.STRING, lastTabComplete);
         wrapper.write(Type.BOOLEAN, false);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/ViaIdleThread.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/ViaIdleThread.java
@@ -12,7 +12,7 @@ public class ViaIdleThread implements Runnable {
         for (UserConnection info : Via.getManager().getPortedPlayers().values()) {
             if (info.has(ProtocolInfo.class) && info.get(ProtocolInfo.class).getPipeline().contains(Protocol1_9TO1_8.class)) {
                 long nextIdleUpdate = info.get(MovementTracker.class).getNextIdlePacket();
-                if (nextIdleUpdate <= System.currentTimeMillis()) {
+                if (nextIdleUpdate <= System.nanoTime()) {
                     if (info.getChannel().isOpen()) {
                         Via.getManager().getProviders().get(MovementTransmitterProvider.class).sendPlayer(info);
                     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/MovementTracker.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/MovementTracker.java
@@ -1,12 +1,14 @@
 package us.myles.ViaVersion.protocols.protocol1_9to1_8.storage;
 
+import java.util.concurrent.TimeUnit;
+
 import lombok.Getter;
 import lombok.Setter;
 import us.myles.ViaVersion.api.data.StoredObject;
 import us.myles.ViaVersion.api.data.UserConnection;
 
 public class MovementTracker extends StoredObject {
-    private static final long IDLE_PACKET_DELAY = 50L; // Update every 50ms (20tps)
+    private static final long IDLE_PACKET_DELAY = TimeUnit.MILLISECONDS.toNanos(50L); // Update every 50ms (20tps)
     private static final long IDLE_PACKET_LIMIT = 20; // Max 20 ticks behind
     @Getter
     private long nextIdlePacket = 0L;
@@ -21,6 +23,6 @@ public class MovementTracker extends StoredObject {
     public void incrementIdlePacket() {
         // Notify of next update
         // Allow a maximum lag spike of 1 second (20 ticks/updates)
-        this.nextIdlePacket = Math.max(nextIdlePacket + IDLE_PACKET_DELAY, System.currentTimeMillis() - IDLE_PACKET_DELAY * IDLE_PACKET_LIMIT);
+        this.nextIdlePacket = Math.max(nextIdlePacket + IDLE_PACKET_DELAY, System.nanoTime() - IDLE_PACKET_DELAY * IDLE_PACKET_LIMIT);
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/PlaceBlockTracker.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/PlaceBlockTracker.java
@@ -1,5 +1,7 @@
 package us.myles.ViaVersion.protocols.protocol1_9to1_8.storage;
 
+import java.util.concurrent.TimeUnit;
+
 import lombok.Getter;
 import lombok.Setter;
 import us.myles.ViaVersion.api.data.StoredObject;
@@ -23,13 +25,13 @@ public class PlaceBlockTracker extends StoredObject {
      * @return True if it has passed
      */
     public boolean isExpired(int ms) {
-        return System.currentTimeMillis() > (lastPlaceTimestamp + ms);
+        return System.nanoTime() > (lastPlaceTimestamp + TimeUnit.MILLISECONDS.toNanos(ms));
     }
 
     /**
      * Set the last place time to the current time
      */
     public void updateTime() {
-        lastPlaceTimestamp = System.currentTimeMillis();
+        lastPlaceTimestamp = System.nanoTime();
     }
 }


### PR DESCRIPTION
Pretty straightforward change, wall-clock time should not be used to measure duration's as it can lead to issues when the underlying systems time changes. For example, if the system time changes backwards few seconds this could potentially lead to kicking users from server for "Sending too many packets"