### PR TITLE
Fix item hover event on 1.12

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/ChatItemRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/ChatItemRewriter.java
@@ -3,6 +3,7 @@ package us.myles.ViaVersion.protocols.protocol1_12to1_11_1;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import us.myles.ViaVersion.api.data.UserConnection;
 
 import java.util.regex.Pattern;
@@ -20,23 +21,30 @@ public class ChatItemRewriter {
                     if (hoverEvent.has("action") && hoverEvent.has("value")) {
                         String type = hoverEvent.get("action").getAsString();
                         if (type.equals("show_item") || type.equals("show_entity")) {
-                            if (hoverEvent.get("value").isJsonPrimitive()) {
-                                if (hoverEvent.get("value").getAsJsonPrimitive().isString()) {
-                                    String value = hoverEvent.get("value").getAsString();
-                                    value = indexRemoval.matcher(value).replaceAll("");
-                                    hoverEvent.addProperty("value", value);
+                            JsonElement value = hoverEvent.get("value");
+
+                            if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+                                String newValue = indexRemoval.matcher(value.getAsString()).replaceAll("");
+                                hoverEvent.addProperty("value", newValue);
+                            } else if (value.isJsonArray()) {
+                                JsonArray newArray = new JsonArray();
+
+                                for (JsonElement valueElement : value.getAsJsonArray()) {
+                                    if (valueElement.isJsonPrimitive() && valueElement.getAsJsonPrimitive().isString()) {
+                                        String newValue = indexRemoval.matcher(valueElement.getAsString()).replaceAll("");
+                                        newArray.add(new JsonPrimitive(newValue));
+                                    }
                                 }
+
+                                hoverEvent.add("value", newArray);
                             }
                         }
                     }
                 }
-            } else {
-                if (obj.has("extra")) {
-                    toClient(obj.get("extra"), user);
-                }
+            } else if (obj.has("extra")) {
+                toClient(obj.get("extra"), user);
             }
-        }
-        if (element instanceof JsonArray) {
+        } else if (element instanceof JsonArray) {
             JsonArray array = (JsonArray) element;
             for (JsonElement value : array) {
                 toClient(value, user);


### PR DESCRIPTION
Fix item hover event on 1.12 when the `value` of the hover event is a string array and not a string, like this (from Item2Chat):
```
          "hoverEvent": {
            "action": "show_item",
            "value": [
              "{id:\"minecraft:diamond_sword\",Count:1b,tag:{ench:[0:{lvl:2s,id:19s}]},Damage:4s}"
            ]
          }
```

Tests with [Item2Chat](https://www.spigotmc.org/resources/item2chat.33622/) v4.2.0 (fix #826, and should fix #799) using 1.12.2 client on 1.8.8 server:

Before
![Before](https://user-images.githubusercontent.com/30863452/67403117-ce429f80-f5b1-11e9-9981-e295d35e1a64.png)

After
![After](https://user-images.githubusercontent.com/30863452/67403129-d1d62680-f5b1-11e9-881a-e55a4ad2d58f.png)
