### PR TITLE
corrected 1.9.x -> 1.10 sound pitch adjustments

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_10to1_9_3/Protocol1_10To1_9_3_4.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_10to1_9_3/Protocol1_10To1_9_3_4.java
@@ -22,7 +22,7 @@ public class Protocol1_10To1_9_3_4 extends Protocol<ClientboundPackets1_9_3, Cli
     public static final ValueTransformer<Short, Float> TO_NEW_PITCH = new ValueTransformer<Short, Float>(Type.FLOAT) {
         @Override
         public Float transform(PacketWrapper wrapper, Short inputValue) throws Exception {
-            return inputValue / 63.5F;
+            return inputValue / 63.0F;
         }
     };
     public static final ValueTransformer<List<Metadata>, List<Metadata>> TRANSFORM_METADATA = new ValueTransformer<List<Metadata>, List<Metadata>>(Types1_9.METADATA_LIST) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/Protocol1_9_3To1_9_1_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/Protocol1_9_3To1_9_1_2.java
@@ -12,6 +12,7 @@ import us.myles.ViaVersion.api.minecraft.chunks.ChunkSection;
 import us.myles.ViaVersion.api.protocol.Protocol;
 import us.myles.ViaVersion.api.remapper.PacketHandler;
 import us.myles.ViaVersion.api.remapper.PacketRemapper;
+import us.myles.ViaVersion.api.remapper.ValueTransformer;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.chunks.FakeTileEntity;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
@@ -22,6 +23,13 @@ import us.myles.ViaVersion.protocols.protocol1_9to1_8.ServerboundPackets1_9;
 import java.util.List;
 
 public class Protocol1_9_3To1_9_1_2 extends Protocol<ClientboundPackets1_9, ClientboundPackets1_9_3, ServerboundPackets1_9, ServerboundPackets1_9_3> {
+
+    public static final ValueTransformer<Short, Short> ADJUST_PITCH = new ValueTransformer<Short, Short>(Type.UNSIGNED_BYTE, Type.UNSIGNED_BYTE) {
+        @Override
+        public Short transform(PacketWrapper wrapper, Short inputValue) throws Exception {
+            return (short) Math.round(inputValue / 63.5F * 63.0F);
+        }
+    };
 
     public Protocol1_9_3To1_9_1_2() {
         super(ClientboundPackets1_9.class, ClientboundPackets1_9_3.class, ServerboundPackets1_9.class, ServerboundPackets1_9_3.class);
@@ -132,6 +140,20 @@ public class Protocol1_9_3To1_9_1_2 extends Protocol<ClientboundPackets1_9, Clie
                         clientWorld.setEnvironment(dimensionId);
                     }
                 });
+            }
+        });
+
+        // Sound effect
+        registerOutgoing(ClientboundPackets1_9.SOUND, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // 0 - Sound name
+                map(Type.VAR_INT); // 1 - Sound Category
+                map(Type.INT); // 2 - x
+                map(Type.INT); // 3 - y
+                map(Type.INT); // 4 - z
+                map(Type.FLOAT); // 5 - Volume
+                map(ADJUST_PITCH); // 6 - Pitch
             }
         });
     }


### PR DESCRIPTION
This PR fixes the changes made in sound pitch reading from 1.9.2 -> 1.9.3.
Tested with 1.9.4 client on 1.9.2 server and 1.9.4 client on 1.9.4 server using noteblocks tuned to the same pitch.