### PR TITLE
Fix scoreboard colors on 1.13

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -105,8 +105,7 @@ public class Protocol1_13To1_12_2 extends Protocol {
             };
 
     // These are arbitrary rewrite values, it just needs an invalid color code character.
-    protected static EnumMap<ChatColor, Character> SCOREBOARD_TEAM_NAME_REWRITE = new EnumMap<>(ChatColor.class);
-    // @formatter:on
+    protected static final EnumMap<ChatColor, Character> SCOREBOARD_TEAM_NAME_REWRITE = new EnumMap<>(ChatColor.class);
 
     static {
         SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.BLACK, 'g');
@@ -125,6 +124,13 @@ public class Protocol1_13To1_12_2 extends Protocol {
         SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.LIGHT_PURPLE, 'z');
         SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.YELLOW, '!');
         SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.WHITE, '?');
+        SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.MAGIC, '#');
+        SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.BOLD, '(');
+        SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.STRIKETHROUGH, ')');
+        SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.UNDERLINE, ':');
+        SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.ITALIC, ';');
+        SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.RESET, '/');
+
         MappingData.init();
         ConnectionData.init();
         RecipeData.init();


### PR DESCRIPTION
Fix scoreboard colors for some plugins using non colors formatting like `§r` for players names (same as #1050 but with other color/formatting codes).

This should fix #1255, but I can’t test because the plugins are not public.

I tested with QuickBoard (wich use `§r`) - https://github.com/ViaVersion/ViaVersion/issues/1255#issuecomment-486296053 - and it works

Tests with QuickBoard v4.3.0, using 1.13.2 client on 1.8.8 server:
_Before:_
![Before](https://user-images.githubusercontent.com/30863452/66392218-7a3f9480-e9cf-11e9-9d2e-33c87d5bddfb.png)

_After:_
![After](https://user-images.githubusercontent.com/30863452/66392225-7ca1ee80-e9cf-11e9-8a4b-de1b6240a0b6.png)
