### PR TITLE
Remove "API" from name in fabric.mod.json

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "viaversion",
-  "name": "ViaVersion API",
+  "name": "ViaVersion",
   "version": "${project.version}",
   "description": "${project.description}",
   "license": "MIT",


### PR DESCRIPTION
It's kinda of a library, but it has implementations too. I don't know how to categorize it