### PR TITLE
Fix IOB in 1.13 recipe request

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -826,7 +826,17 @@ public class Protocol1_13To1_12_2 extends Protocol<ClientboundPackets1_12_1, Cli
             @Override
             public void registerMap() {
                 map(Type.BYTE); // Window id
-                handler(wrapper -> wrapper.write(Type.VAR_INT, Integer.parseInt(wrapper.read(Type.STRING).substring(18))));
+
+                handler(wrapper -> {
+                    String s = wrapper.read(Type.STRING);
+                    Integer id;
+                    if (s.length() < 19 || (id = Ints.tryParse(s.substring(18))) == null) {
+                        wrapper.cancel();
+                        return;
+                    }
+
+                    wrapper.write(Type.VAR_INT, id);
+                });
             }
         });
 


### PR DESCRIPTION
Hello,

I had been experiencing problems with one of my 1.8 servers kicking out players who would try to open up the Recipe Book while on newer versions, issue fixed by https://github.com/ViaVersion/ViaVersion/commit/78bb5f171f946b25afb1d9d82d9ec760e1638a8d. Although, now that they could open up the book, if they happened to have a recipe unlocked and decided to click on it, they would get kicked off the server, producing an error similar to the original bug.

I'm completely new to ViaVersion's codebase, but replicating the same approach taken by the referenced commit apparently fixes the problem all together, with no more unexpected crashes for my players.