### PR TITLE
Close the open inventory before opening a new one on 1.16

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
@@ -24,6 +24,7 @@ import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.packets.EntityPackets;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.packets.InventoryPackets;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.packets.WorldPackets;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.storage.EntityTracker1_16;
+import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.storage.InventoryTracker1_16;
 import us.myles.ViaVersion.util.GsonUtil;
 
 import java.nio.charset.StandardCharsets;
@@ -273,5 +274,6 @@ public class Protocol1_16To1_15_2 extends Protocol<ClientboundPackets1_15, Clien
     @Override
     public void init(UserConnection userConnection) {
         userConnection.put(new EntityTracker1_16(userConnection));
+        userConnection.put(new InventoryTracker1_16(userConnection));
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
@@ -6,6 +6,7 @@ import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.LongTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import com.github.steveice10.opennbt.tag.builtin.Tag;
+import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.protocol.Protocol;
@@ -15,8 +16,10 @@ import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.api.type.types.UUIDIntArrayType;
 import us.myles.ViaVersion.protocols.protocol1_15to1_14_4.ClientboundPackets1_15;
 import us.myles.ViaVersion.protocols.protocol1_14to1_13_2.data.RecipeRewriter1_14;
+import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.Protocol1_16To1_15_2;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.ServerboundPackets1_16;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.data.MappingData;
+import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.storage.InventoryTracker1_16;
 
 import java.util.UUID;
 
@@ -28,22 +31,50 @@ public class InventoryPackets {
         protocol.registerOutgoing(ClientboundPackets1_15.OPEN_WINDOW, new PacketRemapper() {
             @Override
             public void registerMap() {
-                map(Type.VAR_INT);
-                map(Type.VAR_INT);
-                map(Type.COMPONENT);
+                map(Type.VAR_INT); // Window Id
+                map(Type.VAR_INT); // Window Type
+                map(Type.COMPONENT); // Window Title
 
                 handler(wrapper -> {
+                    InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
+                    if (inventoryTracker.getInventory() != -1) {
+                        // Close open inventory before opening a new one.
+                        PacketWrapper closePacket = wrapper.create(0x13); // 1.16 inventory close
+                        closePacket.write(Type.UNSIGNED_BYTE, inventoryTracker.getInventory());
+                        closePacket.send(Protocol1_16To1_15_2.class, true, true);
+                    }
+
+                    int windowId = wrapper.get(Type.VAR_INT, 0);
                     int windowType = wrapper.get(Type.VAR_INT, 1);
                     if (windowType >= 20) { // smithing added with id 20
                         wrapper.set(Type.VAR_INT, 1, ++windowType);
                     }
+
+                    inventoryTracker.setInventory((short) windowId);
+
+                    // Workaround for packet order issue
+                    wrapper.send(Protocol1_16To1_15_2.class, true, true);
+                    wrapper.cancel();
                 });
             }
         });
+
+        protocol.registerOutgoing(ClientboundPackets1_15.CLOSE_WINDOW, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.UNSIGNED_BYTE);
+
+                handler(wrapper -> {
+                    InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
+                    inventoryTracker.setInventory((short) -1);
+                });
+            }
+        });
+
         protocol.registerOutgoing(ClientboundPackets1_15.WINDOW_PROPERTY, new PacketRemapper() {
             @Override
             public void registerMap() {
-                map(Type.UNSIGNED_BYTE); // Window id
+                map(Type.UNSIGNED_BYTE); // Window Id
                 map(Type.SHORT); // Property
                 map(Type.SHORT); // Value
 
@@ -82,6 +113,18 @@ public class InventoryPackets {
 
         itemRewriter.registerClickWindow(ServerboundPackets1_16.CLICK_WINDOW, Type.FLAT_VAR_INT_ITEM);
         itemRewriter.registerCreativeInvAction(ServerboundPackets1_16.CREATIVE_INVENTORY_ACTION, Type.FLAT_VAR_INT_ITEM);
+
+        protocol.registerIncoming(ServerboundPackets1_16.CLOSE_WINDOW, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.UNSIGNED_BYTE);
+
+                handler(wrapper -> {
+                    InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
+                    inventoryTracker.setInventory((short) -1);
+                });
+            }
+        });
 
         protocol.registerIncoming(ServerboundPackets1_16.EDIT_BOOK, new PacketRemapper() {
             @Override

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
@@ -16,6 +16,7 @@ import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.api.type.types.UUIDIntArrayType;
 import us.myles.ViaVersion.protocols.protocol1_15to1_14_4.ClientboundPackets1_15;
 import us.myles.ViaVersion.protocols.protocol1_14to1_13_2.data.RecipeRewriter1_14;
+import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.ClientboundPackets1_16;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.Protocol1_16To1_15_2;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.ServerboundPackets1_16;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.data.MappingData;
@@ -39,7 +40,7 @@ public class InventoryPackets {
                     InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
                     if (inventoryTracker.getInventory() != -1) {
                         // Close open inventory before opening a new one.
-                        PacketWrapper closePacket = wrapper.create(0x13); // 1.16 inventory close
+                        PacketWrapper closePacket = wrapper.create(ClientboundPackets1_16.CLOSE_WINDOW.ordinal());
                         closePacket.write(Type.UNSIGNED_BYTE, inventoryTracker.getInventory());
                         closePacket.send(Protocol1_16To1_15_2.class, true, true);
                     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/storage/InventoryTracker1_16.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/storage/InventoryTracker1_16.java
@@ -1,0 +1,20 @@
+package us.myles.ViaVersion.protocols.protocol1_16to1_15_2.storage;
+
+import us.myles.ViaVersion.api.data.StoredObject;
+import us.myles.ViaVersion.api.data.UserConnection;
+
+public class InventoryTracker1_16 extends StoredObject {
+    private short inventory = -1;
+
+    public InventoryTracker1_16(UserConnection user) {
+        super(user);
+    }
+
+    public short getInventory() {
+        return this.inventory;
+    }
+
+    public void setInventory(short inventory) {
+        this.inventory = inventory;
+    }
+}


### PR DESCRIPTION
On older versions of the server you could open an inventory with one already open and it would close the old one and open the new one. On 1.16 this does not appear to be the case and attempting to do this would result in both inventories closing. This broke all the inventory menus we had on Mineteria and caused similar issues on another larger server. As a result this change tracks the inventory ID that has been open and removes it when it has closed. An attempt to open an inventory while one is already open will make sure the previous inventory is closed first. This solved problems on both servers.