### PR TITLE
Fixing block placement for players with a lot of CPS

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java
@@ -326,11 +326,18 @@ public class WorldPackets {
                     @Override
                     public void handle(PacketWrapper wrapper) throws Exception {
                         Position position = wrapper.get(Type.POSITION, 0);
+                        short x = wrapper.get(Type.UNSIGNED_BYTE, 1);
+                        short y = wrapper.get(Type.UNSIGNED_BYTE, 2);
+                        short z = wrapper.get(Type.UNSIGNED_BYTE, 3);
+
                         PlaceBlockTracker tracker = wrapper.user().get(PlaceBlockTracker.class);
-                        if (tracker.getLastPlacedPosition() != null && tracker.getLastPlacedPosition().equals(position) && !tracker.isExpired(50))
+                        if (tracker == null) return;
+                        if (!tracker.isExpired(5) && tracker.isSame(position, x, y, z)) {
                             wrapper.cancel();
+                            return;
+                        }
                         tracker.updateTime();
-                        tracker.setLastPlacedPosition(position);
+                        tracker.setLastPlacedPosition(position, x, y, z);
                     }
                 });
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
@@ -39,7 +39,7 @@ public class EntityTracker1_9 extends EntityTracker {
     private final Set<Integer> validBlocking = Sets.newConcurrentHashSet();
     private final Set<Integer> knownHolograms = Sets.newConcurrentHashSet();
     private final Set<Position> blockInteractions = Collections.newSetFromMap(CacheBuilder.newBuilder()
-            .maximumSize(10)
+            .maximumSize(1000)
             .expireAfterAccess(250, TimeUnit.MILLISECONDS)
             .<Position, Boolean>build()
             .asMap());

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/PlaceBlockTracker.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/PlaceBlockTracker.java
@@ -7,6 +7,7 @@ import us.myles.ViaVersion.api.minecraft.Position;
 public class PlaceBlockTracker extends StoredObject {
     private long lastPlaceTimestamp = 0;
     private Position lastPlacedPosition = null;
+    private short x = -1, y = -1, z = -1;
 
     public PlaceBlockTracker(UserConnection user) {
         super(user);
@@ -29,15 +30,35 @@ public class PlaceBlockTracker extends StoredObject {
         lastPlaceTimestamp = System.currentTimeMillis();
     }
 
-    public long getLastPlaceTimestamp() {
-        return lastPlaceTimestamp;
+    /**
+     * Checks if the place clicked the same block again
+     *
+     * @param lastPlacedPosition the last placed position
+     * @param x the x position of the crosshair
+     * @param y the y position of the crosshair
+     * @param z the z position of the crosshair
+     * @return True if the block is the same as the stored block
+     */
+    public boolean isSame(Position lastPlacedPosition, short x, short y, short z) {
+        return lastPlacedPosition.equals(this.lastPlacedPosition)
+                && x == this.x
+                && y == this.y
+                && z == this.z;
     }
 
-    public Position getLastPlacedPosition() {
-        return lastPlacedPosition;
-    }
-
-    public void setLastPlacedPosition(Position lastPlacedPosition) {
+    /**
+     * Sets the last placed block position and face
+     *
+     * @param lastPlacedPosition the block position the player just placed a block at
+     * @param x the x position of the crosshair
+     * @param y the y position of the crosshair
+     * @param z the z position of the crosshair
+     */
+    public void setLastPlacedPosition(Position lastPlacedPosition, short x, short y, short z) {
         this.lastPlacedPosition = lastPlacedPosition;
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
+
 }


### PR DESCRIPTION
Players with a lot of CPS would have problems placing blocks if they can click faster than every 50ms because right now there is a check for double InteractEvents and with this pull request this should be fixed. I'm also upping the cache for block interactions to 1000 because some players can click really fast or are using AutoClicker and we don't want them to cause too much noise.