### PR TITLE
Fix sound ID shift in 1.11

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/Protocol1_11To1_10.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/Protocol1_11To1_10.java
@@ -337,7 +337,7 @@ public class Protocol1_11To1_10 extends Protocol<ClientboundPackets1_9_3, Client
             id += 1;
         if (id >= 197) // evocation things
             id += 8;
-        if (id >= 196) // Rip the Experience orb touch sound :'(
+        if (id >= 207) // Rip the Experience orb touch sound :'(
             id -= 1;
         if (id >= 279) // Liama's
             id += 9;


### PR DESCRIPTION
This possibly got broken in the rewrite in dc62394.
Fixes ender pearl throw and experience bottle throw/pickup sounds.