### PR TITLE
Don't try to send register messages without channels

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -178,7 +178,12 @@ public class InventoryPackets {
                                         Via.getPlatform().getLogger().warning("Ignoring plugin channel in outgoing REGISTER: " + channels[i]);
                                     }
                                 }
-                                wrapper.write(Type.REMAINING_BYTES, Joiner.on('\0').join(rewrittenChannels).getBytes(StandardCharsets.UTF_8));
+                                if (!rewrittenChannels.isEmpty()) {
+                                    wrapper.write(Type.REMAINING_BYTES, Joiner.on('\0').join(rewrittenChannels).getBytes(StandardCharsets.UTF_8));
+                                } else {
+                                    wrapper.cancel();
+                                    return;
+                                }
                             }
                         }
                         wrapper.set(Type.STRING, 0, channel);


### PR DESCRIPTION
Bukkit interprets this as attempting to register the channel "" (the empty string), which fails on Minecraft 1.13 and above.