### PR TITLE
Asynchronously load mapping data

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
@@ -10,6 +10,7 @@ import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.ViaAPI;
 import us.myles.ViaVersion.api.command.ViaCommandSender;
 import us.myles.ViaVersion.api.configuration.ConfigurationProvider;
+import us.myles.ViaVersion.api.data.MappingDataLoader;
 import us.myles.ViaVersion.api.platform.TaskId;
 import us.myles.ViaVersion.api.platform.ViaPlatform;
 import us.myles.ViaVersion.bukkit.classgenerator.ClassGenerator;
@@ -80,6 +81,10 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaPlatform {
             compatSpigotBuild = true;
         } catch (Exception e) {
             compatSpigotBuild = false;
+        }
+
+        if (getServer().getPluginManager().getPlugin("ViaBackwards") != null) {
+            MappingDataLoader.setCacheJsonMappings(true);
         }
 
         // Generate classes needed (only works if it's compat or ps)

--- a/bukkit/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
@@ -84,7 +84,7 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaPlatform {
         }
 
         if (getServer().getPluginManager().getPlugin("ViaBackwards") != null) {
-            MappingDataLoader.setCacheJsonMappings(true);
+            MappingDataLoader.enableMappingsCache();
         }
 
         // Generate classes needed (only works if it's compat or ps)

--- a/bungee/src/main/java/us/myles/ViaVersion/BungeePlugin.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/BungeePlugin.java
@@ -66,7 +66,7 @@ public class BungeePlugin extends Plugin implements ViaPlatform, Listener {
     @Override
     public void onEnable() {
         if (ProxyServer.getInstance().getPluginManager().getPlugin("ViaBackwards") != null) {
-            MappingDataLoader.setCacheJsonMappings(true);
+            MappingDataLoader.enableMappingsCache();
         }
 
         // Inject

--- a/bungee/src/main/java/us/myles/ViaVersion/BungeePlugin.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/BungeePlugin.java
@@ -12,6 +12,7 @@ import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.ViaAPI;
 import us.myles.ViaVersion.api.command.ViaCommandSender;
 import us.myles.ViaVersion.api.configuration.ConfigurationProvider;
+import us.myles.ViaVersion.api.data.MappingDataLoader;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.platform.TaskId;
 import us.myles.ViaVersion.api.platform.ViaPlatform;
@@ -37,7 +38,7 @@ public class BungeePlugin extends Plugin implements ViaPlatform, Listener {
     @Override
     public void onLoad() {
         try {
-            ProtocolConstants.class.getField("MINECRAFT_1_14_4");
+            ProtocolConstants.class.getField("MINECRAFT_1_15_2");
         } catch (NoSuchFieldException e) {
             getLogger().warning("      / \\");
             getLogger().warning("     /   \\");
@@ -47,10 +48,12 @@ public class BungeePlugin extends Plugin implements ViaPlatform, Listener {
             getLogger().warning(" /     o     \\");
             getLogger().warning("/_____________\\");
         }
+
         api = new BungeeViaAPI();
         config = new BungeeViaConfig(getDataFolder());
         commandHandler = new BungeeCommandHandler();
         ProxyServer.getInstance().getPluginManager().registerCommand(this, new BungeeCommand(commandHandler));
+
         // Init platform
         Via.init(ViaManager.builder()
                 .platform(this)
@@ -62,6 +65,10 @@ public class BungeePlugin extends Plugin implements ViaPlatform, Listener {
 
     @Override
     public void onEnable() {
+        if (ProxyServer.getInstance().getPluginManager().getPlugin("ViaBackwards") != null) {
+            MappingDataLoader.setCacheJsonMappings(true);
+        }
+
         // Inject
         Via.getManager().init();
     }

--- a/common/src/main/java/us/myles/ViaVersion/ViaManager.java
+++ b/common/src/main/java/us/myles/ViaVersion/ViaManager.java
@@ -1,8 +1,6 @@
 package us.myles.ViaVersion;
 
 import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.platform.ViaInjector;
@@ -48,7 +46,7 @@ public class ViaManager {
         if (platform.getConf().isCheckForUpdates())
             UpdateUtil.sendUpdateMessage();
         // Force class load
-        ProtocolRegistry.getSupportedVersions();
+        ProtocolRegistry.init();
         // Inject
         try {
             injector.inject();

--- a/common/src/main/java/us/myles/ViaVersion/api/Via.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/Via.java
@@ -7,6 +7,7 @@ import us.myles.ViaVersion.api.platform.ViaPlatform;
 public class Via {
     private static ViaPlatform platform;
     private static ViaManager manager;
+    private static boolean cacheJsonMappings;
 
     /**
      * Register the ViaManager associated with the platform.

--- a/common/src/main/java/us/myles/ViaVersion/api/data/MappingDataLoader.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/data/MappingDataLoader.java
@@ -1,16 +1,24 @@
 package us.myles.ViaVersion.api.data;
 
-import com.google.gson.*;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.util.GsonUtil;
 
-import java.io.*;
-import java.util.HashMap;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MappingDataLoader {
 
-    private static final Map<String, JsonObject> MAPPINGS_CACHE = new HashMap<>();
+    private static final Map<String, JsonObject> MAPPINGS_CACHE = new ConcurrentHashMap<>();
     private static boolean cacheJsonMappings;
 
     /**
@@ -19,22 +27,26 @@ public class MappingDataLoader {
      *
      * @return true if mappings should be cached
      */
-    public static boolean cacheJsonMappings() {
+    public static boolean isCacheJsonMappings() {
         return cacheJsonMappings;
     }
 
-    public static void setCacheJsonMappings(boolean cacheJsonMappings) {
-        MappingDataLoader.cacheJsonMappings = cacheJsonMappings;
-        Via.getPlatform().getLogger().info("Enabled caching of mappingdata for ViaBackwards!");
+    public static void enableMappingsCache() {
+        cacheJsonMappings = true;
     }
 
     /**
-     * @see #cacheJsonMappings()
+     * Returns the cached mappings. Cleared after Via has been fully loaded.
+     *
+     * @see #isCacheJsonMappings()
      */
     public static Map<String, JsonObject> getMappingsCache() {
         return MAPPINGS_CACHE;
     }
 
+    /**
+     * Loads the file from the plugin folder if present, else from the bundled resources.
+     */
     public static JsonObject loadFromDataDir(String name) {
         File file = new File(Via.getPlatform().getDataFolder(), name);
         if (!file.exists()) return loadData(name);
@@ -52,11 +64,26 @@ public class MappingDataLoader {
         return null;
     }
 
+    /**
+     * Loads the file from the bundled resources. Uses the cache if enabled.
+     */
     public static JsonObject loadData(String name) {
         return loadData(name, false);
     }
 
+    /**
+     * Loads the file from the bundled resources. Uses the cache if enabled.
+     *
+     * @param cacheIfEnabled whether loaded files should be cached
+     */
     public static JsonObject loadData(String name, boolean cacheIfEnabled) {
+        if (cacheJsonMappings) {
+            JsonObject cached = MAPPINGS_CACHE.get(name);
+            if (cached != null) {
+                return cached;
+            }
+        }
+
         InputStream stream = getResource(name);
         InputStreamReader reader = new InputStreamReader(stream);
         try {

--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/Protocol.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/Protocol.java
@@ -18,8 +18,14 @@ public abstract class Protocol {
     private final Map<Packet, ProtocolPacket> incoming = new HashMap<>();
     private final Map<Packet, ProtocolPacket> outgoing = new HashMap<>();
     private final Map<Class, Object> storedObjects = new HashMap<>(); // currently only used for MetadataRewriters
+    private final boolean hasMappingDataToLoad;
 
     public Protocol() {
+        this(false);
+    }
+
+    public Protocol(boolean hasMappingDataToLoad) {
+        this.hasMappingDataToLoad = hasMappingDataToLoad;
         registerPackets();
     }
 
@@ -50,6 +56,14 @@ public abstract class Protocol {
      * Register the packets for this protocol.
      */
     protected abstract void registerPackets();
+
+    /**
+     * Load mapping data for the protocol.
+     * <p>
+     * To be overridden if needed.
+     */
+    protected void loadMappingData() {
+    }
 
     /**
      * Handle protocol registration phase, use this to register providers / tasks.
@@ -162,6 +176,10 @@ public abstract class Protocol {
 
     public void cancelOutgoing(State state, int oldPacketID) {
         cancelOutgoing(state, oldPacketID, -1);
+    }
+
+    public boolean hasMappingDataToLoad() {
+        return hasMappingDataToLoad;
     }
 
     /**

--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
@@ -130,7 +130,11 @@ public class ProtocolRegistry {
                 CompletableFuture<Void> future = new CompletableFuture<>();
                 mappingLoaderFutures.put(protocol.getClass(), future);
                 mappingLoaderExecutor.execute(() -> {
-                    protocol.loadMappingData();
+                    try {
+                        protocol.loadMappingData();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
                     future.complete(null);
                 });
             } else {
@@ -334,12 +338,15 @@ public class ProtocolRegistry {
         }
     }
 
-    public static void getMappingLoaderFuture(Class<? extends Protocol> protocolClass, Runnable runnable) {
-        CompletableFuture<Void> future = mappingLoaderFutures.get(protocolClass);
-        if (future != null) {
-            future.whenComplete((v, t) -> runnable.run());
-        } else {
-            runnable.run();
-        }
+    public static CompletableFuture<Void> getMappingLoaderFuture(Class<? extends Protocol> protocolClass) {
+        return mappingLoaderFutures.get(protocolClass);
+    }
+
+    public static Map<Class<? extends Protocol>, CompletableFuture<Void>> getMappingLoaderFutures() {
+        return mappingLoaderFutures;
+    }
+
+    public static ThreadPoolExecutor getMappingLoaderExecutor() {
+        return mappingLoaderExecutor;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
@@ -88,6 +88,10 @@ public class ProtocolRegistry {
         registerProtocol(new Protocol1_16To1_15_2(), ProtocolVersion.v1_16, ProtocolVersion.v1_15_2);
     }
 
+    public static void init() {
+        // Empty method to trigger static initializer once
+    }
+
     /**
      * Register a protocol
      *

--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
@@ -127,16 +127,8 @@ public class ProtocolRegistry {
         if (protocol.hasMappingDataToLoad()) {
             if (mappingLoaderExecutor != null) {
                 // Submit mapping data loading
-                CompletableFuture<Void> future = new CompletableFuture<>();
+                CompletableFuture<Void> future = CompletableFuture.runAsync(protocol::loadMappingData, mappingLoaderExecutor);
                 mappingLoaderFutures.put(protocol.getClass(), future);
-                mappingLoaderExecutor.execute(() -> {
-                    try {
-                        protocol.loadMappingData();
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                    future.complete(null);
-                });
             } else {
                 // Late protocol adding - just do it on the current thread
                 protocol.loadMappingData();

--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
@@ -127,8 +127,7 @@ public class ProtocolRegistry {
         if (protocol.hasMappingDataToLoad()) {
             if (mappingLoaderExecutor != null) {
                 // Submit mapping data loading
-                CompletableFuture<Void> future = CompletableFuture.runAsync(protocol::loadMappingData, mappingLoaderExecutor);
-                mappingLoaderFutures.put(protocol.getClass(), future);
+                addMappingLoaderFuture(protocol.getClass(), protocol::loadMappingData);
             } else {
                 // Late protocol adding - just do it on the current thread
                 protocol.loadMappingData();
@@ -330,15 +329,12 @@ public class ProtocolRegistry {
         }
     }
 
+    public static void addMappingLoaderFuture(Class<? extends Protocol> protocolClass, Runnable runnable) {
+        CompletableFuture<Void> future = CompletableFuture.runAsync(runnable, mappingLoaderExecutor);
+        mappingLoaderFutures.put(protocolClass, future);
+    }
+
     public static CompletableFuture<Void> getMappingLoaderFuture(Class<? extends Protocol> protocolClass) {
         return mappingLoaderFutures.get(protocolClass);
-    }
-
-    public static Map<Class<? extends Protocol>, CompletableFuture<Void>> getMappingLoaderFutures() {
-        return mappingLoaderFutures;
-    }
-
-    public static ThreadPoolExecutor getMappingLoaderExecutor() {
-        return mappingLoaderExecutor;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/base/BaseProtocol.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/base/BaseProtocol.java
@@ -58,6 +58,8 @@ public class BaseProtocol extends Protocol {
                         if (protocols != null) {
                             for (Pair<Integer, Protocol> prot : protocols) {
                                 pipeline.add(prot.getValue());
+                                // Ensure mapping data has already been loaded
+                                ProtocolRegistry.completeMappingDataLoading(prot.getValue().getClass());
                             }
                             wrapper.set(Type.VAR_INT, 0, protocol);
                         }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/base/BaseProtocol1_7.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/base/BaseProtocol1_7.java
@@ -9,7 +9,6 @@ import net.md_5.bungee.api.ChatColor;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Pair;
 import us.myles.ViaVersion.api.Via;
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
 import us.myles.ViaVersion.api.protocol.ProtocolVersion;
@@ -188,11 +187,6 @@ public class BaseProtocol1_7 extends Protocol {
         }); // Login Start Packet
         registerIncoming(State.LOGIN, 0x01, 0x01); // Encryption Response Packet
         registerIncoming(State.LOGIN, 0x02, 0x02); // Plugin Response (1.13)
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
-
     }
 
     public static String addDashes(String trimmedUUID) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11_1to1_11/Protocol1_11_1To1_11.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11_1to1_11/Protocol1_11_1To1_11.java
@@ -1,16 +1,10 @@
 package us.myles.ViaVersion.protocols.protocol1_11_1to1_11;
 
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 
 public class Protocol1_11_1To1_11 extends Protocol {
     @Override
     protected void registerPackets() {
         // Only had metadata changes, see wiki.vg for full info.
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
-
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12_1to1_12/Protocol1_12_1To1_12.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12_1to1_12/Protocol1_12_1To1_12.java
@@ -1,7 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_12_1to1_12;
 
 import us.myles.ViaVersion.api.PacketWrapper;
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.remapper.PacketHandler;
 import us.myles.ViaVersion.api.remapper.PacketRemapper;
@@ -86,10 +85,5 @@ public class Protocol1_12_1To1_12 extends Protocol {
                 });
             }
         });
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
-
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12_2to1_12_1/Protocol1_12_2To1_12_1.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12_2to1_12_1/Protocol1_12_2To1_12_1.java
@@ -1,6 +1,5 @@
 package us.myles.ViaVersion.protocols.protocol1_12_2to1_12_1;
 
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.remapper.PacketRemapper;
 import us.myles.ViaVersion.api.type.Type;
@@ -25,10 +24,5 @@ public class Protocol1_12_2To1_12_1 extends Protocol {
                 map(Type.LONG, Type.VAR_INT);
             }
         });
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
-
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13_2to1_13_1/Protocol1_13_2To1_13_1.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13_2to1_13_1/Protocol1_13_2To1_13_1.java
@@ -1,7 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_13_2to1_13_1;
 
 import us.myles.ViaVersion.api.PacketWrapper;
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.remapper.PacketHandler;
@@ -70,10 +69,5 @@ public class Protocol1_13_2To1_13_1 extends Protocol {
                 });
             }
         });
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
-
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -42,14 +42,15 @@ import java.util.Map;
 
 public class Protocol1_13To1_12_2 extends Protocol {
 
-    public static final PacketHandler POS_TO_3_INT = new PacketHandler() {
-        @Override
-        public void handle(PacketWrapper wrapper) throws Exception {
-            Position position = wrapper.read(Type.POSITION);
-            wrapper.write(Type.INT, position.getX());
-            wrapper.write(Type.INT, (int) position.getY());
-            wrapper.write(Type.INT, position.getZ());
-        }
+    public Protocol1_13To1_12_2() {
+        super(true);
+    }
+
+    public static final PacketHandler POS_TO_3_INT = wrapper -> {
+        Position position = wrapper.read(Type.POSITION);
+        wrapper.write(Type.INT, position.getX());
+        wrapper.write(Type.INT, (int) position.getY());
+        wrapper.write(Type.INT, position.getZ());
     };
 
     public static final PacketHandler SEND_DECLARE_COMMANDS_AND_TAGS =
@@ -132,11 +133,6 @@ public class Protocol1_13To1_12_2 extends Protocol {
         SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.UNDERLINE, ':');
         SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.ITALIC, ';');
         SCOREBOARD_TEAM_NAME_REWRITE.put(ChatColor.RESET, '/');
-
-        MappingData.init();
-        ConnectionData.init();
-        RecipeData.init();
-        BlockIdData.init();
     }
 
     @Override
@@ -1149,6 +1145,14 @@ public class Protocol1_13To1_12_2 extends Protocol {
         registerIncoming(State.PLAY, 0x1E, 0x28);
         registerIncoming(State.PLAY, 0x1F, 0x29);
         registerIncoming(State.PLAY, 0x20, 0x2A);
+    }
+
+    @Override
+    protected void loadMappingData() {
+        MappingData.init();
+        ConnectionData.init();
+        RecipeData.init();
+        BlockIdData.init();
     }
 
     @Override

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/ConnectionData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/ConnectionData.java
@@ -195,7 +195,7 @@ public class ConnectionData {
     public static void init() {
         if (!Via.getConfig().isServersideBlockConnections()) return;
         Via.getPlatform().getLogger().info("Loading block connection mappings ...");
-        JsonObject mapping1_13 = MappingDataLoader.loadData("mapping-1.13.json");
+        JsonObject mapping1_13 = MappingDataLoader.loadData("mapping-1.13.json", true);
         JsonObject blocks1_13 = mapping1_13.getAsJsonObject("blocks");
         for (Entry<String, JsonElement> blockState : blocks1_13.entrySet()) {
             Integer id = Integer.parseInt(blockState.getKey());

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/MappingData.java
@@ -33,23 +33,19 @@ public class MappingData {
     public static Mappings blockMappings;
 
     public static void init() {
-        JsonObject mapping1_12 = MappingDataLoader.loadData("mapping-1.12.json");
-        JsonObject mapping1_13 = MappingDataLoader.loadData("mapping-1.13.json");
+        JsonObject mapping1_12 = MappingDataLoader.loadData("mapping-1.12.json", true);
+        JsonObject mapping1_13 = MappingDataLoader.loadData("mapping-1.13.json", true);
+        Via.getPlatform().getLogger().info("Loading 1.12.2 -> 1.13 mappings...");
 
-        Via.getPlatform().getLogger().info("Loading 1.12.2 -> 1.13 block mapping...");
         blockMappings = new BlockMappingsShortArray(mapping1_12.getAsJsonObject("blocks"), mapping1_13.getAsJsonObject("blocks"));
-        Via.getPlatform().getLogger().info("Loading 1.12.2 -> 1.13 item mapping...");
         MappingDataLoader.mapIdentifiers(oldToNewItems, mapping1_12.getAsJsonObject("items"), mapping1_13.getAsJsonObject("items"));
-        Via.getPlatform().getLogger().info("Loading new 1.13 tags...");
         loadTags(blockTags, mapping1_13.getAsJsonObject("block_tags"));
         loadTags(itemTags, mapping1_13.getAsJsonObject("item_tags"));
         loadTags(fluidTags, mapping1_13.getAsJsonObject("fluid_tags"));
-        Via.getPlatform().getLogger().info("Loading 1.12.2 -> 1.13 enchantment mapping...");
+
         loadEnchantments(oldEnchantmentsIds, mapping1_12.getAsJsonObject("enchantments"));
         enchantmentMappings = new Mappings(72, mapping1_12.getAsJsonObject("enchantments"), mapping1_13.getAsJsonObject("enchantments"));
-        Via.getPlatform().getLogger().info("Loading 1.12.2 -> 1.13 sound mapping...");
         soundMappings = new Mappings(662, mapping1_12.getAsJsonArray("sounds"), mapping1_13.getAsJsonArray("sounds"));
-        Via.getPlatform().getLogger().info("Loading 1.12.2 -> 1.13 plugin channel mappings...");
 
         JsonObject object = MappingDataLoader.loadFromDataDir("channelmappings-1.13.json");
         if (object != null) {
@@ -64,7 +60,6 @@ public class MappingData {
             }
         }
 
-        Via.getPlatform().getLogger().info("Loading translation mappping");
         Map<String, String> translateData = GsonUtil.getGson().fromJson(
                 new InputStreamReader(MappingData.class.getClassLoader().getResourceAsStream("assets/viaversion/data/mapping-lang-1.12-1.13.json")),
                 new TypeToken<Map<String, String>>() {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/MappingData.java
@@ -33,9 +33,9 @@ public class MappingData {
     public static Mappings blockMappings;
 
     public static void init() {
+        Via.getPlatform().getLogger().info("Loading 1.12.2 -> 1.13 mappings...");
         JsonObject mapping1_12 = MappingDataLoader.loadData("mapping-1.12.json", true);
         JsonObject mapping1_13 = MappingDataLoader.loadData("mapping-1.13.json", true);
-        Via.getPlatform().getLogger().info("Loading 1.12.2 -> 1.13 mappings...");
 
         blockMappings = new BlockMappingsShortArray(mapping1_12.getAsJsonObject("blocks"), mapping1_13.getAsJsonObject("blocks"));
         MappingDataLoader.mapIdentifiers(oldToNewItems, mapping1_12.getAsJsonObject("items"), mapping1_13.getAsJsonObject("items"));

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_3to1_14_2/Protocol1_14_3To1_14_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_3to1_14_2/Protocol1_14_3To1_14_2.java
@@ -1,7 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_14_3to1_14_2;
 
 import us.myles.ViaVersion.api.PacketWrapper;
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.remapper.PacketHandler;
 import us.myles.ViaVersion.api.remapper.PacketRemapper;
@@ -42,9 +41,5 @@ public class Protocol1_14_3To1_14_2 extends Protocol {
                 });
             }
         });
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_4to1_14_3/Protocol1_14_4To1_14_3.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_4to1_14_3/Protocol1_14_4To1_14_3.java
@@ -1,7 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_14_4to1_14_3;
 
 import us.myles.ViaVersion.api.PacketWrapper;
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.remapper.PacketHandler;
 import us.myles.ViaVersion.api.remapper.PacketRemapper;
@@ -39,9 +38,5 @@ public class Protocol1_14_4To1_14_3 extends Protocol {
                 });
             }
         });
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/Protocol1_14To1_13_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/Protocol1_14To1_13_2.java
@@ -19,8 +19,8 @@ import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
 public class Protocol1_14To1_13_2 extends Protocol {
 
-    static {
-        MappingData.init();
+    public Protocol1_14To1_13_2() {
+        super(true);
     }
 
     @Override
@@ -252,6 +252,14 @@ public class Protocol1_14To1_13_2 extends Protocol {
         registerIncoming(State.PLAY, 0x28, 0x2B);
 
         registerIncoming(State.PLAY, 0x2A, 0x2D);
+    }
+
+    @Override
+    protected void loadMappingData() {
+        MappingData.init();
+        WorldPackets.air = MappingData.blockStateMappings.getNewId(0);
+        WorldPackets.voidAir = MappingData.blockStateMappings.getNewId(8591);
+        WorldPackets.caveAir = MappingData.blockStateMappings.getNewId(8592);
     }
 
     public static int getNewSoundId(int id) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/data/MappingData.java
@@ -23,9 +23,9 @@ public class MappingData {
     public static Set<Integer> nonFullBlocks;
 
     public static void init() {
+        Via.getPlatform().getLogger().info("Loading 1.13.2 -> 1.14 mappings...");
         JsonObject mapping1_13_2 = MappingDataLoader.loadData("mapping-1.13.2.json", true);
         JsonObject mapping1_14 = MappingDataLoader.loadData("mapping-1.14.json", true);
-        Via.getPlatform().getLogger().info("Loading 1.13.2 -> 1.14 mappings...");
 
         blockStateMappings = new Mappings(mapping1_13_2.getAsJsonObject("blockstates"), mapping1_14.getAsJsonObject("blockstates"));
         blockMappings = new Mappings(mapping1_13_2.getAsJsonObject("blocks"), mapping1_14.getAsJsonObject("blocks"));

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/data/MappingData.java
@@ -23,26 +23,21 @@ public class MappingData {
     public static Set<Integer> nonFullBlocks;
 
     public static void init() {
-        JsonObject mapping1_13_2 = MappingDataLoader.loadData("mapping-1.13.2.json");
-        JsonObject mapping1_14 = MappingDataLoader.loadData("mapping-1.14.json");
+        JsonObject mapping1_13_2 = MappingDataLoader.loadData("mapping-1.13.2.json", true);
+        JsonObject mapping1_14 = MappingDataLoader.loadData("mapping-1.14.json", true);
+        Via.getPlatform().getLogger().info("Loading 1.13.2 -> 1.14 mappings...");
 
-        Via.getPlatform().getLogger().info("Loading 1.13.2 -> 1.14 blockstate mapping...");
         blockStateMappings = new Mappings(mapping1_13_2.getAsJsonObject("blockstates"), mapping1_14.getAsJsonObject("blockstates"));
-        Via.getPlatform().getLogger().info("Loading 1.13.2 -> 1.14 block mapping...");
         blockMappings = new Mappings(mapping1_13_2.getAsJsonObject("blocks"), mapping1_14.getAsJsonObject("blocks"));
-        Via.getPlatform().getLogger().info("Loading 1.13.2 -> 1.14 item mapping...");
         MappingDataLoader.mapIdentifiers(oldToNewItems, mapping1_13_2.getAsJsonObject("items"), mapping1_14.getAsJsonObject("items"));
-        Via.getPlatform().getLogger().info("Loading 1.13.2 -> 1.14 sound mapping...");
         soundMappings = new Mappings(mapping1_13_2.getAsJsonArray("sounds"), mapping1_14.getAsJsonArray("sounds"));
 
-        Via.getPlatform().getLogger().info("Loading 1.14 blockstates...");
         JsonObject blockStates = mapping1_14.getAsJsonObject("blockstates");
         Map<String, Integer> blockStateMap = new HashMap<>(blockStates.entrySet().size());
         for (Map.Entry<String, JsonElement> entry : blockStates.entrySet()) {
             blockStateMap.put(entry.getValue().getAsString(), Integer.parseInt(entry.getKey()));
         }
 
-        Via.getPlatform().getLogger().info("Loading 1.14 heightmap data...");
         JsonObject heightMapData = MappingDataLoader.loadData("heightMapData-1.14.json");
         JsonArray motionBlocking = heightMapData.getAsJsonArray("MOTION_BLOCKING");
         us.myles.ViaVersion.protocols.protocol1_14to1_13_2.data.MappingData.motionBlocking = new HashSet<>(motionBlocking.size());

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
@@ -28,11 +28,11 @@ import us.myles.ViaVersion.util.CompactArrayUtil;
 import java.util.Arrays;
 
 public class WorldPackets {
-    private static final int AIR = MappingData.blockStateMappings.getNewId(0);
-    private static final int VOID_AIR = MappingData.blockStateMappings.getNewId(8591);
-    private static final int CAVE_AIR = MappingData.blockStateMappings.getNewId(8592);
     public static final int SERVERSIDE_VIEW_DISTANCE = 64;
     private static final byte[] FULL_LIGHT = new byte[2048];
+    public static int air;
+    public static int voidAir;
+    public static int caveAir;
 
     static {
         Arrays.fill(FULL_LIGHT, (byte) 0xff);
@@ -156,7 +156,7 @@ public class WorldPackets {
                             for (int i = 0; i < section.getPaletteSize(); i++) {
                                 int old = section.getPaletteEntry(i);
                                 int newId = Protocol1_14To1_13_2.getNewBlockStateId(old);
-                                if (!hasBlock && newId != AIR && newId != VOID_AIR && newId != CAVE_AIR) { // air, void_air, cave_air
+                                if (!hasBlock && newId != air && newId != voidAir && newId != caveAir) { // air, void_air, cave_air
                                     hasBlock = true;
                                 }
                                 section.setPaletteEntry(i, newId);
@@ -171,7 +171,7 @@ public class WorldPackets {
                                 for (int y = 0; y < 16; y++) {
                                     for (int z = 0; z < 16; z++) {
                                         int id = section.getFlatBlock(x, y, z);
-                                        if (id != AIR && id != VOID_AIR && id != CAVE_AIR) {
+                                        if (id != air && id != voidAir && id != caveAir) {
                                             nonAirBlockCount++;
                                             worldSurface[x + z * 16] = y + s * 16 + 1; // +1 (top of the block)
                                         }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15_1to1_15/Protocol1_15_1To1_15.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15_1to1_15/Protocol1_15_1To1_15.java
@@ -1,15 +1,10 @@
 package us.myles.ViaVersion.protocols.protocol1_15_1to1_15;
 
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 
 public class Protocol1_15_1To1_15 extends Protocol {
 
     @Override
     protected void registerPackets() {
-    }
-
-    @Override
-    public void init(UserConnection user) {
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15_2to1_15_1/Protocol1_15_2To1_15_1.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15_2to1_15_1/Protocol1_15_2To1_15_1.java
@@ -1,15 +1,10 @@
 package us.myles.ViaVersion.protocols.protocol1_15_2to1_15_1;
 
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 
 public class Protocol1_15_2To1_15_1 extends Protocol {
 
     @Override
     protected void registerPackets() {
-    }
-
-    @Override
-    public void init(UserConnection user) {
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/Protocol1_15To1_14_4.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/Protocol1_15To1_14_4.java
@@ -21,6 +21,8 @@ import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
 public class Protocol1_15To1_14_4 extends Protocol {
 
+    private TagRewriter tagRewriter;
+
     public Protocol1_15To1_14_4() {
         super(true);
     }
@@ -118,13 +120,7 @@ public class Protocol1_15To1_14_4 extends Protocol {
         });
 
         // Tags
-        TagRewriter tagRewriter = new TagRewriter(this, Protocol1_15To1_14_4::getNewBlockId, InventoryPackets::getNewItemId, EntityPackets::getNewEntityId);
-        int[] shulkerBoxes = new int[17];
-        int shulkerBoxOffset = 501;
-        for (int i = 0; i < 17; i++) {
-            shulkerBoxes[i] = shulkerBoxOffset + i;
-        }
-        tagRewriter.addTag(TagType.BLOCK, "minecraft:shulker_boxes", shulkerBoxes);
+        tagRewriter = new TagRewriter(this, Protocol1_15To1_14_4::getNewBlockId, InventoryPackets::getNewItemId, EntityPackets::getNewEntityId);
         tagRewriter.register(0x5B, 0x5C);
 
         registerOutgoing(State.PLAY, 0x08, 0x09);
@@ -209,6 +205,13 @@ public class Protocol1_15To1_14_4 extends Protocol {
     @Override
     protected void loadMappingData() {
         MappingData.init();
+
+        int[] shulkerBoxes = new int[17];
+        int shulkerBoxOffset = 501;
+        for (int i = 0; i < 17; i++) {
+            shulkerBoxes[i] = shulkerBoxOffset + i;
+        }
+        tagRewriter.addTag(TagType.BLOCK, "minecraft:shulker_boxes", shulkerBoxes);
     }
 
     public static int getNewBlockStateId(int id) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/Protocol1_15To1_14_4.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/Protocol1_15To1_14_4.java
@@ -21,11 +21,14 @@ import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
 public class Protocol1_15To1_14_4 extends Protocol {
 
+    public Protocol1_15To1_14_4() {
+        super(true);
+    }
+
     @Override
     protected void registerPackets() {
         new MetadataRewriter1_15To1_14_4(this);
 
-        MappingData.init();
         EntityPackets.register(this);
         PlayerPackets.register(this);
         WorldPackets.register(this);
@@ -201,6 +204,11 @@ public class Protocol1_15To1_14_4 extends Protocol {
 
         registerOutgoing(State.PLAY, 0x58, 0x59);
         registerOutgoing(State.PLAY, 0x59, 0x5A);
+    }
+
+    @Override
+    protected void loadMappingData() {
+        MappingData.init();
     }
 
     public static int getNewBlockStateId(int id) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/data/MappingData.java
@@ -15,16 +15,13 @@ public class MappingData {
 
     public static void init() {
         JsonObject diffmapping = MappingDataLoader.loadData("mappingdiff-1.14to1.15.json");
-        JsonObject mapping1_14 = MappingDataLoader.loadData("mapping-1.14.json");
-        JsonObject mapping1_15 = MappingDataLoader.loadData("mapping-1.15.json");
+        JsonObject mapping1_14 = MappingDataLoader.loadData("mapping-1.14.json", true);
+        JsonObject mapping1_15 = MappingDataLoader.loadData("mapping-1.15.json", true);
+        Via.getPlatform().getLogger().info("Loading 1.14.4 -> 1.15 mappings...");
 
-        Via.getPlatform().getLogger().info("Loading 1.14.4 -> 1.15 blockstate mapping...");
         blockStateMappings = new Mappings(mapping1_14.getAsJsonObject("blockstates"), mapping1_15.getAsJsonObject("blockstates"), diffmapping.getAsJsonObject("blockstates"));
-        Via.getPlatform().getLogger().info("Loading 1.14.4 -> 1.15 block mapping...");
         blockMappings = new Mappings(mapping1_14.getAsJsonObject("blocks"), mapping1_15.getAsJsonObject("blocks"));
-        Via.getPlatform().getLogger().info("Loading 1.14.4 -> 1.15 item mapping...");
         MappingDataLoader.mapIdentifiers(oldToNewItems, mapping1_14.getAsJsonObject("items"), mapping1_15.getAsJsonObject("items"));
-        Via.getPlatform().getLogger().info("Loading 1.14.4 -> 1.15 sound mapping...");
         soundMappings = new Mappings(mapping1_14.getAsJsonArray("sounds"), mapping1_15.getAsJsonArray("sounds"), false);
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/data/MappingData.java
@@ -14,10 +14,10 @@ public class MappingData {
     public static Mappings soundMappings;
 
     public static void init() {
+        Via.getPlatform().getLogger().info("Loading 1.14.4 -> 1.15 mappings...");
         JsonObject diffmapping = MappingDataLoader.loadData("mappingdiff-1.14to1.15.json");
         JsonObject mapping1_14 = MappingDataLoader.loadData("mapping-1.14.json", true);
         JsonObject mapping1_15 = MappingDataLoader.loadData("mapping-1.15.json", true);
-        Via.getPlatform().getLogger().info("Loading 1.14.4 -> 1.15 mappings...");
 
         blockStateMappings = new Mappings(mapping1_14.getAsJsonObject("blockstates"), mapping1_15.getAsJsonObject("blockstates"), diffmapping.getAsJsonObject("blockstates"));
         blockMappings = new Mappings(mapping1_14.getAsJsonObject("blocks"), mapping1_15.getAsJsonObject("blocks"));

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
@@ -20,11 +20,14 @@ import java.util.UUID;
 
 public class Protocol1_16To1_15_2 extends Protocol {
 
+    public Protocol1_16To1_15_2() {
+        super(true);
+    }
+
     @Override
     protected void registerPackets() {
         MetadataRewriter1_16To1_15_2 metadataRewriter = new MetadataRewriter1_16To1_15_2(this);
 
-        MappingData.init();
         EntityPackets.register(this);
         WorldPackets.register(this);
         InventoryPackets.register(this);
@@ -130,6 +133,11 @@ public class Protocol1_16To1_15_2 extends Protocol {
         registerOutgoing(State.PLAY, 0x4C, 0x4D);
         registerOutgoing(State.PLAY, 0x4D, 0x4E);
         registerOutgoing(State.PLAY, 0x4E, 0x43);
+    }
+
+    @Override
+    protected void loadMappingData() {
+        MappingData.init();
     }
 
     public static int getNewBlockStateId(int id) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
@@ -20,6 +20,8 @@ import java.util.UUID;
 
 public class Protocol1_16To1_15_2 extends Protocol {
 
+    private TagRewriter tagRewriter;
+
     public Protocol1_16To1_15_2() {
         super(true);
     }
@@ -32,16 +34,7 @@ public class Protocol1_16To1_15_2 extends Protocol {
         WorldPackets.register(this);
         InventoryPackets.register(this);
 
-        TagRewriter tagRewriter = new TagRewriter(this, Protocol1_16To1_15_2::getNewBlockId, InventoryPackets::getNewItemId, metadataRewriter::getNewEntityId);
-        tagRewriter.addTag(TagType.BLOCK, "minecraft:beacon_base_blocks", 133, 134, 148, 265);
-        tagRewriter.addTag(TagType.BLOCK, "minecraft:climbable", 160, 241, 658);
-        tagRewriter.addTag(TagType.BLOCK, "minecraft:fire", 142);
-        tagRewriter.addTag(TagType.ITEM, "minecraft:beacon_payment_items", 529, 530, 531, 760);
-        // The client crashes if we don't send all tags it may use
-        tagRewriter.addEmptyTag(TagType.BLOCK, "minecraft:soul_speed_blocks");
-        tagRewriter.addEmptyTag(TagType.BLOCK, "minecraft:soul_fire_base_blocks");
-        tagRewriter.addEmptyTag(TagType.BLOCK, "minecraft:non_flammable_wood");
-        tagRewriter.addEmptyTag(TagType.ITEM, "minecraft:non_flammable_wood");
+        tagRewriter = new TagRewriter(this, Protocol1_16To1_15_2::getNewBlockId, InventoryPackets::getNewItemId, metadataRewriter::getNewEntityId);
         tagRewriter.register(0x5C, 0x5C);
 
         // Login Success
@@ -138,6 +131,16 @@ public class Protocol1_16To1_15_2 extends Protocol {
     @Override
     protected void loadMappingData() {
         MappingData.init();
+
+        tagRewriter.addTag(TagType.BLOCK, "minecraft:beacon_base_blocks", 133, 134, 148, 265);
+        tagRewriter.addTag(TagType.BLOCK, "minecraft:climbable", 160, 241, 658);
+        tagRewriter.addTag(TagType.BLOCK, "minecraft:fire", 142);
+        tagRewriter.addTag(TagType.ITEM, "minecraft:beacon_payment_items", 529, 530, 531, 760);
+        // The client crashes if we don't send all tags it may use
+        tagRewriter.addEmptyTag(TagType.BLOCK, "minecraft:soul_speed_blocks");
+        tagRewriter.addEmptyTag(TagType.BLOCK, "minecraft:soul_fire_base_blocks");
+        tagRewriter.addEmptyTag(TagType.BLOCK, "minecraft:non_flammable_wood");
+        tagRewriter.addEmptyTag(TagType.ITEM, "minecraft:non_flammable_wood");
     }
 
     public static int getNewBlockStateId(int id) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/data/MappingData.java
@@ -19,16 +19,13 @@ public class MappingData {
 
     public static void init() {
         JsonObject diffmapping = MappingDataLoader.loadData("mappingdiff-1.15to1.16.json");
-        JsonObject mapping1_15 = MappingDataLoader.loadData("mapping-1.15.json");
-        JsonObject mapping1_16 = MappingDataLoader.loadData("mapping-1.16.json");
+        JsonObject mapping1_15 = MappingDataLoader.loadData("mapping-1.15.json", true);
+        JsonObject mapping1_16 = MappingDataLoader.loadData("mapping-1.16.json", true);
+        Via.getPlatform().getLogger().info("Loading 1.15 -> 1.16 mappings...");
 
-        Via.getPlatform().getLogger().info("Loading 1.15 -> 1.16 blockstate mapping...");
         blockStateMappings = new Mappings(mapping1_15.getAsJsonObject("blockstates"), mapping1_16.getAsJsonObject("blockstates"), diffmapping.getAsJsonObject("blockstates"));
-        Via.getPlatform().getLogger().info("Loading 1.15 -> 1.16 block mapping...");
         blockMappings = new Mappings(mapping1_15.getAsJsonObject("blocks"), mapping1_16.getAsJsonObject("blocks"));
-        Via.getPlatform().getLogger().info("Loading 1.15 -> 1.16 item mapping...");
         MappingDataLoader.mapIdentifiers(oldToNewItems, mapping1_15.getAsJsonObject("items"), mapping1_16.getAsJsonObject("items"), diffmapping.getAsJsonObject("items"));
-        Via.getPlatform().getLogger().info("Loading 1.15 -> 1.16 sound mapping...");
         soundMappings = new Mappings(mapping1_15.getAsJsonArray("sounds"), mapping1_16.getAsJsonArray("sounds"), diffmapping.getAsJsonObject("sounds"));
 
         attributeMappings.put("generic.maxHealth", "minecraft:generic.max_health");

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/data/MappingData.java
@@ -18,10 +18,10 @@ public class MappingData {
     public static Mappings soundMappings;
 
     public static void init() {
+        Via.getPlatform().getLogger().info("Loading 1.15 -> 1.16 mappings...");
         JsonObject diffmapping = MappingDataLoader.loadData("mappingdiff-1.15to1.16.json");
         JsonObject mapping1_15 = MappingDataLoader.loadData("mapping-1.15.json", true);
         JsonObject mapping1_16 = MappingDataLoader.loadData("mapping-1.16.json", true);
-        Via.getPlatform().getLogger().info("Loading 1.15 -> 1.16 mappings...");
 
         blockStateMappings = new Mappings(mapping1_15.getAsJsonObject("blockstates"), mapping1_16.getAsJsonObject("blockstates"), diffmapping.getAsJsonObject("blockstates"));
         blockMappings = new Mappings(mapping1_15.getAsJsonObject("blocks"), mapping1_16.getAsJsonObject("blocks"));

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1to1_9/Protocol1_9_1To1_9.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1to1_9/Protocol1_9_1To1_9.java
@@ -1,7 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_9_1to1_9;
 
 import us.myles.ViaVersion.api.PacketWrapper;
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.remapper.PacketHandler;
 import us.myles.ViaVersion.api.remapper.PacketRemapper;
@@ -44,10 +43,5 @@ public class Protocol1_9_1To1_9 extends Protocol {
                 });
             }
         });
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
-
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_9_1/Protocol1_9To1_9_1.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_9_1/Protocol1_9To1_9_1.java
@@ -1,7 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_9to1_9_1;
 
 import us.myles.ViaVersion.api.PacketWrapper;
-import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.remapper.PacketHandler;
 import us.myles.ViaVersion.api.remapper.PacketRemapper;
@@ -46,10 +45,5 @@ public class Protocol1_9To1_9_1 extends Protocol {
                 });
             }
         });
-    }
-
-    @Override
-    public void init(UserConnection userConnection) {
-
     }
 }

--- a/sponge/src/main/java/us/myles/ViaVersion/SpongePlugin.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/SpongePlugin.java
@@ -83,7 +83,7 @@ public class SpongePlugin implements ViaPlatform {
     @Listener
     public void onServerStart(GameAboutToStartServerEvent event) {
         if (game.getPluginManager().getPlugin("ViaBackwards").isPresent()) {
-            MappingDataLoader.setCacheJsonMappings(true);
+            MappingDataLoader.enableMappingsCache();
         }
 
         // Inject!

--- a/sponge/src/main/java/us/myles/ViaVersion/SpongePlugin.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/SpongePlugin.java
@@ -19,6 +19,7 @@ import org.spongepowered.api.text.serializer.TextSerializers;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.command.ViaCommandSender;
 import us.myles.ViaVersion.api.configuration.ConfigurationProvider;
+import us.myles.ViaVersion.api.data.MappingDataLoader;
 import us.myles.ViaVersion.api.platform.TaskId;
 import us.myles.ViaVersion.api.platform.ViaPlatform;
 import us.myles.ViaVersion.dump.PluginInfo;
@@ -68,7 +69,8 @@ public class SpongePlugin implements ViaPlatform {
         conf = new SpongeViaConfig(container, defaultConfig.getParentFile());
         SpongeCommandHandler commandHandler = new SpongeCommandHandler();
         game.getCommandManager().register(this, commandHandler, "viaversion", "viaver", "vvsponge");
-        getLogger().info("ViaVersion " + getPluginVersion() + " is now loaded!");
+        logger.info("ViaVersion " + getPluginVersion() + " is now loaded!");
+
         // Init platform
         Via.init(ViaManager.builder()
                 .platform(this)
@@ -80,6 +82,10 @@ public class SpongePlugin implements ViaPlatform {
 
     @Listener
     public void onServerStart(GameAboutToStartServerEvent event) {
+        if (game.getPluginManager().getPlugin("ViaBackwards").isPresent()) {
+            MappingDataLoader.setCacheJsonMappings(true);
+        }
+
         // Inject!
         logger.info("ViaVersion is injecting!");
         Via.getManager().init();

--- a/velocity/src/main/java/us/myles/ViaVersion/VelocityPlugin.java
+++ b/velocity/src/main/java/us/myles/ViaVersion/VelocityPlugin.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.command.ViaCommandSender;
 import us.myles.ViaVersion.api.configuration.ConfigurationProvider;
+import us.myles.ViaVersion.api.data.MappingDataLoader;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.platform.TaskId;
 import us.myles.ViaVersion.api.platform.ViaPlatform;
@@ -73,6 +74,11 @@ public class VelocityPlugin implements ViaPlatform<Player> {
                 .commandHandler(commandHandler)
                 .loader(new VelocityViaLoader())
                 .injector(new VelocityViaInjector()).build());
+
+        if (proxy.getPluginManager().getPlugin("ViaBackwards").isPresent()) {
+            MappingDataLoader.setCacheJsonMappings(true);
+        }
+
         Via.getManager().init();
     }
 

--- a/velocity/src/main/java/us/myles/ViaVersion/VelocityPlugin.java
+++ b/velocity/src/main/java/us/myles/ViaVersion/VelocityPlugin.java
@@ -76,7 +76,7 @@ public class VelocityPlugin implements ViaPlatform<Player> {
                 .injector(new VelocityViaInjector()).build());
 
         if (proxy.getPluginManager().getPlugin("ViaBackwards").isPresent()) {
-            MappingDataLoader.setCacheJsonMappings(true);
+            MappingDataLoader.enableMappingsCache();
         }
 
         Via.getManager().init();


### PR DESCRIPTION
Depending on how much the CPU has to do during server startup as well, this will generally cut 2 to a bit over 5 seconds of startup time (loading was down from 11 to 4 seconds on a minimal setup Paper 1.15 server with VV and VB, and about a 3 seconds cut on our production servers with quite a limited amount of cores).

Using a cached threadpooplexecutor, mappings will be loaded asynchronously, until a user of a higher/lower client version logs on, in which case it will block and wait for the load (it does not block with clients running the server's version).

If ViaBackwards is present, Via will also cache relevant mappings, so that they will not be loaded twice - **still need ideas on how to enable the caching, currently just done by checking if VB is present** (it's fine, but maybe there's a better way).


A more minor change is a wrapper for the protocolstate and channel id instead of using a pair with boxed Integers, since those maps are called quite frequently, see the first commit https://github.com/ViaVersion/ViaVersion/commit/5d614f14d0c16561ca4d8e4a660c8cdb5e29293d