### PR TITLE
Fix falling dust ID in ParticleMappings

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/data/ParticleMappings.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/data/ParticleMappings.java
@@ -14,7 +14,7 @@ public class ParticleMappings {
 
         Object2IntMap<String> map = MappingDataLoader.arrayToMap(oldMappings);
         blockId = map.getInt("block");
-        fallingDustId = map.getInt("dust");
+        fallingDustId = map.getInt("falling_dust");
         itemId = map.getInt("item");
     }
 


### PR DESCRIPTION
The ID was incorrect causing players to crash when attempting to spawn redstone dust particles. This corrects it to look for the `falling_dust` ID not the `dust` ID, like it was intended to do.

Error caused: https://gist.github.com/connorhartley/57691cd199b57edff126e10d40827308