### PR TITLE
Fix plugin message pattern

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -514,7 +514,7 @@ public class InventoryPackets {
             case "bungeecord:main":
                 return null;
             default:
-                return old.matches("([0-9a-z_.-]*:)?[0-9a-z_/.-]*") // Identifier regex
+                return old.matches("([0-9a-z_.-]+):([0-9a-z_/.-]+)") // Identifier regex
                         ? old : null;
         }
     }
@@ -719,7 +719,7 @@ public class InventoryPackets {
     }
 
     public static String getOldPluginChannelId(String newId) {
-        if (!newId.matches("([0-9a-z_.-]*:)?[0-9a-z_/.-]*")) {
+        if (!newId.matches("([0-9a-z_.-]+):([0-9a-z_/.-]+)")) {
             return null; // Not valid
         }
         int separatorIndex = newId.indexOf(':');


### PR DESCRIPTION
Some smart guy should prolly still verify this (tho it should be good: `+` = once or more, then there's a mandatory `:`, and another once or more for all lowercase alphanumerical thingies).
Before, the `?` allowed to emit the left identifier (which isn't possible in CB) and the`*` also marked a "0 or more"

Fixes https://github.com/ViaVersion/ViaBackwards/issues/138 and https://github.com/ViaVersion/ViaBackwards/issues/128