### PR TITLE
Make several tweaks to Protocol to improve inlining and performance on hot paths

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolPipeline.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolPipeline.java
@@ -1,5 +1,6 @@
 package us.myles.ViaVersion.api.protocol;
 
+import com.google.common.collect.Lists;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
@@ -9,13 +10,13 @@ import us.myles.ViaVersion.packets.State;
 import us.myles.ViaVersion.protocols.base.ProtocolInfo;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 
 public class ProtocolPipeline extends SimpleProtocol {
-    private List<Protocol> protocolList;
+    private List<Protocol> incoming;
+    private List<Protocol> outgoing;
     private UserConnection userConnection;
 
     public ProtocolPipeline(UserConnection userConnection) {
@@ -25,9 +26,10 @@ public class ProtocolPipeline extends SimpleProtocol {
 
     @Override
     protected void registerPackets() {
-        protocolList = new CopyOnWriteArrayList<>();
+        incoming = new CopyOnWriteArrayList<>();
+        outgoing = Lists.reverse(incoming);
         // This is a pipeline so we register basic pipes
-        protocolList.add(ProtocolRegistry.BASE_PROTOCOL);
+        incoming.add(ProtocolRegistry.BASE_PROTOCOL);
     }
 
     @Override
@@ -40,7 +42,7 @@ public class ProtocolPipeline extends SimpleProtocol {
         userConnection.setProtocolInfo(protocolInfo);
 
         /* Init through all our pipes */
-        for (Protocol protocol : protocolList) {
+        for (Protocol protocol : incoming) {
             protocol.init(userConnection);
         }
     }
@@ -52,57 +54,57 @@ public class ProtocolPipeline extends SimpleProtocol {
      * @param protocol The protocol to add to the end
      */
     public void add(Protocol protocol) {
-        if (protocolList != null) {
-            protocolList.add(protocol);
+        if (incoming != null) {
+            incoming.add(protocol);
             protocol.init(userConnection);
             // Move base Protocols to the end, so the login packets can be modified by other protocols
             List<Protocol> toMove = new ArrayList<>();
-            for (Protocol p : protocolList) {
+            for (Protocol p : incoming) {
                 if (ProtocolRegistry.isBaseProtocol(p)) {
                     toMove.add(p);
                 }
             }
-            protocolList.removeAll(toMove);
-            protocolList.addAll(toMove);
+            incoming.removeAll(toMove);
+            incoming.addAll(toMove);
         } else {
-            throw new NullPointerException("Tried to add protocol to early");
+            throw new NullPointerException("Tried to add protocol too early");
         }
     }
 
     @Override
     public void transform(Direction direction, State state, PacketWrapper packetWrapper) throws Exception {
         int originalID = packetWrapper.getId();
-        List<Protocol> protocols = new ArrayList<>(protocolList);
-        // Other way if outgoing
-        if (direction == Direction.OUTGOING)
-            Collections.reverse(protocols);
+        List<Protocol> protocols = direction == Direction.OUTGOING ? outgoing : incoming;
 
         // Apply protocols
         packetWrapper.apply(direction, state, 0, protocols);
         super.transform(direction, state, packetWrapper);
 
         if (Via.getManager().isDebug()) {
-            // Debug packet
-            int serverProtocol = userConnection.getProtocolInfo().getServerProtocolVersion();
-            int clientProtocol = userConnection.getProtocolInfo().getProtocolVersion();
-            ViaPlatform platform = Via.getPlatform();
-
-            String actualUsername = packetWrapper.user().getProtocolInfo().getUsername();
-            String username = actualUsername != null ? actualUsername + " " : "";
-
-            platform.getLogger().log(Level.INFO, "{0}{1} {2}: {3} (0x{4}) -> {5} (0x{6}) [{7}] {8}",
-                    new Object[]{
-                            username,
-                            direction,
-                            state,
-                            originalID,
-                            Integer.toHexString(originalID),
-                            packetWrapper.getId(),
-                            Integer.toHexString(packetWrapper.getId()),
-                            Integer.toString(clientProtocol),
-                            packetWrapper
-                    });
+            logPacket(direction, state, packetWrapper, originalID);
         }
+    }
+
+    private void logPacket(Direction direction, State state, PacketWrapper packetWrapper, int originalID) {
+        // Debug packet
+        int clientProtocol = userConnection.getProtocolInfo().getProtocolVersion();
+        ViaPlatform platform = Via.getPlatform();
+
+        String actualUsername = packetWrapper.user().getProtocolInfo().getUsername();
+        String username = actualUsername != null ? actualUsername + " " : "";
+
+        platform.getLogger().log(Level.INFO, "{0}{1} {2}: {3} (0x{4}) -> {5} (0x{6}) [{7}] {8}",
+                new Object[]{
+                        username,
+                        direction,
+                        state,
+                        originalID,
+                        Integer.toHexString(originalID),
+                        packetWrapper.getId(),
+                        Integer.toHexString(packetWrapper.getId()),
+                        Integer.toString(clientProtocol),
+                        packetWrapper
+                });
     }
 
     /**
@@ -112,14 +114,14 @@ public class ProtocolPipeline extends SimpleProtocol {
      * @return True if the protocol class is in the pipeline
      */
     public boolean contains(Class<? extends Protocol> pipeClass) {
-        for (Protocol protocol : protocolList) {
+        for (Protocol protocol : incoming) {
             if (protocol.getClass().equals(pipeClass)) return true;
         }
         return false;
     }
 
     public <P extends Protocol> P getProtocol(Class<P> pipeClass) {
-        for (Protocol protocol : protocolList) {
+        for (Protocol protocol : incoming) {
             if (protocol.getClass() == pipeClass) return (P) protocol;
         }
         return null;
@@ -134,7 +136,7 @@ public class ProtocolPipeline extends SimpleProtocol {
      * @throws Exception If it failed to convert / packet cancelld.
      */
     public boolean filter(Object o, List list) throws Exception {
-        for (Protocol protocol : protocolList) {
+        for (Protocol protocol : incoming) {
             if (protocol.isFiltered(o.getClass())) {
                 protocol.filterPacket(userConnection, o, list);
                 return true;
@@ -145,7 +147,7 @@ public class ProtocolPipeline extends SimpleProtocol {
     }
 
     public List<Protocol> pipes() {
-        return protocolList;
+        return incoming;
     }
 
     /**


### PR DESCRIPTION
For once, this PR is largely original work. This PR refactors the `transform()` hot-spot method on `Protocol` and `ProtocolPipeline` to get them below the magical 325 bytecode limit that otherwise forces HotSpot to not consider inlining the method.

The error code and debug logging path is not performance-critical so splitting them out into their own paths ultimately improves performance.

Tested with ViaVersion on a 1.12.2 server (porting to 1.16.1) and ViaBackwards (porting to 1.9.4).