### PR TITLE
Fix Wrong AutoTeam Color

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
@@ -246,12 +246,12 @@ public class EntityTracker1_9 extends EntityTracker {
             if (!teamExists) {
                 wrapper.write(Type.BYTE, (byte) 0); // make team
                 wrapper.write(Type.STRING, "viaversion");
-                wrapper.write(Type.STRING, ""); // prefix
+                wrapper.write(Type.STRING, "§f"); // prefix
                 wrapper.write(Type.STRING, ""); // suffix
                 wrapper.write(Type.BYTE, (byte) 0); // friendly fire
                 wrapper.write(Type.STRING, ""); // nametags
                 wrapper.write(Type.STRING, "never"); // collision rule :)
-                wrapper.write(Type.BYTE, (byte) 0); // color
+                wrapper.write(Type.BYTE, (byte) 15); // color
             } else {
                 wrapper.write(Type.BYTE, (byte) 3);
             }


### PR DESCRIPTION
The team created to remove collisions for 1.9+ players on 1.8.x servers is set to be black. On 1.9-1.12 clients this isn't visible, since the prefix is empty, but on 1.13+ clients the player name will be shown black if team-colour-fix option is set to false. This will fix that, setting the white color to the team.

Tested on 1.8.7 server with 1.15.2 client.