### PR TITLE
fix entity attributes length prefix

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
@@ -211,6 +211,7 @@ public class EntityPackets {
                 handler(wrapper -> {
                     wrapper.passthrough(Type.VAR_INT);
                     int size = wrapper.passthrough(Type.INT);
+                    int actualSize = size;
                     for (int i = 0; i < size; i++) {
                         // Attributes have been renamed and are now namespaced identifiers
                         String key = wrapper.read(Type.STRING);
@@ -218,7 +219,10 @@ public class EntityPackets {
                         if (attributeIdentifier == null) {
                             attributeIdentifier = "minecraft:" + key;
                             if (!us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.MappingData.isValid1_13Channel(attributeIdentifier)) {
-                                Via.getPlatform().getLogger().warning("Invalid attribute: " + key);
+                                if (!Via.getConfig().isSuppressConversionWarnings()) {
+                                    Via.getPlatform().getLogger().warning("Invalid attribute: " + key);
+                                }
+                                wrapper.set(Type.INT, 0, --actualSize);
                                 wrapper.read(Type.DOUBLE);
                                 int modifierSize = wrapper.read(Type.VAR_INT);
                                 for (int j = 0; j < modifierSize; j++) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
@@ -222,7 +222,7 @@ public class EntityPackets {
                                 if (!Via.getConfig().isSuppressConversionWarnings()) {
                                     Via.getPlatform().getLogger().warning("Invalid attribute: " + key);
                                 }
-                                wrapper.set(Type.INT, 0, --actualSize);
+                                actualSize--;
                                 wrapper.read(Type.DOUBLE);
                                 int modifierSize = wrapper.read(Type.VAR_INT);
                                 for (int j = 0; j < modifierSize; j++) {
@@ -243,6 +243,9 @@ public class EntityPackets {
                             wrapper.passthrough(Type.DOUBLE);
                             wrapper.passthrough(Type.BYTE);
                         }
+                    }
+                    if (size != actualSize) {
+                        wrapper.set(Type.INT, 0, actualSize);
                     }
                 });
             }


### PR DESCRIPTION
This fixes a bug where an entity attribute discarded for having an invalid identifier would not cause the resulting packet's length prefix to be updated, resulting in a packet that reported having more attributes that it actually did.

It also makes invalid entity attribute messages be hidden by the `suppress-conversion-warnings` config option.