### PR TITLE
Add vines blockconnection to prevent unwanted climbing

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaConfig.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaConfig.java
@@ -241,6 +241,11 @@ public class BukkitViaConfig extends Config implements ViaVersionConfig {
     }
 
     @Override
+    public boolean isVineClimbFix() {
+        return getBoolean("vine-climb-fix", false);
+    }
+
+    @Override
     public boolean isSnowCollisionFix() {
         return getBoolean("fix-low-snow-collision", false);
     }

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
@@ -294,6 +294,11 @@ public class BungeeViaConfig extends Config implements ViaVersionConfig {
     }
 
     @Override
+    public boolean isVineClimbFix() {
+        return getBoolean("vine-climb-fix", false);
+    }
+
+    @Override
     public boolean isSnowCollisionFix() {
         return getBoolean("fix-low-snow-collision", false);
     }

--- a/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
@@ -297,6 +297,13 @@ public interface ViaVersionConfig {
     boolean isStemWhenBlockAbove();
 
     /**
+     * Vines not connected to any blocks will be mapped to air for 1.13+ clients to prevent them from climbing up.
+     *
+     * @return True if enabled
+     */
+    boolean isVineClimbFix();
+
+    /**
      * When activated, the 1-layer snow will be sent as 2-layer snow to 1.13+ clients to have collision.
      *
      * @return True if enabled

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/ConnectionData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/ConnectionData.java
@@ -252,6 +252,10 @@ public class ConnectionData {
         initActions.addAll(ChorusPlantConnectionHandler.init());
         initActions.add(TripwireConnectionHandler.init());
         initActions.add(SnowyGrassConnectionHandler.init());
+        if (Via.getConfig().isVineClimbFix()) {
+            initActions.add(VineConnectionHandler.init());
+        }
+
         for (String key : keyToId.keySet()) {
             WrappedBlockData wrappedBlockData = WrappedBlockData.fromString(key);
             for (ConnectorInitAction action : initActions) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/VineConnectionHandler.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/VineConnectionHandler.java
@@ -1,0 +1,48 @@
+package us.myles.ViaVersion.protocols.protocol1_13to1_12_2.blockconnections;
+
+import us.myles.ViaVersion.api.data.UserConnection;
+import us.myles.ViaVersion.api.minecraft.BlockFace;
+import us.myles.ViaVersion.api.minecraft.Position;
+
+import java.util.HashSet;
+import java.util.Set;
+
+class VineConnectionHandler extends ConnectionHandler {
+    private static final Set<Integer> vines = new HashSet<>();
+
+    static ConnectionData.ConnectorInitAction init() {
+        final VineConnectionHandler connectionHandler = new VineConnectionHandler();
+        return new ConnectionData.ConnectorInitAction() {
+            @Override
+            public void check(WrappedBlockData blockData) {
+                if (!blockData.getMinecraftKey().equals("minecraft:vine")) return;
+
+                vines.add(blockData.getSavedBlockStateId());
+                ConnectionData.connectionHandlerMap.put(blockData.getSavedBlockStateId(), connectionHandler);
+            }
+        };
+    }
+
+    @Override
+    public int connect(UserConnection user, Position position, int blockState) {
+        if (isAttachedToBlock(user, position)) return blockState;
+
+        Position upperPos = position.getRelative(BlockFace.TOP);
+        int upperBlock = getBlockData(user, upperPos);
+        if (vines.contains(upperBlock) && isAttachedToBlock(user, upperPos)) return blockState;
+
+        // Map to air if not attached to block, and upper block is also not a vine attached to a block
+        return 0;
+    }
+
+    private boolean isAttachedToBlock(UserConnection user, Position position) {
+        return isAttachedToBlock(user, position, BlockFace.EAST)
+                || isAttachedToBlock(user, position, BlockFace.WEST)
+                || isAttachedToBlock(user, position, BlockFace.NORTH)
+                || isAttachedToBlock(user, position, BlockFace.SOUTH);
+    }
+
+    private boolean isAttachedToBlock(UserConnection user, Position position, BlockFace blockFace) {
+        return ConnectionData.occludingStates.contains(getBlockData(user, position.getRelative(blockFace)));
+    }
+}

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -135,7 +135,7 @@ fix-1_14-health-nan: true
 # Should 1.15+ clients respawn instantly / without showing a death screen?
 use-1_15-instant-respawn: false
 #
-# Enable serverside block-connections for 1.13+ clients
+# Enable serverside block-connections for 1.13+ clients - all of the options in this section are built around this option
 serverside-blockconnections: false
 # Sets the method for the block connections (world for highly experimental (USE AT OWN RISK) world-level or packet for packet-level)
 blockconnection-method: packet
@@ -144,6 +144,8 @@ reduce-blockstorage-memory: false
 # When activated with serverside-blockconnections, flower parts with blocks above will be sent as stems
 # Useful for lobbyservers where users can't build and those stems are used decoratively
 flowerstem-when-block-above: false
+# Vines that are not connected to blocks will be mapped to air, else 1.13+ would still be able to climb up on them.
+vine-climb-fix: false
 #
 #----------------------------------------------------------#
 #             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
@@ -247,6 +247,11 @@ public class SpongeViaConfig extends Config implements ViaVersionConfig {
     }
 
     @Override
+    public boolean isVineClimbFix() {
+        return getBoolean("vine-climb-fix", false);
+    }
+
+    @Override
     public boolean isSnowCollisionFix() {
         return getBoolean("fix-low-snow-collision", false);
     }

--- a/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
+++ b/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
@@ -299,6 +299,11 @@ public class VelocityViaConfig extends Config implements ViaVersionConfig {
     }
 
     @Override
+    public boolean isVineClimbFix() {
+        return getBoolean("vine-climb-fix", false);
+    }
+
+    @Override
     public boolean isSnowCollisionFix() {
         return getBoolean("fix-low-snow-collision", false);
     }


### PR DESCRIPTION
Works by only sending vines that are either:
a) attached to a block or
b) have another vine above them that is attached to a block
Fixes #1640