### PR TITLE
Fix CharBuffer allowing the index to advance to the size of the character sequence

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/minecraft/nbt/BinaryTagIO.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/minecraft/nbt/BinaryTagIO.java
@@ -193,7 +193,7 @@ public final class BinaryTagIO {
             final CharBuffer buffer = new CharBuffer(input);
             final TagStringReader parser = new TagStringReader(buffer);
             final CompoundTag tag = parser.compound();
-            if (buffer.skipWhitespace().hasMore()) {
+            if (buffer.skipWhitespace().hasValue()) {
                 throw new IOException("Document had trailing content after first CompoundTag");
             }
             return tag;

--- a/common/src/main/java/us/myles/ViaVersion/api/minecraft/nbt/CharBuffer.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/minecraft/nbt/CharBuffer.java
@@ -45,20 +45,38 @@ package us.myles.ViaVersion.api.minecraft.nbt;
     }
 
     /**
-     * Get the current character and advance
+     * Get the current character and advance if possible
      *
      * @return current character
      */
     public char take() {
-        return this.sequence.charAt(this.index++);
+        int idx = this.index;
+        if (this.canAdvance()) this.advance();
+        return this.sequence.charAt(idx);
     }
 
-    public boolean advance() {
+    /**
+     * Advances the index of this char buffer
+     */
+    public void advance() {
         this.index++;
-        return this.hasMore();
     }
 
-    public boolean hasMore() {
+    /**
+     * Checks if the index can advance
+     *
+     * @return Whether the index can advance
+     */
+    public boolean canAdvance() {
+        return (this.index + 1) < this.sequence.length();
+    }
+
+    /**
+     * Checks if the index has a value
+     *
+     * @return Whether the index has a value
+     */
+    public boolean hasValue() {
         return this.index < this.sequence.length();
     }
 
@@ -99,18 +117,19 @@ package us.myles.ViaVersion.api.minecraft.nbt;
      */
     public CharBuffer expect(final char expectedChar) throws StringTagParseException {
         this.skipWhitespace();
-        if (!this.hasMore()) {
+        if (!this.hasValue()) {
             throw this.makeError("Expected character '" + expectedChar + "' but got EOF");
         }
         if (this.peek() != expectedChar) {
             throw this.makeError("Expected character '" + expectedChar + "' but got '" + this.peek() + "'");
         }
+
         this.take();
         return this;
     }
 
     public CharBuffer skipWhitespace() {
-        while (this.hasMore() && Character.isWhitespace(this.peek())) this.advance();
+        while (this.canAdvance() && Character.isWhitespace(this.peek())) this.advance();
         return this;
     }
 


### PR DESCRIPTION
This checks to make sure the index is being advanced to a valid index in the character sequence, fixing the 1.13 to 1.12.2 chat hover text index out of bounds exception.

Error this attempts to fix: https://paste.gg/p/anonymous/8ccbb5873ef343a88be1574e48d154fb/files/711a3d982a5b4445bc3fafab06fc0764/raw