### PR TITLE
Fix - client leaves from server when dust particle occurs in 20w49a-21w03a

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/packets/InventoryPackets.java
@@ -33,32 +33,7 @@ public class InventoryPackets {
             }
         });
 
-        protocol.registerOutgoing(ClientboundPackets1_16_2.SPAWN_PARTICLE, new PacketRemapper() {
-            @Override
-            public void registerMap() {
-                map(Type.INT); // Particle id
-                map(Type.BOOLEAN); // Long distance
-                map(Type.DOUBLE); // X
-                map(Type.DOUBLE); // Y
-                map(Type.DOUBLE); // Z
-                map(Type.FLOAT); // Offset X
-                map(Type.FLOAT); // Offset Y
-                map(Type.FLOAT); // Offset Z
-                map(Type.FLOAT); // Particle data
-                map(Type.INT); // Particle count
-                handler(wrapper -> {
-                    int id = wrapper.get(Type.INT, 0);
-                    if (id == 14) { // Dust
-                        // RGB now written as doubles
-                        wrapper.write(Type.DOUBLE, wrapper.read(Type.FLOAT).doubleValue()); // R
-                        wrapper.write(Type.DOUBLE, wrapper.read(Type.FLOAT).doubleValue()); // G
-                        wrapper.write(Type.DOUBLE, wrapper.read(Type.FLOAT).doubleValue()); // B
-                        wrapper.passthrough(Type.FLOAT); // Scale
-                    }
-                });
-                handler(itemRewriter.getSpawnParticleHandler(Type.FLAT_VAR_INT_ITEM));
-            }
-        });
+        itemRewriter.registerSpawnParticle(ClientboundPackets1_16_2.SPAWN_PARTICLE, Type.FLAT_VAR_INT_ITEM, Type.DOUBLE);
     }
 
     public static void toClient(Item item) {


### PR DESCRIPTION
If used a double value for redstone particles in 21w03a, it is correct that the code should work without any problems.
but, [same errors](https://github.com/ViaVersion/ViaVersion/issues/2249) occurred in 21w03a.

[It seems that mojang decided to use the float value instead of double.](https://bugs.mojang.com/browse/MC-207900)

![image](https://user-images.githubusercontent.com/45729082/105322723-95f29c80-5c0c-11eb-8e37-8c56ba8564cc.png)
