### PR TITLE
Fixed encoding not properly working with other packet reading libraries

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/handlers/BukkitEncodeHandler.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/handlers/BukkitEncodeHandler.java
@@ -54,8 +54,10 @@ public class BukkitEncodeHandler extends MessageToByteEncoder implements ViaHand
                     throw (Error) e.getCause();
                 }
             }
+            
+        } else {
+            bytebuf.clear().writeBytes((ByteBuf) o);
         }
-
         transform(bytebuf);
     }
 


### PR DESCRIPTION
Injecting a message to byte encoder beforehand would break outbound packets in ViaVersion. This solution is a good fix which won't impact anything.