### PR TITLE
Avoid a bit of overhead in manual primitive type reading

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/PacketWrapper.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/PacketWrapper.java
@@ -219,7 +219,7 @@ public class PacketWrapper {
      */
     public void writeToBuffer(ByteBuf buffer) throws Exception {
         if (id != -1) {
-            Type.VAR_INT.write(buffer, id);
+            Type.VAR_INT.writePrimitive(buffer, id);
         }
         if (!readableObjects.isEmpty()) {
             packetValues.addAll(readableObjects);

--- a/common/src/main/java/us/myles/ViaVersion/api/data/UserConnection.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/data/UserConnection.java
@@ -217,7 +217,7 @@ public class UserConnection {
         ByteBuf buf = packet.alloc().buffer();
         try {
             try {
-                Type.VAR_INT.write(buf, PacketWrapper.PASSTHROUGH_ID);
+                Type.VAR_INT.writePrimitive(buf, PacketWrapper.PASSTHROUGH_ID);
             } catch (Exception e) {
                 // Should not happen
                 Via.getPlatform().getLogger().warning("Type.VAR_INT.write thrown an exception: " + e);
@@ -315,7 +315,7 @@ public class UserConnection {
     }
 
     private void transform(ByteBuf buf, Direction direction, Function<Throwable, Exception> cancelSupplier) throws Exception {
-        int id = Type.VAR_INT.read(buf);
+        int id = Type.VAR_INT.readPrimitive(buf);
         if (id == PacketWrapper.PASSTHROUGH_ID) return;
 
         PacketWrapper wrapper = new PacketWrapper(id, buf, this);

--- a/common/src/main/java/us/myles/ViaVersion/api/type/Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/Type.java
@@ -56,14 +56,14 @@ public abstract class Type<T> implements ByteBufReader<T>, ByteBufWriter<T> {
     @Deprecated
     public static final Type<Long[]> LONG_ARRAY = new ArrayType<>(Type.LONG);
 
-    public static final Type<Float> FLOAT = new FloatType();
+    public static final FloatType FLOAT = new FloatType();
     /**
      * @deprecated unreasonable overhead
      */
     @Deprecated
     public static final Type<Float[]> FLOAT_ARRAY = new ArrayType<>(Type.FLOAT);
 
-    public static final Type<Short> SHORT = new ShortType();
+    public static final ShortType SHORT = new ShortType();
     /**
      * @deprecated unreasonable overhead
      */
@@ -84,7 +84,7 @@ public abstract class Type<T> implements ByteBufReader<T>, ByteBufWriter<T> {
     public static final Type<UUID> UUID_INT_ARRAY = new UUIDIntArrayType();
     public static final Type<UUID[]> UUID_ARRAY = new ArrayType<>(Type.UUID);
     /* Variable Types */
-    public static final Type<Integer> VAR_INT = new VarIntType();
+    public static final VarIntType VAR_INT = new VarIntType();
     /**
      * @deprecated unreasonable overhead, use VAR_INT_ARRAY_PRIMITIVE
      */

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/ArrayType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/ArrayType.java
@@ -20,7 +20,7 @@ public class ArrayType<T> extends Type<T[]> {
 
     @Override
     public T[] read(ByteBuf buffer) throws Exception {
-        int amount = Type.VAR_INT.read(buffer);
+        int amount = Type.VAR_INT.readPrimitive(buffer);
         T[] array = (T[]) Array.newInstance(elementType.getOutputClass(), amount);
 
         for (int i = 0; i < amount; i++) {
@@ -31,7 +31,7 @@ public class ArrayType<T> extends Type<T[]> {
 
     @Override
     public void write(ByteBuf buffer, T[] object) throws Exception {
-        Type.VAR_INT.write(buffer, object.length);
+        Type.VAR_INT.writePrimitive(buffer, object.length);
         for (T o : object) {
             elementType.write(buffer, o);
         }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/ByteArrayType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/ByteArrayType.java
@@ -11,13 +11,13 @@ public class ByteArrayType extends Type<byte[]> {
 
     @Override
     public void write(ByteBuf buffer, byte[] object) throws Exception {
-        Type.VAR_INT.write(buffer, object.length);
+        Type.VAR_INT.writePrimitive(buffer, object.length);
         buffer.writeBytes(object);
     }
 
     @Override
     public byte[] read(ByteBuf buffer) throws Exception {
-        int length = Type.VAR_INT.read(buffer);
+        int length = Type.VAR_INT.readPrimitive(buffer);
         Preconditions.checkArgument(buffer.isReadable(length), "Length is fewer than readable bytes");
         byte[] array = new byte[length];
         buffer.readBytes(array);

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/FloatType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/FloatType.java
@@ -5,20 +5,36 @@ import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.api.type.TypeConverter;
 
 public class FloatType extends Type<Float> implements TypeConverter<Float> {
+
     public FloatType() {
         super(Float.class);
     }
 
+    public float readPrimitive(ByteBuf buffer) {
+        return buffer.readFloat();
+    }
+
+    public void writePrimitive(ByteBuf buffer, float object) {
+        buffer.writeFloat(object);
+    }
+
+    /**
+     * @deprecated use {@link #readPrimitive(ByteBuf)} for manual reading to avoid wrapping
+     */
     @Override
+    @Deprecated
     public Float read(ByteBuf buffer) {
         return buffer.readFloat();
     }
 
+    /**
+     * @deprecated use {@link #writePrimitive(ByteBuf, float)} for manual reading to avoid wrapping
+     */
     @Override
+    @Deprecated
     public void write(ByteBuf buffer, Float object) {
         buffer.writeFloat(object);
     }
-
 
     @Override
     public Float from(Object o) {

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/ShortType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/ShortType.java
@@ -5,16 +5,33 @@ import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.api.type.TypeConverter;
 
 public class ShortType extends Type<Short> implements TypeConverter<Short> {
+
     public ShortType() {
         super(Short.class);
     }
 
+    public short readPrimitive(ByteBuf buffer) {
+        return buffer.readShort();
+    }
+
+    public void writePrimitive(ByteBuf buffer, short object) {
+        buffer.writeShort(object);
+    }
+
+    /**
+     * @deprecated use {@link #readPrimitive(ByteBuf)} for manual reading to avoid wrapping
+     */
     @Override
+    @Deprecated
     public Short read(ByteBuf buffer) {
         return buffer.readShort();
     }
 
+    /**
+     * @deprecated use {@link #writePrimitive(ByteBuf, short)} for manual reading to avoid wrapping
+     */
     @Override
+    @Deprecated
     public void write(ByteBuf buffer, Short object) {
         buffer.writeShort(object);
     }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/StringType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/StringType.java
@@ -17,7 +17,7 @@ public class StringType extends Type<String> {
 
     @Override
     public String read(ByteBuf buffer) throws Exception {
-        int len = Type.VAR_INT.read(buffer);
+        int len = Type.VAR_INT.readPrimitive(buffer);
 
         Preconditions.checkArgument(len <= Short.MAX_VALUE * maxJavaCharUtf8Length,
                 "Cannot receive string longer than Short.MAX_VALUE * "  + maxJavaCharUtf8Length + " bytes (got %s bytes)", len);
@@ -36,7 +36,7 @@ public class StringType extends Type<String> {
         Preconditions.checkArgument(object.length() <= Short.MAX_VALUE, "Cannot send string longer than Short.MAX_VALUE (got %s characters)", object.length());
 
         byte[] b = object.getBytes(StandardCharsets.UTF_8);
-        Type.VAR_INT.write(buffer, b.length);
+        Type.VAR_INT.writePrimitive(buffer, b.length);
         buffer.writeBytes(b);
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/VarIntArrayType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/VarIntArrayType.java
@@ -11,20 +11,20 @@ public class VarIntArrayType extends Type<int[]> {
 
     @Override
     public int[] read(ByteBuf buffer) throws Exception {
-        int length = Type.VAR_INT.read(buffer);
+        int length = Type.VAR_INT.readPrimitive(buffer);
         Preconditions.checkArgument(buffer.isReadable(length)); // Sanity check, at least 1 byte will be used for each varint
         int[] array = new int[length];
         for (int i = 0; i < array.length; i++) {
-            array[i] = Type.VAR_INT.read(buffer);
+            array[i] = Type.VAR_INT.readPrimitive(buffer);
         }
         return array;
     }
 
     @Override
     public void write(ByteBuf buffer, int[] object) throws Exception {
-        Type.VAR_INT.write(buffer, object.length);
+        Type.VAR_INT.writePrimitive(buffer, object.length);
         for (int i : object) {
-            Type.VAR_INT.write(buffer, i);
+            Type.VAR_INT.writePrimitive(buffer, i);
         }
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/VarIntType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/VarIntType.java
@@ -10,10 +10,26 @@ public class VarIntType extends Type<Integer> implements TypeConverter<Integer> 
         super("VarInt", Integer.class);
     }
 
-    @Override
-    public void write(ByteBuf buffer, Integer object) {
+    public int readPrimitive(ByteBuf buffer) {
+        int out = 0;
+        int bytes = 0;
+        byte in;
+        do {
+            in = buffer.readByte();
+
+            out |= (in & 0x7F) << (bytes++ * 7);
+
+            if (bytes > 5) { // 5 is maxBytes
+                throw new RuntimeException("VarInt too big");
+            }
+
+        } while ((in & 0x80) == 0x80);
+        return out;
+    }
+
+    public void writePrimitive(ByteBuf buffer, int object) {
         int part;
-        while (true) {
+        do {
             part = object & 0x7F;
 
             object >>>= 7;
@@ -23,34 +39,26 @@ public class VarIntType extends Type<Integer> implements TypeConverter<Integer> 
 
             buffer.writeByte(part);
 
-            if (object == 0) {
-                break;
-            }
-        }
+        } while (object != 0);
     }
 
+    /**
+     * @deprecated use {@link #readPrimitive(ByteBuf)} for manual reading to avoid wrapping
+     */
     @Override
+    @Deprecated
     public Integer read(ByteBuf buffer) {
-        int out = 0;
-        int bytes = 0;
-        byte in;
-        while (true) {
-            in = buffer.readByte();
-
-            out |= (in & 0x7F) << (bytes++ * 7);
-
-            if (bytes > 5) { // 5 is maxBytes
-                throw new RuntimeException("VarInt too big");
-            }
-
-            if ((in & 0x80) != 0x80) {
-                break;
-            }
-        }
-
-        return out;
+        return readPrimitive(buffer);
     }
 
+    /**
+     * @deprecated use {@link #writePrimitive(ByteBuf, int)} for manual reading to avoid wrapping
+     */
+    @Override
+    @Deprecated
+    public void write(ByteBuf buffer, Integer object) {
+        writePrimitive(buffer, object);
+    }
 
     @Override
     public Integer from(Object o) {

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/BlockChangeRecordType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/BlockChangeRecordType.java
@@ -13,7 +13,7 @@ public class BlockChangeRecordType extends Type<BlockChangeRecord> {
     public BlockChangeRecord read(ByteBuf buffer) throws Exception {
         short horizontal = Type.UNSIGNED_BYTE.read(buffer);
         short y = Type.UNSIGNED_BYTE.read(buffer);
-        int blockId = Type.VAR_INT.read(buffer);
+        int blockId = Type.VAR_INT.readPrimitive(buffer);
 
         return new BlockChangeRecord(horizontal, y, blockId);
     }
@@ -22,6 +22,6 @@ public class BlockChangeRecordType extends Type<BlockChangeRecord> {
     public void write(ByteBuf buffer, BlockChangeRecord object) throws Exception {
         Type.UNSIGNED_BYTE.write(buffer, object.getHorizontal());
         Type.UNSIGNED_BYTE.write(buffer, object.getY());
-        Type.VAR_INT.write(buffer, object.getBlockId());
+        Type.VAR_INT.writePrimitive(buffer, object.getBlockId());
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/EulerAngleType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/EulerAngleType.java
@@ -11,17 +11,17 @@ public class EulerAngleType extends Type<EulerAngle> {
 
     @Override
     public EulerAngle read(ByteBuf buffer) throws Exception {
-        float x = Type.FLOAT.read(buffer);
-        float y = Type.FLOAT.read(buffer);
-        float z = Type.FLOAT.read(buffer);
+        float x = Type.FLOAT.readPrimitive(buffer);
+        float y = Type.FLOAT.readPrimitive(buffer);
+        float z = Type.FLOAT.readPrimitive(buffer);
 
         return new EulerAngle(x, y, z);
     }
 
     @Override
     public void write(ByteBuf buffer, EulerAngle object) throws Exception {
-        Type.FLOAT.write(buffer, object.getX());
-        Type.FLOAT.write(buffer, object.getY());
-        Type.FLOAT.write(buffer, object.getZ());
+        Type.FLOAT.writePrimitive(buffer, object.getX());
+        Type.FLOAT.writePrimitive(buffer, object.getY());
+        Type.FLOAT.writePrimitive(buffer, object.getZ());
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/FlatItemArrayType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/FlatItemArrayType.java
@@ -12,7 +12,7 @@ public class FlatItemArrayType extends BaseItemArrayType {
 
     @Override
     public Item[] read(ByteBuf buffer) throws Exception {
-        int amount = Type.SHORT.read(buffer);
+        int amount = Type.SHORT.readPrimitive(buffer);
         Item[] array = new Item[amount];
         for (int i = 0; i < amount; i++) {
             array[i] = Type.FLAT_ITEM.read(buffer);
@@ -22,7 +22,7 @@ public class FlatItemArrayType extends BaseItemArrayType {
 
     @Override
     public void write(ByteBuf buffer, Item[] object) throws Exception {
-        Type.SHORT.write(buffer, (short) object.length);
+        Type.SHORT.writePrimitive(buffer, (short) object.length);
         for (Item o : object) {
             Type.FLAT_ITEM.write(buffer, o);
         }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/FlatVarIntItemArrayType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/FlatVarIntItemArrayType.java
@@ -12,7 +12,7 @@ public class FlatVarIntItemArrayType extends BaseItemArrayType {
 
     @Override
     public Item[] read(ByteBuf buffer) throws Exception {
-        int amount = Type.SHORT.read(buffer);
+        int amount = Type.SHORT.readPrimitive(buffer);
         Item[] array = new Item[amount];
         for (int i = 0; i < amount; i++) {
             array[i] = Type.FLAT_VAR_INT_ITEM.read(buffer);
@@ -22,7 +22,7 @@ public class FlatVarIntItemArrayType extends BaseItemArrayType {
 
     @Override
     public void write(ByteBuf buffer, Item[] object) throws Exception {
-        Type.SHORT.write(buffer, (short) object.length);
+        Type.SHORT.writePrimitive(buffer, (short) object.length);
         for (Item o : object) {
             Type.FLAT_VAR_INT_ITEM.write(buffer, o);
         }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/FlatVarIntItemType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/FlatVarIntItemType.java
@@ -16,7 +16,7 @@ public class FlatVarIntItemType extends BaseItemType {
             return null;
         } else {
             Item item = new Item();
-            item.setIdentifier(Type.VAR_INT.read(buffer));
+            item.setIdentifier(Type.VAR_INT.readPrimitive(buffer));
             item.setAmount(buffer.readByte());
             item.setTag(Type.NBT.read(buffer));
             return item;
@@ -29,7 +29,7 @@ public class FlatVarIntItemType extends BaseItemType {
             buffer.writeBoolean(false);
         } else {
             buffer.writeBoolean(true);
-            Type.VAR_INT.write(buffer, object.getIdentifier());
+            Type.VAR_INT.writePrimitive(buffer, object.getIdentifier());
             buffer.writeByte(object.getAmount());
             Type.NBT.write(buffer, object.getTag());
         }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/ItemArrayType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/ItemArrayType.java
@@ -12,7 +12,7 @@ public class ItemArrayType extends BaseItemArrayType {
 
     @Override
     public Item[] read(ByteBuf buffer) throws Exception {
-        int amount = Type.SHORT.read(buffer);
+        int amount = Type.SHORT.readPrimitive(buffer);
         Item[] array = new Item[amount];
         for (int i = 0; i < amount; i++) {
             array[i] = Type.ITEM.read(buffer);
@@ -22,7 +22,7 @@ public class ItemArrayType extends BaseItemArrayType {
 
     @Override
     public void write(ByteBuf buffer, Item[] object) throws Exception {
-        Type.SHORT.write(buffer, (short) object.length);
+        Type.SHORT.writePrimitive(buffer, (short) object.length);
         for (Item o : object) {
             Type.ITEM.write(buffer, o);
         }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/OptionalVarIntType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/OptionalVarIntType.java
@@ -10,14 +10,14 @@ public class OptionalVarIntType extends Type<Integer> {
 
     @Override
     public Integer read(ByteBuf buffer) throws Exception {
-        int read = Type.VAR_INT.read(buffer);
+        int read = Type.VAR_INT.readPrimitive(buffer);
         if (read == 0) return null;
         return read - 1;
     }
 
     @Override
     public void write(ByteBuf buffer, Integer object) throws Exception {
-        if (object == null) Type.VAR_INT.write(buffer, 0);
-        else Type.VAR_INT.write(buffer, object + 1);
+        if (object == null) Type.VAR_INT.writePrimitive(buffer, 0);
+        else Type.VAR_INT.writePrimitive(buffer, object + 1);
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/Particle1_14Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/Particle1_14Type.java
@@ -12,28 +12,28 @@ public class Particle1_14Type extends Type<Particle> {
 
     @Override
     public void write(ByteBuf buffer, Particle object) throws Exception {
-        Type.VAR_INT.write(buffer, object.getId());
+        Type.VAR_INT.writePrimitive(buffer, object.getId());
         for (Particle.ParticleData data : object.getArguments())
             data.getType().write(buffer, data.getValue());
     }
 
     @Override
     public Particle read(ByteBuf buffer) throws Exception {
-        int type = Type.VAR_INT.read(buffer);
+        int type = Type.VAR_INT.readPrimitive(buffer);
         Particle particle = new Particle(type);
 
         switch (type) {
             // Block / Falling Dust /
             case 3:
             case 23:
-                particle.getArguments().add(new Particle.ParticleData(Type.VAR_INT, Type.VAR_INT.read(buffer))); // Flat Block
+                particle.getArguments().add(new Particle.ParticleData(Type.VAR_INT, Type.VAR_INT.readPrimitive(buffer))); // Flat Block
                 break;
             // Dust
             case 14:
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Red 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Green 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Blue 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer)));// Scale 0.01 - 4
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Red 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Green 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Blue 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer)));// Scale 0.01 - 4
                 break;
             // Item
             case 32:

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/VillagerDataType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/minecraft/VillagerDataType.java
@@ -11,13 +11,13 @@ public class VillagerDataType extends Type<VillagerData> {
 
     @Override
     public VillagerData read(ByteBuf buffer) throws Exception {
-        return new VillagerData(Type.VAR_INT.read(buffer), Type.VAR_INT.read(buffer), Type.VAR_INT.read(buffer));
+        return new VillagerData(Type.VAR_INT.readPrimitive(buffer), Type.VAR_INT.readPrimitive(buffer), Type.VAR_INT.readPrimitive(buffer));
     }
 
     @Override
     public void write(ByteBuf buffer, VillagerData object) throws Exception {
-        Type.VAR_INT.write(buffer, object.getType());
-        Type.VAR_INT.write(buffer, object.getProfession());
-        Type.VAR_INT.write(buffer, object.getLevel());
+        Type.VAR_INT.writePrimitive(buffer, object.getType());
+        Type.VAR_INT.writePrimitive(buffer, object.getProfession());
+        Type.VAR_INT.writePrimitive(buffer, object.getLevel());
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_13.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_13.java
@@ -24,15 +24,15 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
             bitsPerBlock = GLOBAL_PALETTE;
         }
 
-        int paletteLength = bitsPerBlock == GLOBAL_PALETTE ? 0 : Type.VAR_INT.read(buffer);
+        int paletteLength = bitsPerBlock == GLOBAL_PALETTE ? 0 : Type.VAR_INT.readPrimitive(buffer);
         // Read palette
         chunkSection.clearPalette();
         for (int i = 0; i < paletteLength; i++) {
-            chunkSection.addPaletteEntry(Type.VAR_INT.read(buffer));
+            chunkSection.addPaletteEntry(Type.VAR_INT.readPrimitive(buffer));
         }
 
         // Read blocks
-        long[] blockData = new long[Type.VAR_INT.read(buffer)];
+        long[] blockData = new long[Type.VAR_INT.readPrimitive(buffer)];
         if (blockData.length > 0) {
             int expectedLength = (int) Math.ceil(ChunkSection.SIZE * bitsPerBlock / 64.0);
             if (blockData.length != expectedLength) {
@@ -64,15 +64,15 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
 
         // Write pallet (or not)
         if (bitsPerBlock != GLOBAL_PALETTE) {
-            Type.VAR_INT.write(buffer, chunkSection.getPaletteSize());
+            Type.VAR_INT.writePrimitive(buffer, chunkSection.getPaletteSize());
             for (int i = 0; i < chunkSection.getPaletteSize(); i++) {
-                Type.VAR_INT.write(buffer, chunkSection.getPaletteEntry(i));
+                Type.VAR_INT.writePrimitive(buffer, chunkSection.getPaletteEntry(i));
             }
         }
 
         long[] data = CompactArrayUtil.createCompactArray(bitsPerBlock, ChunkSection.SIZE,
                 bitsPerBlock == GLOBAL_PALETTE ? chunkSection::getFlatBlock : chunkSection::getPaletteIndex);
-        Type.VAR_INT.write(buffer, data.length);
+        Type.VAR_INT.writePrimitive(buffer, data.length);
         for (long l : data) {
             buffer.writeLong(l);
         }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_16.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_16.java
@@ -24,15 +24,15 @@ public class ChunkSectionType1_16 extends Type<ChunkSection> {
             bitsPerBlock = GLOBAL_PALETTE;
         }
 
-        int paletteLength = bitsPerBlock == GLOBAL_PALETTE ? 0 : Type.VAR_INT.read(buffer);
+        int paletteLength = bitsPerBlock == GLOBAL_PALETTE ? 0 : Type.VAR_INT.readPrimitive(buffer);
         // Read palette
         chunkSection.clearPalette();
         for (int i = 0; i < paletteLength; i++) {
-            chunkSection.addPaletteEntry(Type.VAR_INT.read(buffer));
+            chunkSection.addPaletteEntry(Type.VAR_INT.readPrimitive(buffer));
         }
 
         // Read blocks
-        long[] blockData = new long[Type.VAR_INT.read(buffer)];
+        long[] blockData = new long[Type.VAR_INT.readPrimitive(buffer)];
         if (blockData.length > 0) {
             char valuesPerLong = (char) (64 / bitsPerBlock);
             int expectedLength = (ChunkSection.SIZE + valuesPerLong - 1) / valuesPerLong;
@@ -65,15 +65,15 @@ public class ChunkSectionType1_16 extends Type<ChunkSection> {
 
         // Write pallet (or not)
         if (bitsPerBlock != GLOBAL_PALETTE) {
-            Type.VAR_INT.write(buffer, chunkSection.getPaletteSize());
+            Type.VAR_INT.writePrimitive(buffer, chunkSection.getPaletteSize());
             for (int i = 0; i < chunkSection.getPaletteSize(); i++) {
-                Type.VAR_INT.write(buffer, chunkSection.getPaletteEntry(i));
+                Type.VAR_INT.writePrimitive(buffer, chunkSection.getPaletteEntry(i));
             }
         }
 
         long[] data = CompactArrayUtil.createCompactArrayWithPadding(bitsPerBlock, ChunkSection.SIZE,
                 bitsPerBlock == GLOBAL_PALETTE ? chunkSection::getFlatBlock : chunkSection::getPaletteIndex);
-        Type.VAR_INT.write(buffer, data.length);
+        Type.VAR_INT.writePrimitive(buffer, data.length);
         for (long l : data) {
             buffer.writeLong(l);
         }

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_9.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_9.java
@@ -29,19 +29,19 @@ public class ChunkSectionType1_9 extends Type<ChunkSection> {
         if (bitsPerBlock > 8) {
             bitsPerBlock = GLOBAL_PALETTE;
         }
-        int paletteLength = Type.VAR_INT.read(buffer);
+        int paletteLength = Type.VAR_INT.readPrimitive(buffer);
         // Read palette
         chunkSection.clearPalette();
         for (int i = 0; i < paletteLength; i++) {
             if (bitsPerBlock != GLOBAL_PALETTE) {
-                chunkSection.addPaletteEntry(Type.VAR_INT.read(buffer));
+                chunkSection.addPaletteEntry(Type.VAR_INT.readPrimitive(buffer));
             } else {
-                Type.VAR_INT.read(buffer);
+                Type.VAR_INT.readPrimitive(buffer);
             }
         }
 
         // Read blocks
-        long[] blockData = new long[Type.VAR_INT.read(buffer)];
+        long[] blockData = new long[Type.VAR_INT.readPrimitive(buffer)];
         if (blockData.length > 0) {
             int expectedLength = (int) Math.ceil(ChunkSection.SIZE * bitsPerBlock / 64.0);
             if (blockData.length != expectedLength) {
@@ -75,17 +75,17 @@ public class ChunkSectionType1_9 extends Type<ChunkSection> {
 
         // Write pallet (or not)
         if (bitsPerBlock != GLOBAL_PALETTE) {
-            Type.VAR_INT.write(buffer, chunkSection.getPaletteSize());
+            Type.VAR_INT.writePrimitive(buffer, chunkSection.getPaletteSize());
             for (int i = 0; i < chunkSection.getPaletteSize(); i++) {
-                Type.VAR_INT.write(buffer, chunkSection.getPaletteEntry(i));
+                Type.VAR_INT.writePrimitive(buffer, chunkSection.getPaletteEntry(i));
             }
         } else {
-            Type.VAR_INT.write(buffer, 0);
+            Type.VAR_INT.writePrimitive(buffer, 0);
         }
 
         long[] data = CompactArrayUtil.createCompactArray(bitsPerBlock, ChunkSection.SIZE,
                 bitsPerBlock == GLOBAL_PALETTE ? chunkSection::getFlatBlock : chunkSection::getPaletteIndex);
-        Type.VAR_INT.write(buffer, data.length);
+        Type.VAR_INT.writePrimitive(buffer, data.length);
         for (long l : data) {
             buffer.writeLong(l);
         }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13_2to1_13_1/types/Particle1_13_2Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13_2to1_13_1/types/Particle1_13_2Type.java
@@ -11,28 +11,28 @@ public class Particle1_13_2Type extends Type<Particle> {
 
     @Override
     public void write(ByteBuf buffer, Particle object) throws Exception {
-        Type.VAR_INT.write(buffer, object.getId());
+        Type.VAR_INT.writePrimitive(buffer, object.getId());
         for (Particle.ParticleData data : object.getArguments())
             data.getType().write(buffer, data.getValue());
     }
 
     @Override
     public Particle read(ByteBuf buffer) throws Exception {
-        int type = Type.VAR_INT.read(buffer);
+        int type = Type.VAR_INT.readPrimitive(buffer);
         Particle particle = new Particle(type);
 
         switch (type) {
             // Block / Falling Dust /
             case 3:
             case 20:
-                particle.getArguments().add(new Particle.ParticleData(Type.VAR_INT, Type.VAR_INT.read(buffer))); // Flat Block
+                particle.getArguments().add(new Particle.ParticleData(Type.VAR_INT, Type.VAR_INT.readPrimitive(buffer))); // Flat Block
                 break;
             // Dust
             case 11:
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Red 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Green 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Blue 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer)));// Scale 0.01 - 4
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Red 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Green 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Blue 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer)));// Scale 0.01 - 4
                 break;
             // Item
             case 27:

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
@@ -29,8 +29,8 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
         int chunkZ = input.readInt();
 
         boolean fullChunk = input.readBoolean();
-        int primaryBitmask = Type.VAR_INT.read(input);
-        ByteBuf data = input.readSlice(Type.VAR_INT.read(input));
+        int primaryBitmask = Type.VAR_INT.readPrimitive(input);
+        ByteBuf data = input.readSlice(Type.VAR_INT.readPrimitive(input));
 
         // Read sections
         ChunkSection[] sections = new ChunkSection[16];
@@ -75,7 +75,7 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getZ());
 
         output.writeBoolean(chunk.isFullChunk());
-        Type.VAR_INT.write(output, chunk.getBitmask());
+        Type.VAR_INT.writePrimitive(output, chunk.getBitmask());
 
         ByteBuf buf = output.alloc().buffer();
         try {
@@ -90,7 +90,7 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
 
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 1024 : 0));
+            Type.VAR_INT.writePrimitive(output, buf.readableBytes() + (chunk.isBiomeData() ? 1024 : 0));
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Particle1_13Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Particle1_13Type.java
@@ -12,28 +12,28 @@ public class Particle1_13Type extends Type<Particle> {
 
     @Override
     public void write(ByteBuf buffer, Particle object) throws Exception {
-        Type.VAR_INT.write(buffer, object.getId());
+        Type.VAR_INT.writePrimitive(buffer, object.getId());
         for (Particle.ParticleData data : object.getArguments())
             data.getType().write(buffer, data.getValue());
     }
 
     @Override
     public Particle read(ByteBuf buffer) throws Exception {
-        int type = Type.VAR_INT.read(buffer);
+        int type = Type.VAR_INT.readPrimitive(buffer);
         Particle particle = new Particle(type);
 
         switch (type) {
             // Block / Falling Dust /
             case 3:
             case 20:
-                particle.getArguments().add(new Particle.ParticleData(Type.VAR_INT, Type.VAR_INT.read(buffer))); // Flat Block
+                particle.getArguments().add(new Particle.ParticleData(Type.VAR_INT, Type.VAR_INT.readPrimitive(buffer))); // Flat Block
                 break;
             // Dust
             case 11:
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Red 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Green 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer))); // Blue 0 - 1
-                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.read(buffer)));// Scale 0.01 - 4
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Red 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Green 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer))); // Blue 0 - 1
+                particle.getArguments().add(new Particle.ParticleData(Type.FLOAT, Type.FLOAT.readPrimitive(buffer)));// Scale 0.01 - 4
                 break;
             // Item
             case 27:

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/types/Chunk1_14Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/types/Chunk1_14Type.java
@@ -28,10 +28,10 @@ public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
         int chunkZ = input.readInt();
 
         boolean fullChunk = input.readBoolean();
-        int primaryBitmask = Type.VAR_INT.read(input);
+        int primaryBitmask = Type.VAR_INT.readPrimitive(input);
         CompoundTag heightMap = Type.NBT.read(input);
 
-        Type.VAR_INT.read(input);
+        Type.VAR_INT.readPrimitive(input);
 
         // Read sections
         ChunkSection[] sections = new ChunkSection[16];
@@ -70,7 +70,7 @@ public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getZ());
 
         output.writeBoolean(chunk.isFullChunk());
-        Type.VAR_INT.write(output, chunk.getBitmask());
+        Type.VAR_INT.writePrimitive(output, chunk.getBitmask());
         Type.NBT.write(output, chunk.getHeightMap());
 
         ByteBuf buf = output.alloc().buffer();
@@ -83,7 +83,7 @@ public class Chunk1_14Type extends PartialType<Chunk, ClientWorld> {
                 Types1_13.CHUNK_SECTION.write(buf, section);
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 1024 : 0)); // 256 * 4
+            Type.VAR_INT.writePrimitive(output, buf.readableBytes() + (chunk.isBiomeData() ? 1024 : 0)); // 256 * 4
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/types/Chunk1_15Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/types/Chunk1_15Type.java
@@ -29,7 +29,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
         int chunkZ = input.readInt();
 
         boolean fullChunk = input.readBoolean();
-        int primaryBitmask = Type.VAR_INT.read(input);
+        int primaryBitmask = Type.VAR_INT.readPrimitive(input);
         CompoundTag heightMap = Type.NBT.read(input);
 
         int[] biomeData = fullChunk ? new int[1024] : null;
@@ -39,7 +39,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        Type.VAR_INT.read(input); // data size in bytes
+        Type.VAR_INT.readPrimitive(input); // data size in bytes
 
         // Read sections
         ChunkSection[] sections = new ChunkSection[16];
@@ -71,7 +71,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getZ());
 
         output.writeBoolean(chunk.isFullChunk());
-        Type.VAR_INT.write(output, chunk.getBitmask());
+        Type.VAR_INT.writePrimitive(output, chunk.getBitmask());
         Type.NBT.write(output, chunk.getHeightMap());
 
         // Write biome data
@@ -91,7 +91,7 @@ public class Chunk1_15Type extends PartialType<Chunk, ClientWorld> {
                 Types1_13.CHUNK_SECTION.write(buf, section);
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes());
+            Type.VAR_INT.writePrimitive(output, buf.readableBytes());
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/types/Chunk1_16Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/types/Chunk1_16Type.java
@@ -30,7 +30,7 @@ public class Chunk1_16Type extends PartialType<Chunk, ClientWorld> {
 
         boolean fullChunk = input.readBoolean();
         boolean ignoreOldLightData = input.readBoolean();
-        int primaryBitmask = Type.VAR_INT.read(input);
+        int primaryBitmask = Type.VAR_INT.readPrimitive(input);
         CompoundTag heightMap = Type.NBT.read(input);
 
         int[] biomeData = fullChunk ? new int[1024] : null;
@@ -40,7 +40,7 @@ public class Chunk1_16Type extends PartialType<Chunk, ClientWorld> {
             }
         }
 
-        Type.VAR_INT.read(input); // data size in bytes
+        Type.VAR_INT.readPrimitive(input); // data size in bytes
 
         // Read sections
         ChunkSection[] sections = new ChunkSection[16];
@@ -73,7 +73,7 @@ public class Chunk1_16Type extends PartialType<Chunk, ClientWorld> {
 
         output.writeBoolean(chunk.isFullChunk());
         output.writeBoolean(chunk.isIgnoreOldLightData());
-        Type.VAR_INT.write(output, chunk.getBitmask());
+        Type.VAR_INT.writePrimitive(output, chunk.getBitmask());
         Type.NBT.write(output, chunk.getHeightMap());
 
         // Write biome data
@@ -93,7 +93,7 @@ public class Chunk1_16Type extends PartialType<Chunk, ClientWorld> {
                 Types1_16.CHUNK_SECTION.write(buf, section);
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes());
+            Type.VAR_INT.writePrimitive(output, buf.readableBytes());
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1_2to1_9_3_4/types/Chunk1_9_3_4Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1_2to1_9_3_4/types/Chunk1_9_3_4Type.java
@@ -29,8 +29,8 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
         int chunkZ = input.readInt();
 
         boolean fullChunk = input.readBoolean();
-        int primaryBitmask = Type.VAR_INT.read(input);
-        Type.VAR_INT.read(input);
+        int primaryBitmask = Type.VAR_INT.readPrimitive(input);
+        Type.VAR_INT.readPrimitive(input);
 
         // Read sections
         ChunkSection[] sections = new ChunkSection[16];
@@ -71,7 +71,7 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getZ());
 
         output.writeBoolean(chunk.isFullChunk());
-        Type.VAR_INT.write(output, chunk.getBitmask());
+        Type.VAR_INT.writePrimitive(output, chunk.getBitmask());
 
         ByteBuf buf = output.alloc().buffer();
         try {
@@ -85,7 +85,7 @@ public class Chunk1_9_3_4Type extends PartialType<Chunk, ClientWorld> {
                 section.writeSkyLight(buf);
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 256 : 0));
+            Type.VAR_INT.writePrimitive(output, buf.readableBytes() + (chunk.isBiomeData() ? 256 : 0));
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/types/Chunk1_9_1_2Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/types/Chunk1_9_1_2Type.java
@@ -32,9 +32,9 @@ public class Chunk1_9_1_2Type extends PartialType<Chunk, ClientWorld> {
         int chunkZ = input.readInt();
 
         boolean groundUp = input.readBoolean();
-        int primaryBitmask = Type.VAR_INT.read(input);
+        int primaryBitmask = Type.VAR_INT.readPrimitive(input);
         // Size (unused)
-        Type.VAR_INT.read(input);
+        Type.VAR_INT.readPrimitive(input);
 
         BitSet usedSections = new BitSet(16);
         ChunkSection[] sections = new ChunkSection[16];
@@ -75,7 +75,7 @@ public class Chunk1_9_1_2Type extends PartialType<Chunk, ClientWorld> {
         output.writeInt(chunk.getZ());
 
         output.writeBoolean(chunk.isFullChunk());
-        Type.VAR_INT.write(output, chunk.getBitmask());
+        Type.VAR_INT.writePrimitive(output, chunk.getBitmask());
 
         ByteBuf buf = output.alloc().buffer();
         try {
@@ -90,7 +90,7 @@ public class Chunk1_9_1_2Type extends PartialType<Chunk, ClientWorld> {
 
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.isBiomeData() ? 256 : 0));
+            Type.VAR_INT.writePrimitive(output, buf.readableBytes() + (chunk.isBiomeData() ? 256 : 0));
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java
@@ -56,7 +56,7 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
         long chunkHash = toLong(chunkX, chunkZ);
         boolean fullChunk = input.readByte() != 0;
         int bitmask = input.readUnsignedShort();
-        int dataLength = Type.VAR_INT.read(input);
+        int dataLength = Type.VAR_INT.readPrimitive(input);
 
         // Data to be read
         BitSet usedSections = new BitSet(16);
@@ -138,7 +138,7 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
         output.writeInt(chunk.getZ());
         if (chunk.isUnloadPacket()) return;
         output.writeByte(chunk.isFullChunk() ? 0x01 : 0x00);
-        Type.VAR_INT.write(output, chunk.getBitmask());
+        Type.VAR_INT.writePrimitive(output, chunk.getBitmask());
 
         ByteBuf buf = output.alloc().buffer();
         try {
@@ -152,7 +152,7 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
                 section.writeSkyLight(buf);
             }
             buf.readerIndex(0);
-            Type.VAR_INT.write(output, buf.readableBytes() + (chunk.hasBiomeData() ? 256 : 0));
+            Type.VAR_INT.writePrimitive(output, buf.readableBytes() + (chunk.hasBiomeData() ? 256 : 0));
             output.writeBytes(buf);
         } finally {
             buf.release(); // release buffer

--- a/common/src/test/java/us/myles/ViaVersion/common/test/type/StringTypeTest.java
+++ b/common/src/test/java/us/myles/ViaVersion/common/test/type/StringTypeTest.java
@@ -35,7 +35,7 @@ public class StringTypeTest {
     public void testStringReadOverflowException() throws Exception {
         // Read exception
         final ByteBuf buf = Unpooled.buffer();
-        Type.VAR_INT.write(buf, (Short.MAX_VALUE + 1) * 4);
+        Type.VAR_INT.writePrimitive(buf, (Short.MAX_VALUE + 1) * 4);
         for (int i = 0; i < Short.MAX_VALUE / 2 + 1; i++) {
             buf.writeBytes(new byte[]{0x04, (byte) 0xf0, (byte) 0x9f, (byte) 0xa7, (byte) 0xbd}); // Sponge emoji
         }


### PR DESCRIPTION
Mostly interesting for proper object type reading (arrays, chunks, etc.) that manually call the type read/write methods + packet varint channel id