### PR TITLE
Rework inventory workaround to cancel animation if in an open inventory for 1.16

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
@@ -16,9 +16,11 @@ import us.myles.ViaVersion.api.type.types.version.Types1_14;
 import us.myles.ViaVersion.protocols.protocol1_15to1_14_4.ClientboundPackets1_15;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.ClientboundPackets1_16;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.Protocol1_16To1_15_2;
+import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.ServerboundPackets1_16;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.data.MappingData;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.metadata.MetadataRewriter1_16To1_15_2;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.storage.EntityTracker1_16;
+import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.storage.InventoryTracker1_16;
 
 import java.util.UUID;
 
@@ -238,6 +240,19 @@ public class EntityPackets {
                             wrapper.passthrough(Type.DOUBLE);
                             wrapper.passthrough(Type.BYTE);
                         }
+                    }
+                });
+            }
+        });
+
+        protocol.registerIncoming(ServerboundPackets1_16.ANIMATION, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                handler(wrapper -> {
+                    InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
+                    // Don't send an arm swing if the player is switching between inventories.
+                    if (inventoryTracker.getInventory() != -1) {
+                        wrapper.cancel();
                     }
                 });
             }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
@@ -6,7 +6,6 @@ import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.LongTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import com.github.steveice10.opennbt.tag.builtin.Tag;
-import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.protocol.Protocol;
@@ -16,8 +15,6 @@ import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.api.type.types.UUIDIntArrayType;
 import us.myles.ViaVersion.protocols.protocol1_15to1_14_4.ClientboundPackets1_15;
 import us.myles.ViaVersion.protocols.protocol1_14to1_13_2.data.RecipeRewriter1_14;
-import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.ClientboundPackets1_16;
-import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.Protocol1_16To1_15_2;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.ServerboundPackets1_16;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.data.MappingData;
 import us.myles.ViaVersion.protocols.protocol1_16to1_15_2.storage.InventoryTracker1_16;
@@ -38,24 +35,12 @@ public class InventoryPackets {
 
                 handler(wrapper -> {
                     InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
-                    if (inventoryTracker.getInventory() != -1) {
-                        // Close open inventory before opening a new one.
-                        PacketWrapper closePacket = wrapper.create(ClientboundPackets1_16.CLOSE_WINDOW.ordinal());
-                        closePacket.write(Type.UNSIGNED_BYTE, inventoryTracker.getInventory());
-                        closePacket.send(Protocol1_16To1_15_2.class, true, true);
-                    }
-
                     int windowId = wrapper.get(Type.VAR_INT, 0);
                     int windowType = wrapper.get(Type.VAR_INT, 1);
                     if (windowType >= 20) { // smithing added with id 20
                         wrapper.set(Type.VAR_INT, 1, ++windowType);
                     }
-
                     inventoryTracker.setInventory((short) windowId);
-
-                    // Workaround for packet order issue
-                    wrapper.send(Protocol1_16To1_15_2.class, true, true);
-                    wrapper.cancel();
                 });
             }
         });


### PR DESCRIPTION
Partially reverts #2007 and instead replaces it with a better solution. Rather than closing the current inventory as a new one is sent, this instead cancels any arm-swing that the client sends when swapping inventories (explained more extensively [here](https://github.com/ViaVersion/ViaVersion/pull/2007#issuecomment-678675622)).

Before:
![ezgif-7-625588efa4d2](https://user-images.githubusercontent.com/29153871/90963316-3c7b1b80-e47c-11ea-9528-73f838441396.gif)
As you can see, every time I click the stone which is supposed to open a new inventory, it just re-opens the one that opens when I left-click the glowstone. May be a bit difficult to see, but this is more easily observed from one I sent of this happening on The Hive.

After:
![ezgif-7-ee3df8b306f5](https://user-images.githubusercontent.com/29153871/90963359-86fc9800-e47c-11ea-98b7-f366f782a432.gif)

This has been tested extensively and no unintended side effects have been observed as a result of it.