### PR TITLE
Fixed 1.9 -> 1.8 enderman held item metadata translation

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
@@ -43,6 +43,14 @@ public class MetadataRewriter1_13To1_12_2 extends MetadataRewriter {
             }
         }
 
+        // Remap held block to match new format for remapping to flat block
+        if (type == Entity1_13Types.EntityType.ENDERMAN && metadata.getId() == 12) {
+            int stateId = (int) metadata.getValue();
+            int id = stateId & 4095;
+            int data = stateId >> 12 & 15;
+            metadata.setValue((id << 4) | (data & 0xF));
+        }
+
         // 1.13 changed item to flat item (no data)
         if (metadata.getMetaType() == MetaType1_13.Slot) {
             metadata.setMetaType(MetaType1_13.Slot);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/metadata/MetaIndex.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/metadata/MetaIndex.java
@@ -68,8 +68,8 @@ public enum MetaIndex {
     // villager
     VILLAGER_PROFESSION(VILLAGER, 16, MetaType1_8.Int, 12, MetaType1_9.VarInt),
     // enderman
-    ENDERMAN_BLOCK(ENDERMAN, 16, MetaType1_8.Short, 11, MetaType1_9.BlockID), // special case
-    ENDERMAN_BLOCKDATA(ENDERMAN, 17, MetaType1_8.Byte, 11, MetaType1_9.BlockID), // special case
+    ENDERMAN_BLOCKSTATE(ENDERMAN, 16, MetaType1_8.Short, 11, MetaType1_9.BlockID),
+    ENDERMAN_BLOCKDATA(ENDERMAN, 17, MetaType1_8.Byte, MetaType1_9.Discontinued), //always 0 when sent, never read by the client
     ENDERMAN_ISSCREAMING(ENDERMAN, 18, MetaType1_8.Byte, 12, MetaType1_9.Boolean),
     // zombie
     ZOMBIE_ISCHILD(ZOMBIE, 12, MetaType1_8.Byte, 11, MetaType1_9.Boolean),

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
@@ -112,16 +112,8 @@ public class MetadataRewriter1_9To1_8 extends MetadataRewriter {
                 metadata.setValue(value);
                 break;
             case BlockID:
-                // convert from int, short, byte
-                if (metaIndex.getOldType() == MetaType1_8.Byte) {
-                    metadata.setValue(((Byte) value).intValue());
-                }
-                if (metaIndex.getOldType() == MetaType1_8.Short) {
-                    metadata.setValue(((Short) value).intValue());
-                }
-                if (metaIndex.getOldType() == MetaType1_8.Int) {
-                    metadata.setValue(value);
-                }
+                // Convert from int, short, byte
+                metadata.setValue(((Number) value).intValue());
                 break;
             default:
                 metadatas.remove(metadata);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
@@ -39,19 +39,6 @@ public class MetadataRewriter1_9To1_8 extends MetadataRewriter {
         metadata.setId(metaIndex.getNewIndex());
         metadata.setMetaType(metaIndex.getNewType());
 
-        if (type == Entity1_10Types.EntityType.ENDERMAN && metaIndex.getNewType() == MetaType1_9.BlockID) {
-            if (metaIndex.getOldType() == MetaType1_8.Short) {
-                int id = (Short) metadata.getValue();
-                Metadata meta = getMetaByIndex(17, metadatas);
-                int data = meta != null ? (Byte) meta.getValue() : 0;
-                int combined = (id << 4) | (data & 0xF);
-                metadata.setValue(combined);
-            } else {
-                metadatas.remove(metadata);
-            }
-            return;
-        }
-
         Object value = metadata.getValue();
         switch (metaIndex.getNewType()) {
             case Byte:
@@ -123,6 +110,18 @@ public class MetadataRewriter1_9To1_8 extends MetadataRewriter {
             case Chat:
                 value = Protocol1_9To1_8.fixJson(value.toString());
                 metadata.setValue(value);
+                break;
+            case BlockID:
+                // convert from int, short, byte
+                if (metaIndex.getOldType() == MetaType1_8.Byte) {
+                    metadata.setValue(((Byte) value).intValue());
+                }
+                if (metaIndex.getOldType() == MetaType1_8.Short) {
+                    metadata.setValue(((Short) value).intValue());
+                }
+                if (metaIndex.getOldType() == MetaType1_8.Int) {
+                    metadata.setValue(value);
+                }
                 break;
             default:
                 metadatas.remove(metadata);


### PR DESCRIPTION
This PR fixes enderman metadata translation (previously they had invalid items on 1.8 server for 1.9+ clients). Now its fixed and tested for 1.9 and 1.13