### PR TITLE
Issue with the CanDestroy taglist

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -405,13 +405,13 @@ public class InventoryPackets {
                     if (numberConverted != null) {
                         oldId = numberConverted;
                     }
-                    String[] newValues = BlockIdData.blockIdMapping.get(oldId);
+                    String[] newValues = BlockIdData.blockIdMapping.get(oldId.toLowerCase(Locale.ROOT));
                     if (newValues != null) {
                         for (String newValue : newValues) {
                             newCanPlaceOn.add(new StringTag("", newValue));
                         }
                     } else {
-                        newCanPlaceOn.add(new StringTag("", oldId));
+                        newCanPlaceOn.add(new StringTag("", oldId.toLowerCase(Locale.ROOT)));
                     }
                 }
                 tag.put(newCanPlaceOn);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -27,6 +27,7 @@ import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.SpawnEggRewriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class InventoryPackets {
     private static String NBT_TAG_NAME;
@@ -426,13 +427,13 @@ public class InventoryPackets {
                     if (numberConverted != null) {
                         oldId = numberConverted;
                     }
-                    String[] newValues = BlockIdData.blockIdMapping.get(oldId.toLowerCase());
+                    String[] newValues = BlockIdData.blockIdMapping.get(oldId.toLowerCase(Locale.ROOT));
                     if (newValues != null) {
                         for (String newValue : newValues) {
                             newCanDestroy.add(new StringTag("", newValue));
                         }
                     } else {
-                        newCanDestroy.add(new StringTag("", oldId.toLowerCase()));
+                        newCanDestroy.add(new StringTag("", oldId.toLowerCase(Locale.ROOT)));
                     }
                 }
                 tag.put(newCanDestroy);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -426,13 +426,13 @@ public class InventoryPackets {
                     if (numberConverted != null) {
                         oldId = numberConverted;
                     }
-                    String[] newValues = BlockIdData.blockIdMapping.get(oldId);
+                    String[] newValues = BlockIdData.blockIdMapping.get(oldId.toLowerCase());
                     if (newValues != null) {
                         for (String newValue : newValues) {
                             newCanDestroy.add(new StringTag("", newValue));
                         }
                     } else {
-                        newCanDestroy.add(new StringTag("", oldId));
+                        newCanDestroy.add(new StringTag("", oldId.toLowerCase()));
                     }
                 }
                 tag.put(newCanDestroy);


### PR DESCRIPTION
**The Issue**

On our 1.12.2 server we had a problem that clients which are playing on 1.13+ can't use a pickaxe with the 'CanDestroy' tag. This is I figured because of the pickaxe having a taglist of the materials written in full caps. The issue thus being that a client lower or equal to 1.12.2 does accept this tag, but a 1.13+ client doesn't because the client apparently wants a material written in lower caps.

This is a 1.12.2 client which can interact with blocks: 
https://gyazo.com/64880380560d9b5ff4756b549c1e7f26

This is a 1.13.2 client which can't interact with some blocks (the tag has STONE written in caps): 
https://gyazo.com/6ec22751ab10d75b3ece548b321cf7ae

**Why Should ViaVersion Have This Fix?**
Simply because some clients can use the pickaxe with the tag, and some can't. Thus not allowing for a good experience with every client, while that's kind of the whole point of ViaVersion to create a good one.

**My Solution**
The solution is really simply, and literally 2 lines of code. It sends the material list to lowercase to the client.

And this is the result as you can see on a 1.13.2 client (the tag has STONE written in caps): 
https://gyazo.com/37d9247eb39770ad9acd4fc6caff5489