### PR TITLE
Minor chunk type cleanup

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/BaseChunk.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/BaseChunk.java
@@ -1,29 +1,32 @@
 package us.myles.ViaVersion.api.minecraft.chunks;
 
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
-import lombok.AllArgsConstructor;
 
 import java.util.List;
 
-@AllArgsConstructor
 public class BaseChunk implements Chunk {
     protected final int x;
     protected final int z;
-    protected final boolean groundUp;
+    protected final boolean fullChunk;
     protected final int bitmask;
     protected final ChunkSection[] sections;
     protected int[] biomeData;
     protected CompoundTag heightMap;
     protected final List<CompoundTag> blockEntities;
 
-    public BaseChunk(int x, int z, boolean groundUp, int bitmask, ChunkSection[] sections, int[] biomeData, List<CompoundTag> blockEntities) {
+    public BaseChunk(int x, int z, boolean fullChunk, int bitmask, ChunkSection[] sections, int[] biomeData, CompoundTag heightMap, List<CompoundTag> blockEntities) {
         this.x = x;
         this.z = z;
-        this.groundUp = groundUp;
+        this.fullChunk = fullChunk;
         this.bitmask = bitmask;
         this.sections = sections;
         this.biomeData = biomeData;
+        this.heightMap = heightMap;
         this.blockEntities = blockEntities;
+    }
+
+    public BaseChunk(int x, int z, boolean fullChunk, int bitmask, ChunkSection[] sections, int[] biomeData, List<CompoundTag> blockEntities) {
+        this(x, z, fullChunk, bitmask, sections, biomeData, null, blockEntities);
     }
 
     @Override
@@ -42,8 +45,8 @@ public class BaseChunk implements Chunk {
     }
 
     @Override
-    public boolean isGroundUp() {
-        return groundUp;
+    public boolean isFullChunk() {
+        return fullChunk;
     }
 
     @Override

--- a/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/Chunk.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/Chunk.java
@@ -5,11 +5,19 @@ import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import java.util.List;
 
 public interface Chunk {
+
     int getX();
 
     int getZ();
 
     boolean isBiomeData();
+
+    boolean isFullChunk();
+
+    @Deprecated
+    default boolean isGroundUp() {
+        return isFullChunk();
+    }
 
     int getBitmask();
 
@@ -24,6 +32,4 @@ public interface Chunk {
     void setHeightMap(CompoundTag heightMap);
 
     List<CompoundTag> getBlockEntities();
-
-    boolean isGroundUp();
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/Chunk1_8.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/Chunk1_8.java
@@ -29,12 +29,7 @@ public class Chunk1_8 extends BaseChunk {
      * @return True if the chunks has biome data
      */
     public boolean hasBiomeData() {
-        return biomeData != null && groundUp;
-    }
-
-    @Override
-    public boolean isBiomeData() {
-        return biomeData != null;
+        return biomeData != null && fullChunk;
     }
 
     public boolean isUnloadPacket() {

--- a/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/ChunkSection.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/ChunkSection.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ChunkSection {
+
     /**
      * Size (dimensions) of blocks in a chunks section.
      */

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
@@ -13,6 +13,7 @@ import us.myles.ViaVersion.api.type.types.minecraft.BaseChunkType;
 import us.myles.ViaVersion.api.type.types.version.Types1_13;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
@@ -55,7 +56,7 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        List<CompoundTag> nbtData = Arrays.asList(Type.NBT_ARRAY.read(input));
+        List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NBT_ARRAY.read(input)));
 
         // Read all the remaining bytes (workaround for #681)
         if (input.readableBytes() > 0) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
@@ -13,9 +13,7 @@ import us.myles.ViaVersion.api.type.types.minecraft.BaseChunkType;
 import us.myles.ViaVersion.api.type.types.version.Types1_13;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -29,22 +27,15 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
         int chunkX = input.readInt();
         int chunkZ = input.readInt();
 
-        boolean groundUp = input.readBoolean();
+        boolean fullChunk = input.readBoolean();
         int primaryBitmask = Type.VAR_INT.read(input);
         ByteBuf data = input.readSlice(Type.VAR_INT.read(input));
 
-        BitSet usedSections = new BitSet(16);
-        ChunkSection[] sections = new ChunkSection[16];
-        // Calculate section count from bitmask
-        for (int i = 0; i < 16; i++) {
-            if ((primaryBitmask & (1 << i)) != 0) {
-                usedSections.set(i);
-            }
-        }
-
         // Read sections
+        ChunkSection[] sections = new ChunkSection[16];
         for (int i = 0; i < 16; i++) {
-            if (!usedSections.get(i)) continue; // Section not set
+            if ((primaryBitmask & (1 << i)) == 0) continue; // Section not set
+
             ChunkSection section = Types1_13.CHUNK_SECTION.read(data);
             sections[i] = section;
             section.readBlockLight(data);
@@ -53,18 +44,18 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        int[] biomeData = groundUp ? new int[256] : null;
-        if (groundUp) {
+        int[] biomeData = fullChunk ? new int[256] : null;
+        if (fullChunk) {
             if (data.readableBytes() >= 256 * 4) {
                 for (int i = 0; i < 256; i++) {
                     biomeData[i] = data.readInt();
                 }
             } else {
-                Via.getPlatform().getLogger().log(Level.WARNING, "Chunk x="+ chunkX + " z=" + chunkZ + " doesn't have biome data!");
+                Via.getPlatform().getLogger().log(Level.WARNING, "Chunk x=" + chunkX + " z=" + chunkZ + " doesn't have biome data!");
             }
         }
 
-        List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NBT_ARRAY.read(input)));
+        List<CompoundTag> nbtData = Arrays.asList(Type.NBT_ARRAY.read(input));
 
         // Read all the remaining bytes (workaround for #681)
         if (input.readableBytes() > 0) {
@@ -74,7 +65,7 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        return new BaseChunk(chunkX, chunkZ, groundUp, primaryBitmask, sections, biomeData, nbtData);
+        return new BaseChunk(chunkX, chunkZ, fullChunk, primaryBitmask, sections, biomeData, nbtData);
     }
 
     @Override
@@ -82,7 +73,7 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getX());
         output.writeInt(chunk.getZ());
 
-        output.writeBoolean(chunk.isGroundUp());
+        output.writeBoolean(chunk.isFullChunk());
         Type.VAR_INT.write(output, chunk.getBitmask());
 
         ByteBuf buf = output.alloc().buffer();
@@ -98,7 +89,7 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
 
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 256 * 4 : 0));
+            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 1024 : 0));
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
@@ -199,12 +199,12 @@ public class WorldPackets {
                         lightPacket.write(Type.VAR_INT, chunk.getX());
                         lightPacket.write(Type.VAR_INT, chunk.getZ());
 
-                        int skyLightMask = chunk.isGroundUp() ? 0x3ffff : 0; // all 18 bits set if ground up
+                        int skyLightMask = chunk.isFullChunk() ? 0x3ffff : 0; // all 18 bits set if ground up
                         int blockLightMask = 0;
                         for (int i = 0; i < chunk.getSections().length; i++) {
                             ChunkSection sec = chunk.getSections()[i];
                             if (sec == null) continue;
-                            if (!chunk.isGroundUp() && sec.hasSkyLight()) {
+                            if (!chunk.isFullChunk() && sec.hasSkyLight()) {
                                 skyLightMask |= (1 << (i + 1));
                             }
                             blockLightMask |= (1 << (i + 1));
@@ -217,18 +217,18 @@ public class WorldPackets {
 
                         // not sending skylight/setting empty skylight causes client lag due to some weird calculations
                         // only do this on the initial chunk send (not when chunk.isGroundUp() is false)
-                        if (chunk.isGroundUp())
+                        if (chunk.isFullChunk())
                             lightPacket.write(Type.BYTE_ARRAY_PRIMITIVE, FULL_LIGHT); // chunk below 0
                         for (ChunkSection section : chunk.getSections()) {
                             if (section == null || !section.hasSkyLight()) {
-                                if (chunk.isGroundUp()) {
+                                if (chunk.isFullChunk()) {
                                     lightPacket.write(Type.BYTE_ARRAY_PRIMITIVE, FULL_LIGHT);
                                 }
                                 continue;
                             }
                             lightPacket.write(Type.BYTE_ARRAY_PRIMITIVE, section.getSkyLight());
                         }
-                        if (chunk.isGroundUp())
+                        if (chunk.isFullChunk())
                             lightPacket.write(Type.BYTE_ARRAY_PRIMITIVE, FULL_LIGHT); // chunk above 255
 
                         for (ChunkSection section : chunk.getSections()) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/types/Chunk1_14Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/types/Chunk1_14Type.java
@@ -12,6 +12,7 @@ import us.myles.ViaVersion.api.type.types.minecraft.BaseChunkType;
 import us.myles.ViaVersion.api.type.types.version.Types1_13;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        List<CompoundTag> nbtData = Arrays.asList(Type.NBT_ARRAY.read(input));
+        List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NBT_ARRAY.read(input)));
 
         // Read all the remaining bytes (workaround for #681)
         if (input.readableBytes() > 0) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/types/Chunk1_14Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/types/Chunk1_14Type.java
@@ -12,9 +12,7 @@ import us.myles.ViaVersion.api.type.types.minecraft.BaseChunkType;
 import us.myles.ViaVersion.api.type.types.version.Types1_13;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 
 public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
@@ -28,37 +26,31 @@ public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
         int chunkX = input.readInt();
         int chunkZ = input.readInt();
 
-        boolean groundUp = input.readBoolean();
+        boolean fullChunk = input.readBoolean();
         int primaryBitmask = Type.VAR_INT.read(input);
         CompoundTag heightMap = Type.NBT.read(input);
+
         Type.VAR_INT.read(input);
 
-        BitSet usedSections = new BitSet(16);
-        ChunkSection[] sections = new ChunkSection[16];
-        // Calculate section count from bitmask
-        for (int i = 0; i < 16; i++) {
-            if ((primaryBitmask & (1 << i)) != 0) {
-                usedSections.set(i);
-            }
-        }
-
         // Read sections
+        ChunkSection[] sections = new ChunkSection[16];
         for (int i = 0; i < 16; i++) {
-            if (!usedSections.get(i)) continue; // Section not set
+            if ((primaryBitmask & (1 << i)) == 0) continue; // Section not set
+
             short nonAirBlocksCount = input.readShort();
             ChunkSection section = Types1_13.CHUNK_SECTION.read(input);
             section.setNonAirBlocksCount(nonAirBlocksCount);
             sections[i] = section;
         }
 
-        int[] biomeData = groundUp ? new int[256] : null;
-        if (groundUp) {
+        int[] biomeData = fullChunk ? new int[256] : null;
+        if (fullChunk) {
             for (int i = 0; i < 256; i++) {
                 biomeData[i] = input.readInt();
             }
         }
 
-        List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NBT_ARRAY.read(input)));
+        List<CompoundTag> nbtData = Arrays.asList(Type.NBT_ARRAY.read(input));
 
         // Read all the remaining bytes (workaround for #681)
         if (input.readableBytes() > 0) {
@@ -68,7 +60,7 @@ public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        return new BaseChunk(chunkX, chunkZ, groundUp, primaryBitmask, sections, biomeData, heightMap, nbtData);
+        return new BaseChunk(chunkX, chunkZ, fullChunk, primaryBitmask, sections, biomeData, heightMap, nbtData);
     }
 
     @Override
@@ -76,7 +68,7 @@ public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getX());
         output.writeInt(chunk.getZ());
 
-        output.writeBoolean(chunk.isGroundUp());
+        output.writeBoolean(chunk.isFullChunk());
         Type.VAR_INT.write(output, chunk.getBitmask());
         Type.NBT.write(output, chunk.getHeightMap());
 
@@ -85,11 +77,12 @@ public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
             for (int i = 0; i < 16; i++) {
                 ChunkSection section = chunk.getSections()[i];
                 if (section == null) continue; // Section not set
+
                 buf.writeShort(section.getNonAirBlocksCount());
                 Types1_13.CHUNK_SECTION.write(buf, section);
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 256 * 4 : 0));
+            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 1024 : 0)); // 256 * 4
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/packets/WorldPackets.java
@@ -42,7 +42,7 @@ public class WorldPackets {
                         Chunk chunk = wrapper.read(new Chunk1_14Type(clientWorld));
                         wrapper.write(new Chunk1_15Type(clientWorld), chunk);
 
-                        if (chunk.isGroundUp()) {
+                        if (chunk.isFullChunk()) {
                             int[] biomeData = chunk.getBiomeData();
                             int[] newBiomeData = new int[1024];
                             if (biomeData != null) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/types/Chunk1_15Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/types/Chunk1_15Type.java
@@ -12,12 +12,11 @@ import us.myles.ViaVersion.api.type.types.minecraft.BaseChunkType;
 import us.myles.ViaVersion.api.type.types.version.Types1_13;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 
 public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
+    private static final CompoundTag[] A = new CompoundTag[0];
 
     public Chunk1_15Type(ClientWorld param) {
         super(param, Chunk.class);
@@ -28,38 +27,31 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
         int chunkX = input.readInt();
         int chunkZ = input.readInt();
 
-        boolean groundUp = input.readBoolean();
+        boolean fullChunk = input.readBoolean();
         int primaryBitmask = Type.VAR_INT.read(input);
         CompoundTag heightMap = Type.NBT.read(input);
 
-        int[] biomeData = groundUp ? new int[1024] : null;
-        if (groundUp) {
+        int[] biomeData = fullChunk ? new int[1024] : null;
+        if (fullChunk) {
             for (int i = 0; i < 1024; i++) {
                 biomeData[i] = input.readInt();
             }
         }
 
-        Type.VAR_INT.read(input);
-
-        BitSet usedSections = new BitSet(16);
-        ChunkSection[] sections = new ChunkSection[16];
-        // Calculate section count from bitmask
-        for (int i = 0; i < 16; i++) {
-            if ((primaryBitmask & (1 << i)) != 0) {
-                usedSections.set(i);
-            }
-        }
+        Type.VAR_INT.read(input); // data size in bytes
 
         // Read sections
+        ChunkSection[] sections = new ChunkSection[16];
         for (int i = 0; i < 16; i++) {
-            if (!usedSections.get(i)) continue; // Section not set
+            if ((primaryBitmask & (1 << i)) == 0) continue; // Section not set
+
             short nonAirBlocksCount = input.readShort();
             ChunkSection section = Types1_13.CHUNK_SECTION.read(input);
             section.setNonAirBlocksCount(nonAirBlocksCount);
             sections[i] = section;
         }
 
-        List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NBT_ARRAY.read(input)));
+        List<CompoundTag> nbtData = Arrays.asList(Type.NBT_ARRAY.read(input));
 
         // Read all the remaining bytes (workaround for #681)
         if (input.readableBytes() > 0) {
@@ -69,7 +61,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        return new BaseChunk(chunkX, chunkZ, groundUp, primaryBitmask, sections, biomeData, heightMap, nbtData);
+        return new BaseChunk(chunkX, chunkZ, fullChunk, primaryBitmask, sections, biomeData, heightMap, nbtData);
     }
 
     @Override
@@ -77,7 +69,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getX());
         output.writeInt(chunk.getZ());
 
-        output.writeBoolean(chunk.isGroundUp());
+        output.writeBoolean(chunk.isFullChunk());
         Type.VAR_INT.write(output, chunk.getBitmask());
         Type.NBT.write(output, chunk.getHeightMap());
 
@@ -93,6 +85,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
             for (int i = 0; i < 16; i++) {
                 ChunkSection section = chunk.getSections()[i];
                 if (section == null) continue; // Section not set
+
                 buf.writeShort(section.getNonAirBlocksCount());
                 Types1_13.CHUNK_SECTION.write(buf, section);
             }
@@ -104,7 +97,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
         }
 
         // Write Block Entities
-        Type.NBT_ARRAY.write(output, chunk.getBlockEntities().toArray(new CompoundTag[0]));
+        Type.NBT_ARRAY.write(output, chunk.getBlockEntities().toArray(A));
     }
 
     @Override

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/types/Chunk1_15Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/types/Chunk1_15Type.java
@@ -12,6 +12,7 @@ import us.myles.ViaVersion.api.type.types.minecraft.BaseChunkType;
 import us.myles.ViaVersion.api.type.types.version.Types1_13;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
             sections[i] = section;
         }
 
-        List<CompoundTag> nbtData = Arrays.asList(Type.NBT_ARRAY.read(input));
+        List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NBT_ARRAY.read(input)));
 
         // Read all the remaining bytes (workaround for #681)
         if (input.readableBytes() > 0) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1_2to1_9_3_4/types/Chunk1_9_3_4Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1_2to1_9_3_4/types/Chunk1_9_3_4Type.java
@@ -13,9 +13,7 @@ import us.myles.ViaVersion.api.type.types.minecraft.BaseChunkType;
 import us.myles.ViaVersion.api.type.types.version.Types1_9;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 
 public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
@@ -29,22 +27,15 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
         int chunkX = input.readInt();
         int chunkZ = input.readInt();
 
-        boolean groundUp = input.readBoolean();
+        boolean fullChunk = input.readBoolean();
         int primaryBitmask = Type.VAR_INT.read(input);
         Type.VAR_INT.read(input);
 
-        BitSet usedSections = new BitSet(16);
-        ChunkSection[] sections = new ChunkSection[16];
-        // Calculate section count from bitmask
-        for (int i = 0; i < 16; i++) {
-            if ((primaryBitmask & (1 << i)) != 0) {
-                usedSections.set(i);
-            }
-        }
-
         // Read sections
+        ChunkSection[] sections = new ChunkSection[16];
         for (int i = 0; i < 16; i++) {
-            if (!usedSections.get(i)) continue; // Section not set
+            if ((primaryBitmask & (1 << i)) == 0) continue; // Section not set
+
             ChunkSection section = Types1_9.CHUNK_SECTION.read(input);
             sections[i] = section;
             section.readBlockLight(input);
@@ -53,14 +44,14 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        int[] biomeData = groundUp ? new int[256] : null;
-        if (groundUp) {
+        int[] biomeData = fullChunk ? new int[256] : null;
+        if (fullChunk) {
             for (int i = 0; i < 256; i++) {
                 biomeData[i] = input.readByte() & 0xFF;
             }
         }
 
-        List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NBT_ARRAY.read(input)));
+        List<CompoundTag> nbtData = Arrays.asList(Type.NBT_ARRAY.read(input));
 
         // Read all the remaining bytes (workaround for #681)
         if (input.readableBytes() > 0) {
@@ -70,7 +61,7 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        return new BaseChunk(chunkX, chunkZ, groundUp, primaryBitmask, sections, biomeData, nbtData);
+        return new BaseChunk(chunkX, chunkZ, fullChunk, primaryBitmask, sections, biomeData, nbtData);
     }
 
     @Override
@@ -78,7 +69,7 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getX());
         output.writeInt(chunk.getZ());
 
-        output.writeBoolean(chunk.isGroundUp());
+        output.writeBoolean(chunk.isFullChunk());
         Type.VAR_INT.write(output, chunk.getBitmask());
 
         ByteBuf buf = output.alloc().buffer();
@@ -91,7 +82,6 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
 
                 if (!section.hasSkyLight()) continue; // No sky light, we're done here.
                 section.writeSkyLight(buf);
-
             }
             buf.readerIndex(0);
             Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 256 : 0));

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1_2to1_9_3_4/types/Chunk1_9_3_4Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1_2to1_9_3_4/types/Chunk1_9_3_4Type.java
@@ -13,6 +13,7 @@ import us.myles.ViaVersion.api.type.types.minecraft.BaseChunkType;
 import us.myles.ViaVersion.api.type.types.version.Types1_9;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        List<CompoundTag> nbtData = Arrays.asList(Type.NBT_ARRAY.read(input));
+        List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NBT_ARRAY.read(input)));
 
         // Read all the remaining bytes (workaround for #681)
         if (input.readableBytes() > 0) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/types/Chunk1_9_1_2Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/types/Chunk1_9_1_2Type.java
@@ -75,7 +75,7 @@ public class Chunk1_9_1_2Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getX());
         output.writeInt(chunk.getZ());
 
-        output.writeBoolean(chunk.isGroundUp());
+        output.writeBoolean(chunk.isFullChunk());
         Type.VAR_INT.write(output, chunk.getBitmask());
 
         ByteBuf buf = output.alloc().buffer();

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java
@@ -54,7 +54,7 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
         int chunkX = input.readInt();
         int chunkZ = input.readInt();
         long chunkHash = toLong(chunkX, chunkZ);
-        boolean groundUp = input.readByte() != 0;
+        boolean fullChunk = input.readByte() != 0;
         int bitmask = input.readUnsignedShort();
         int dataLength = Type.VAR_INT.read(input);
 
@@ -74,7 +74,7 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
         // If the chunks is from a chunks bulk, it is never an unload packet
         // Other wise, if it has no data, it is :)
         boolean isBulkPacket = param.getBulkChunks().remove(chunkHash);
-        if (sectionCount == 0 && groundUp && !isBulkPacket && param.getLoadedChunks().contains(chunkHash)) {
+        if (sectionCount == 0 && fullChunk && !isBulkPacket && param.getLoadedChunks().contains(chunkHash)) {
             // This is a chunks unload packet
             param.getLoadedChunks().remove(chunkHash);
             return new Chunk1_8(chunkX, chunkZ);
@@ -121,11 +121,11 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
 
         // Check remaining bytes
         if (bytesLeft > 0) {
-            Via.getPlatform().getLogger().log(Level.WARNING, bytesLeft + " Bytes left after reading chunks! (" + groundUp + ")");
+            Via.getPlatform().getLogger().log(Level.WARNING, bytesLeft + " Bytes left after reading chunks! (" + fullChunk + ")");
         }
 
         // Return chunks
-        return new Chunk1_8(chunkX, chunkZ, groundUp, bitmask, sections, biomeData, new ArrayList<CompoundTag>());
+        return new Chunk1_8(chunkX, chunkZ, fullChunk, bitmask, sections, biomeData, new ArrayList<CompoundTag>());
     }
 
     @Override
@@ -137,7 +137,7 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
         output.writeInt(chunk.getX());
         output.writeInt(chunk.getZ());
         if (chunk.isUnloadPacket()) return;
-        output.writeByte(chunk.isGroundUp() ? 0x01 : 0x00);
+        output.writeByte(chunk.isFullChunk() ? 0x01 : 0x00);
         Type.VAR_INT.write(output, chunk.getBitmask());
 
         ByteBuf buf = output.alloc().buffer();
@@ -150,7 +150,6 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
 
                 if (!section.hasSkyLight()) continue; // No sky light, we're done here.
                 section.writeSkyLight(buf);
-
             }
             buf.readerIndex(0);
             Type.VAR_INT.write(output, buf.readableBytes() + (chunk.hasBiomeData() ? 256 : 0));


### PR DESCRIPTION
Renamed groundUp to fullChunk to be less confusing and removed unnecessary bitset wrapping for one time uses only (probably got copy pasted from older chunks where they were more helpful)