### PR TITLE
Ensure normal keys that end with numbers don't get matched and replaced when replacing indexes

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/ChatItemRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/ChatItemRewriter.java
@@ -9,7 +9,7 @@ import us.myles.ViaVersion.api.data.UserConnection;
 import java.util.regex.Pattern;
 
 public class ChatItemRewriter {
-    private static final Pattern indexRemoval = Pattern.compile("\\d+:(?=([^\"\\\\]*(\\\\.|\"([^\"\\\\]*\\\\.)*[^\"\\\\]*\"))*[^\"]*$)");
+    private static final Pattern indexRemoval = Pattern.compile("(?<![\\w-.+])\\d+:(?=([^\"\\\\]*(\\\\.|\"([^\"\\\\]*\\\\.)*[^\"\\\\]*\"))*[^\"]*$)");
     // Taken from https://stackoverflow.com/questions/6462578/alternative-to-regex-match-all-instances-not-inside-quotes
 
     public static void toClient(JsonElement element, UserConnection user) {


### PR DESCRIPTION
Having an NBT key such as `CrateKey-monthly_february_2020:` would become impossible to have as `2020:` would be matched and replaced. The purpose of this functionality is to replace indexes only. This adds a negative lookbehind to make sure the characters before the match are not that of characters for a valid key. This still allows it to be matched in all other cases, so while `CrateKey-monthly_february_2020:` would not be matched, however `[2020:` would, as well as `,2020` etc. Characters that would invalidate this from being matched are `A-Za-z_-.+`.