### PR TITLE
Add runnable list to be executed before the full init

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/exception/InformativeException.java
+++ b/common/src/main/java/us/myles/ViaVersion/exception/InformativeException.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class InformativeException extends Exception {
     private final Map<String, Object> info = new HashMap<>();
-    private int sources = 0;
+    private int sources;
 
     public InformativeException(Throwable cause) {
         super(cause);

--- a/velocity/src/main/java/us/myles/ViaVersion/VelocityPlugin.java
+++ b/velocity/src/main/java/us/myles/ViaVersion/VelocityPlugin.java
@@ -2,6 +2,7 @@ package us.myles.ViaVersion;
 
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
+import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
@@ -82,7 +83,10 @@ public class VelocityPlugin implements ViaPlatform<Player> {
         if (proxy.getPluginManager().getPlugin("ViaBackwards").isPresent()) {
             MappingDataLoader.enableMappingsCache();
         }
+    }
 
+    @Subscribe(order = PostOrder.LAST)
+    public void onProxyLateInit(ProxyInitializeEvent e) {
         Via.getManager().init();
     }
 


### PR DESCRIPTION
Necessary for the proxies that don't have sync ticking, since the pre-init and full-init happen directly after one another without any option to intercept