### PR TITLE
Fix 1.14+ walk animation

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaConfig.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaConfig.java
@@ -274,4 +274,9 @@ public class BukkitViaConfig extends Config implements ViaVersionConfig {
     public boolean isNonFullBlockLightFix() {
         return getBoolean("fix-non-full-blocklight", true);
     }
+
+    @Override
+    public boolean is1_14HealthNaNFix() {
+        return getBoolean("fix-1_14-health-nan", true);
+    }
 }

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
@@ -330,6 +330,6 @@ public class BungeeViaConfig extends Config implements ViaVersionConfig {
 
     @Override
     public boolean is1_14HealthNaNFix() {
-        return false;
+        return getBoolean("fix-1_14-health-nan", true);
     }
 }

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
@@ -327,4 +327,9 @@ public class BungeeViaConfig extends Config implements ViaVersionConfig {
     public boolean isNonFullBlockLightFix() {
         return getBoolean("fix-non-full-blocklight", true);
     }
+
+    @Override
+    public boolean is1_14HealthNaNFix() {
+        return false;
+    }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
@@ -344,4 +344,6 @@ public interface ViaVersionConfig {
      * @return True if enabled
      */
     boolean isNonFullBlockLightFix();
+
+    boolean is1_14HealthNaNFix();
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/MetadataRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/MetadataRewriter.java
@@ -39,9 +39,9 @@ public class MetadataRewriter {
                 if (metadata.getId() > 5) {
                     metadata.setId(metadata.getId() + 1);
                 }
-                if( metadata.getId() == 8 && type.isOrHasParent(Entity1_14Types.EntityType.LIVINGENTITY)) {
+                if (metadata.getId() == 8 && type.isOrHasParent(Entity1_14Types.EntityType.LIVINGENTITY)) {
                     final float v = ((Number) metadata.getValue()).floatValue();
-                    if(Float.isNaN(v) && Via.getConfig().is1_14HealthNaNFix()) {
+                    if (Float.isNaN(v) && Via.getConfig().is1_14HealthNaNFix()) {
                        metadata.setValue(1F);
                     }
                 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/MetadataRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/MetadataRewriter.java
@@ -39,6 +39,12 @@ public class MetadataRewriter {
                 if (metadata.getId() > 5) {
                     metadata.setId(metadata.getId() + 1);
                 }
+                if( metadata.getId() == 8 && type.isOrHasParent(Entity1_14Types.EntityType.LIVINGENTITY)) {
+                    final float v = ((Number) metadata.getValue()).floatValue();
+                    if(Float.isNaN(v) && Via.getConfig().is1_14HealthNaNFix()) {
+                       metadata.setValue(1F);
+                    }
+                }
 
                 //Metadata 12 added to living_entity
                 if (metadata.getId() > 11 && type.isOrHasParent(Entity1_14Types.EntityType.LIVINGENTITY)) {

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -178,3 +178,5 @@ force-json-transform: false
 minimize-cooldown: true
 # Left handed handling on 1.8 servers
 left-handed-handling: true
+# Fixes walk animation not shown when health is set to Float.NaN
+fix-1_14-health-nan: true

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -128,6 +128,8 @@ change-1_9-hitbox: false
 change-1_14-hitbox: false
 # Fixes 1.14+ clients on sub 1.14 servers having a light value of 0 for non full blocks.
 fix-non-full-blocklight: true
+# Fixes walk animation not shown when health is set to Float.NaN
+fix-1_14-health-nan: true
 #
 # Enable serverside block-connections for 1.13+ clients
 serverside-blockconnections: false
@@ -178,5 +180,3 @@ force-json-transform: false
 minimize-cooldown: true
 # Left handed handling on 1.8 servers
 left-handed-handling: true
-# Fixes walk animation not shown when health is set to Float.NaN
-fix-1_14-health-nan: true

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
@@ -283,6 +283,6 @@ public class SpongeViaConfig extends Config implements ViaVersionConfig {
 
     @Override
     public boolean is1_14HealthNaNFix() {
-        return false;
+        return getBoolean("fix-1_14-health-nan", true);
     }
 }

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
@@ -280,4 +280,9 @@ public class SpongeViaConfig extends Config implements ViaVersionConfig {
     public boolean isNonFullBlockLightFix() {
         return getBoolean("fix-non-full-blocklight", true);
     }
+
+    @Override
+    public boolean is1_14HealthNaNFix() {
+        return false;
+    }
 }

--- a/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
+++ b/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
@@ -336,6 +336,6 @@ public class VelocityViaConfig extends Config implements ViaVersionConfig {
 
     @Override
     public boolean is1_14HealthNaNFix() {
-        return false;
+        return getBoolean("fix-1_14-health-nan", true);
     }
 }

--- a/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
+++ b/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
@@ -333,4 +333,9 @@ public class VelocityViaConfig extends Config implements ViaVersionConfig {
     public boolean isNonFullBlockLightFix() {
         return getBoolean("fix-non-full-blocklight", true);
     }
+
+    @Override
+    public boolean is1_14HealthNaNFix() {
+        return false;
+    }
 }


### PR DESCRIPTION
The player walk animation will not be shown to a player using Minecraft 1.14 or later if the player has their health set to Float.NaN. Several anti damage-indicator plugins replace the players health with NaN before the metadata is sent to the other clients.
This PR fixes #1406 by replacing NaN health with a normal value if it was not disabled in the config. This change will only affect 1.14+ clients.