### PR TITLE
Entity type cleanup

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_13Types.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_13Types.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-// TODO auto generate 18w11a with PAaaS
 public class Entity1_13Types {
 
     public static EntityType getTypeFromId(int typeID, boolean isObject) {

--- a/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_14Types.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_14Types.java
@@ -2,236 +2,228 @@ package us.myles.ViaVersion.api.entities;
 
 import us.myles.ViaVersion.api.Via;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
+public enum Entity1_14Types implements EntityType {
 
-public class Entity1_14Types {
+    ENTITY(-1),
 
-    public static EntityType getTypeFromId(int typeID) {
-        Optional<EntityType> type = EntityType.findById(typeID);
+    AREA_EFFECT_CLOUD(0, ENTITY),
+    END_CRYSTAL(17, ENTITY),
+    EVOKER_FANGS(21, ENTITY),
+    EXPERIENCE_ORB(23, ENTITY),
+    EYE_OF_ENDER(24, ENTITY),
+    FALLING_BLOCK(25, ENTITY),
+    FIREWORK_ROCKET(26, ENTITY),
+    ITEM(34, ENTITY),
+    LLAMA_SPIT(39, ENTITY),
+    TNT(58, ENTITY),
+    SHULKER_BULLET(63, ENTITY),
+    FISHING_BOBBER(101, ENTITY),
 
-        if (!type.isPresent()) {
-            Via.getPlatform().getLogger().severe("Could not find 1.14 type id " + typeID);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
-        }
+    LIVINGENTITY(-1, ENTITY),
+    ARMOR_STAND(1, LIVINGENTITY),
+    PLAYER(100, LIVINGENTITY),
 
-        return type.get();
+    ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
+    ENDER_DRAGON(18, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
+    VILLAGER(84, ABSTRACT_AGEABLE),
+    WANDERING_TRADER(88, ABSTRACT_AGEABLE),
+
+    // Animals
+    ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
+    DOLPHIN(13, ABSTRACT_INSENTIENT),
+    CHICKEN(8, ABSTRACT_ANIMAL),
+    COW(10, ABSTRACT_ANIMAL),
+    MOOSHROOM(49, COW),
+    PANDA(52, ABSTRACT_INSENTIENT),
+    PIG(54, ABSTRACT_ANIMAL),
+    POLAR_BEAR(57, ABSTRACT_ANIMAL),
+    RABBIT(59, ABSTRACT_ANIMAL),
+    SHEEP(61, ABSTRACT_ANIMAL),
+    TURTLE(77, ABSTRACT_ANIMAL),
+    FOX(27, ABSTRACT_ANIMAL),
+
+    ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
+    CAT(6, ABSTRACT_TAMEABLE_ANIMAL),
+    OCELOT(50, ABSTRACT_TAMEABLE_ANIMAL),
+    WOLF(93, ABSTRACT_TAMEABLE_ANIMAL),
+
+    ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
+    PARROT(53, ABSTRACT_PARROT),
+
+    // Horses
+    ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
+    CHESTED_HORSE(-1, ABSTRACT_HORSE),
+    DONKEY(12, CHESTED_HORSE),
+    MULE(48, CHESTED_HORSE),
+    LLAMA(38, CHESTED_HORSE),
+    TRADER_LLAMA(75, CHESTED_HORSE),
+    HORSE(31, ABSTRACT_HORSE),
+    SKELETON_HORSE(66, ABSTRACT_HORSE),
+    ZOMBIE_HORSE(95, ABSTRACT_HORSE),
+
+    // Golem
+    ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
+    SNOW_GOLEM(69, ABSTRACT_GOLEM),
+    IRON_GOLEM(85, ABSTRACT_GOLEM),
+    SHULKER(62, ABSTRACT_GOLEM),
+
+    // Fish
+    ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
+    COD(9, ABSTRACT_FISHES),
+    PUFFERFISH(55, ABSTRACT_FISHES),
+    SALMON(60, ABSTRACT_FISHES),
+    TROPICAL_FISH(76, ABSTRACT_FISHES),
+
+    // Monsters
+    ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
+    BLAZE(4, ABSTRACT_MONSTER),
+    CREEPER(11, ABSTRACT_MONSTER),
+    ENDERMITE(20, ABSTRACT_MONSTER),
+    ENDERMAN(19, ABSTRACT_MONSTER),
+    GIANT(29, ABSTRACT_MONSTER),
+    SILVERFISH(64, ABSTRACT_MONSTER),
+    VEX(83, ABSTRACT_MONSTER),
+    WITCH(89, ABSTRACT_MONSTER),
+    WITHER(90, ABSTRACT_MONSTER),
+    RAVAGER(98, ABSTRACT_MONSTER),
+
+    // Illagers
+    ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
+    ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
+    EVOKER(22, ABSTRACT_EVO_ILLU_ILLAGER),
+    ILLUSIONER(33, ABSTRACT_EVO_ILLU_ILLAGER),
+    VINDICATOR(86, ABSTRACT_ILLAGER_BASE),
+    PILLAGER(87, ABSTRACT_ILLAGER_BASE),
+
+    // Skeletons
+    ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
+    SKELETON(65, ABSTRACT_SKELETON),
+    STRAY(74, ABSTRACT_SKELETON),
+    WITHER_SKELETON(91, ABSTRACT_SKELETON),
+
+    // Guardians
+    GUARDIAN(30, ABSTRACT_MONSTER),
+    ELDER_GUARDIAN(16, GUARDIAN),
+
+    // Spiders
+    SPIDER(72, ABSTRACT_MONSTER),
+    CAVE_SPIDER(7, SPIDER),
+
+    // Zombies - META CHECKED
+    ZOMBIE(94, ABSTRACT_MONSTER),
+    DROWNED(15, ZOMBIE),
+    HUSK(32, ZOMBIE),
+    ZOMBIE_PIGMAN(56, ZOMBIE),
+    ZOMBIE_VILLAGER(96, ZOMBIE),
+
+    // Flying entities
+    ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
+    GHAST(28, ABSTRACT_FLYING),
+    PHANTOM(97, ABSTRACT_FLYING),
+
+    ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
+    BAT(3, ABSTRACT_AMBIENT),
+
+    ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
+    SQUID(73, ABSTRACT_WATERMOB),
+
+    // Slimes
+    SLIME(67, ABSTRACT_INSENTIENT),
+    MAGMA_CUBE(40, SLIME),
+
+    // Hangable objects
+    ABSTRACT_HANGING(-1, ENTITY),
+    LEASH_KNOT(37, ABSTRACT_HANGING),
+    ITEM_FRAME(35, ABSTRACT_HANGING),
+    PAINTING(51, ABSTRACT_HANGING),
+
+    ABSTRACT_LIGHTNING(-1, ENTITY),
+    LIGHTNING_BOLT(99, ABSTRACT_LIGHTNING),
+
+    // Arrows
+    ABSTRACT_ARROW(-1, ENTITY),
+    ARROW(2, ABSTRACT_ARROW),
+    SPECTRAL_ARROW(71, ABSTRACT_ARROW),
+    TRIDENT(82, ABSTRACT_ARROW),
+
+    // Fireballs
+    ABSTRACT_FIREBALL(-1, ENTITY),
+    DRAGON_FIREBALL(14, ABSTRACT_FIREBALL),
+    FIREBALL(36, ABSTRACT_FIREBALL),
+    SMALL_FIREBALL(68, ABSTRACT_FIREBALL),
+    WITHER_SKULL(92, ABSTRACT_FIREBALL),
+
+    // Projectiles
+    PROJECTILE_ABSTRACT(-1, ENTITY),
+    SNOWBALL(70, PROJECTILE_ABSTRACT),
+    ENDER_PEARL(79, PROJECTILE_ABSTRACT),
+    EGG(78, PROJECTILE_ABSTRACT),
+    POTION(81, PROJECTILE_ABSTRACT),
+    EXPERIENCE_BOTTLE(80, PROJECTILE_ABSTRACT),
+
+    // Vehicles
+    MINECART_ABSTRACT(-1, ENTITY),
+    CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
+    CHEST_MINECART(42, CHESTED_MINECART_ABSTRACT),
+    HOPPER_MINECART(45, CHESTED_MINECART_ABSTRACT),
+    MINECART(41, MINECART_ABSTRACT),
+    FURNACE_MINECART(44, MINECART_ABSTRACT),
+    COMMAND_BLOCK_MINECART(43, MINECART_ABSTRACT),
+    TNT_MINECART(47, MINECART_ABSTRACT),
+    SPAWNER_MINECART(46, MINECART_ABSTRACT),
+    BOAT(5, ENTITY);
+
+    private static final EntityType[] TYPES;
+
+    private final int id;
+    private final EntityType parent;
+
+    Entity1_14Types(int id) {
+        this.id = id;
+        this.parent = null;
     }
 
-    public enum EntityType implements us.myles.ViaVersion.api.entities.EntityType {
-        // Auto generated
+    Entity1_14Types(int id, EntityType parent) {
+        this.id = id;
+        this.parent = parent;
+    }
 
-        ENTITY(-1),
+    @Override
+    public int getId() {
+        return id;
+    }
 
-        AREA_EFFECT_CLOUD(0, ENTITY),
-        END_CRYSTAL(17, ENTITY),
-        EVOKER_FANGS(21, ENTITY),
-        EXPERIENCE_ORB(23, ENTITY),
-        EYE_OF_ENDER(24, ENTITY),
-        FALLING_BLOCK(25, ENTITY),
-        FIREWORK_ROCKET(26, ENTITY),
-        ITEM(34, ENTITY),
-        LLAMA_SPIT(39, ENTITY),
-        TNT(58, ENTITY),
-        SHULKER_BULLET(63, ENTITY),
-        FISHING_BOBBER(101, ENTITY),
+    @Override
+    public EntityType getParent() {
+        return parent;
+    }
 
-        LIVINGENTITY(-1, ENTITY),
-        ARMOR_STAND(1, LIVINGENTITY),
-        PLAYER(100, LIVINGENTITY),
-
-        ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
-        ENDER_DRAGON(18, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
-        VILLAGER(84, ABSTRACT_AGEABLE),
-        WANDERING_TRADER(88, ABSTRACT_AGEABLE),
-
-        // Animals
-        ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
-        DOLPHIN(13, ABSTRACT_INSENTIENT),
-        CHICKEN(8, ABSTRACT_ANIMAL),
-        COW(10, ABSTRACT_ANIMAL),
-        MOOSHROOM(49, COW),
-        PANDA(52, ABSTRACT_INSENTIENT),
-        PIG(54, ABSTRACT_ANIMAL),
-        POLAR_BEAR(57, ABSTRACT_ANIMAL),
-        RABBIT(59, ABSTRACT_ANIMAL),
-        SHEEP(61, ABSTRACT_ANIMAL),
-        TURTLE(77, ABSTRACT_ANIMAL),
-        FOX(27, ABSTRACT_ANIMAL),
-
-        ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
-        CAT(6, ABSTRACT_TAMEABLE_ANIMAL),
-        OCELOT(50, ABSTRACT_TAMEABLE_ANIMAL),
-        WOLF(93, ABSTRACT_TAMEABLE_ANIMAL),
-
-        ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
-        PARROT(53, ABSTRACT_PARROT),
-
-        // Horses
-        ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
-        CHESTED_HORSE(-1, ABSTRACT_HORSE),
-        DONKEY(12, CHESTED_HORSE),
-        MULE(48, CHESTED_HORSE),
-        LLAMA(38, CHESTED_HORSE),
-        TRADER_LLAMA(75, CHESTED_HORSE),
-        HORSE(31, ABSTRACT_HORSE),
-        SKELETON_HORSE(66, ABSTRACT_HORSE),
-        ZOMBIE_HORSE(95, ABSTRACT_HORSE),
-
-        // Golem
-        ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
-        SNOW_GOLEM(69, ABSTRACT_GOLEM),
-        IRON_GOLEM(85, ABSTRACT_GOLEM),
-        SHULKER(62, ABSTRACT_GOLEM),
-
-        // Fish
-        ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
-        COD(9, ABSTRACT_FISHES),
-        PUFFERFISH(55, ABSTRACT_FISHES),
-        SALMON(60, ABSTRACT_FISHES),
-        TROPICAL_FISH(76, ABSTRACT_FISHES),
-
-        // Monsters
-        ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
-        BLAZE(4, ABSTRACT_MONSTER),
-        CREEPER(11, ABSTRACT_MONSTER),
-        ENDERMITE(20, ABSTRACT_MONSTER),
-        ENDERMAN(19, ABSTRACT_MONSTER),
-        GIANT(29, ABSTRACT_MONSTER),
-        SILVERFISH(64, ABSTRACT_MONSTER),
-        VEX(83, ABSTRACT_MONSTER),
-        WITCH(89, ABSTRACT_MONSTER),
-        WITHER(90, ABSTRACT_MONSTER),
-        RAVAGER(98, ABSTRACT_MONSTER),
-
-        // Illagers
-        ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
-        ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
-        EVOKER(22, ABSTRACT_EVO_ILLU_ILLAGER),
-        ILLUSIONER(33, ABSTRACT_EVO_ILLU_ILLAGER),
-        VINDICATOR(86, ABSTRACT_ILLAGER_BASE),
-        PILLAGER(87, ABSTRACT_ILLAGER_BASE),
-
-        // Skeletons
-        ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
-        SKELETON(65, ABSTRACT_SKELETON),
-        STRAY(74, ABSTRACT_SKELETON),
-        WITHER_SKELETON(91, ABSTRACT_SKELETON),
-
-        // Guardians
-        GUARDIAN(30, ABSTRACT_MONSTER),
-        ELDER_GUARDIAN(16, GUARDIAN),
-
-        // Spiders
-        SPIDER(72, ABSTRACT_MONSTER),
-        CAVE_SPIDER(7, SPIDER),
-
-        // Zombies - META CHECKED
-        ZOMBIE(94, ABSTRACT_MONSTER),
-        DROWNED(15, ZOMBIE),
-        HUSK(32, ZOMBIE),
-        ZOMBIE_PIGMAN(56, ZOMBIE),
-        ZOMBIE_VILLAGER(96, ZOMBIE),
-
-        // Flying entities
-        ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
-        GHAST(28, ABSTRACT_FLYING),
-        PHANTOM(97, ABSTRACT_FLYING),
-
-        ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
-        BAT(3, ABSTRACT_AMBIENT),
-
-        ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
-        SQUID(73, ABSTRACT_WATERMOB),
-
-        // Slimes
-        SLIME(67, ABSTRACT_INSENTIENT),
-        MAGMA_CUBE(40, SLIME),
-
-        // Hangable objects
-        ABSTRACT_HANGING(-1, ENTITY),
-        LEASH_KNOT(37, ABSTRACT_HANGING),
-        ITEM_FRAME(35, ABSTRACT_HANGING),
-        PAINTING(51, ABSTRACT_HANGING),
-
-        ABSTRACT_LIGHTNING(-1, ENTITY),
-        LIGHTNING_BOLT(99, ABSTRACT_LIGHTNING),
-
-        // Arrows
-        ABSTRACT_ARROW(-1, ENTITY),
-        ARROW(2, ABSTRACT_ARROW),
-        SPECTRAL_ARROW(71, ABSTRACT_ARROW),
-        TRIDENT(82, ABSTRACT_ARROW),
-
-        // Fireballs
-        ABSTRACT_FIREBALL(-1, ENTITY),
-        DRAGON_FIREBALL(14, ABSTRACT_FIREBALL),
-        FIREBALL(36, ABSTRACT_FIREBALL),
-        SMALL_FIREBALL(68, ABSTRACT_FIREBALL),
-        WITHER_SKULL(92, ABSTRACT_FIREBALL),
-
-        // Projectiles
-        PROJECTILE_ABSTRACT(-1, ENTITY),
-        SNOWBALL(70, PROJECTILE_ABSTRACT),
-        ENDER_PEARL(79, PROJECTILE_ABSTRACT),
-        EGG(78, PROJECTILE_ABSTRACT),
-        POTION(81, PROJECTILE_ABSTRACT),
-        EXPERIENCE_BOTTLE(80, PROJECTILE_ABSTRACT),
-
-        // Vehicles
-        MINECART_ABSTRACT(-1, ENTITY),
-        CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
-        CHEST_MINECART(42, CHESTED_MINECART_ABSTRACT),
-        HOPPER_MINECART(45, CHESTED_MINECART_ABSTRACT),
-        MINECART(41, MINECART_ABSTRACT),
-        FURNACE_MINECART(44, MINECART_ABSTRACT),
-        COMMAND_BLOCK_MINECART(43, MINECART_ABSTRACT),
-        TNT_MINECART(47, MINECART_ABSTRACT),
-        SPAWNER_MINECART(46, MINECART_ABSTRACT),
-        BOAT(5, ENTITY),
-        ;
-
-        private static final Map<Integer, EntityType> TYPES = new HashMap<>();
-
-        private final int id;
-        private final EntityType parent;
-
-        EntityType(int id) {
-            this.id = id;
-            this.parent = null;
-        }
-
-        EntityType(int id, EntityType parent) {
-            this.id = id;
-            this.parent = parent;
-        }
-
-        @Override
-        public int getId() {
-            return id;
-        }
-
-        @Override
-        public EntityType getParent() {
-            return parent;
-        }
-
-        static {
-            for (EntityType type : EntityType.values()) {
-                TYPES.put(type.id, type);
+    static {
+        List<Entity1_14Types> types = new ArrayList<>();
+        for (Entity1_14Types type : values()) {
+            if (type.id != -1) {
+                types.add(type);
             }
         }
 
-        public static Optional<EntityType> findById(int id) {
-            if (id == -1)
-                return Optional.empty();
-            return Optional.ofNullable(TYPES.get(id));
+        types.sort(Comparator.comparingInt(Entity1_14Types::getId));
+        TYPES = types.toArray(new EntityType[0]);
+    }
+
+    public static EntityType getTypeFromId(int typeId) {
+        EntityType type;
+        if (typeId < 0 || typeId >= TYPES.length || (type = TYPES[typeId]) == null) {
+            Via.getPlatform().getLogger().severe("Could not find 1.14 type id " + typeId);
+            return ENTITY;
         }
+        return type;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_15Types.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_15Types.java
@@ -2,235 +2,230 @@ package us.myles.ViaVersion.api.entities;
 
 import us.myles.ViaVersion.api.Via;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
+public enum Entity1_15Types implements EntityType {
 
-public class Entity1_15Types {
+    ENTITY(-1),
 
-    public static EntityType getTypeFromId(int typeID) {
-        Optional<EntityType> type = EntityType.findById(typeID);
+    AREA_EFFECT_CLOUD(0, ENTITY),
+    END_CRYSTAL(18, ENTITY),
+    EVOKER_FANGS(22, ENTITY),
+    EXPERIENCE_ORB(24, ENTITY),
+    EYE_OF_ENDER(25, ENTITY),
+    FALLING_BLOCK(26, ENTITY),
+    FIREWORK_ROCKET(27, ENTITY),
+    ITEM(35, ENTITY),
+    LLAMA_SPIT(40, ENTITY),
+    TNT(59, ENTITY),
+    SHULKER_BULLET(64, ENTITY),
+    FISHING_BOBBER(102, ENTITY),
 
-        if (!type.isPresent()) {
-            Via.getPlatform().getLogger().severe("Could not find 1.15 type id " + typeID);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
-        }
+    LIVINGENTITY(-1, ENTITY),
+    ARMOR_STAND(1, LIVINGENTITY),
+    PLAYER(101, LIVINGENTITY),
 
-        return type.get();
+    ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
+    ENDER_DRAGON(19, ABSTRACT_INSENTIENT),
+
+    BEE(4, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
+    VILLAGER(85, ABSTRACT_AGEABLE),
+    WANDERING_TRADER(89, ABSTRACT_AGEABLE),
+
+    // Animals
+    ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
+    DOLPHIN(14, ABSTRACT_INSENTIENT),
+    CHICKEN(9, ABSTRACT_ANIMAL),
+    COW(11, ABSTRACT_ANIMAL),
+    MOOSHROOM(50, COW),
+    PANDA(53, ABSTRACT_INSENTIENT),
+    PIG(55, ABSTRACT_ANIMAL),
+    POLAR_BEAR(58, ABSTRACT_ANIMAL),
+    RABBIT(60, ABSTRACT_ANIMAL),
+    SHEEP(62, ABSTRACT_ANIMAL),
+    TURTLE(78, ABSTRACT_ANIMAL),
+    FOX(28, ABSTRACT_ANIMAL),
+
+    ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
+    CAT(7, ABSTRACT_TAMEABLE_ANIMAL),
+    OCELOT(51, ABSTRACT_TAMEABLE_ANIMAL),
+    WOLF(94, ABSTRACT_TAMEABLE_ANIMAL),
+
+    ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
+    PARROT(54, ABSTRACT_PARROT),
+
+    // Horses
+    ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
+    CHESTED_HORSE(-1, ABSTRACT_HORSE),
+    DONKEY(13, CHESTED_HORSE),
+    MULE(49, CHESTED_HORSE),
+    LLAMA(39, CHESTED_HORSE),
+    TRADER_LLAMA(76, CHESTED_HORSE),
+    HORSE(32, ABSTRACT_HORSE),
+    SKELETON_HORSE(67, ABSTRACT_HORSE),
+    ZOMBIE_HORSE(96, ABSTRACT_HORSE),
+
+    // Golem
+    ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
+    SNOW_GOLEM(70, ABSTRACT_GOLEM),
+    IRON_GOLEM(86, ABSTRACT_GOLEM),
+    SHULKER(63, ABSTRACT_GOLEM),
+
+    // Fish
+    ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
+    COD(10, ABSTRACT_FISHES),
+    PUFFERFISH(56, ABSTRACT_FISHES),
+    SALMON(61, ABSTRACT_FISHES),
+    TROPICAL_FISH(77, ABSTRACT_FISHES),
+
+    // Monsters
+    ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
+    BLAZE(5, ABSTRACT_MONSTER),
+    CREEPER(12, ABSTRACT_MONSTER),
+    ENDERMITE(21, ABSTRACT_MONSTER),
+    ENDERMAN(20, ABSTRACT_MONSTER),
+    GIANT(30, ABSTRACT_MONSTER),
+    SILVERFISH(65, ABSTRACT_MONSTER),
+    VEX(84, ABSTRACT_MONSTER),
+    WITCH(90, ABSTRACT_MONSTER),
+    WITHER(91, ABSTRACT_MONSTER),
+    RAVAGER(99, ABSTRACT_MONSTER),
+
+    // Illagers
+    ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
+    ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
+    EVOKER(23, ABSTRACT_EVO_ILLU_ILLAGER),
+    ILLUSIONER(34, ABSTRACT_EVO_ILLU_ILLAGER),
+    VINDICATOR(87, ABSTRACT_ILLAGER_BASE),
+    PILLAGER(88, ABSTRACT_ILLAGER_BASE),
+
+    // Skeletons
+    ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
+    SKELETON(66, ABSTRACT_SKELETON),
+    STRAY(75, ABSTRACT_SKELETON),
+    WITHER_SKELETON(92, ABSTRACT_SKELETON),
+
+    // Guardians
+    GUARDIAN(31, ABSTRACT_MONSTER),
+    ELDER_GUARDIAN(17, GUARDIAN),
+
+    // Spiders
+    SPIDER(73, ABSTRACT_MONSTER),
+    CAVE_SPIDER(8, SPIDER),
+
+    // Zombies
+    ZOMBIE(95, ABSTRACT_MONSTER),
+    DROWNED(16, ZOMBIE),
+    HUSK(33, ZOMBIE),
+    ZOMBIE_PIGMAN(57, ZOMBIE),
+    ZOMBIE_VILLAGER(97, ZOMBIE),
+
+    // Flying entities
+    ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
+    GHAST(29, ABSTRACT_FLYING),
+    PHANTOM(98, ABSTRACT_FLYING),
+
+    ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
+    BAT(3, ABSTRACT_AMBIENT),
+
+    ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
+    SQUID(74, ABSTRACT_WATERMOB),
+
+    // Slimes
+    SLIME(68, ABSTRACT_INSENTIENT),
+    MAGMA_CUBE(41, SLIME),
+
+    // Hangable objects
+    ABSTRACT_HANGING(-1, ENTITY),
+    LEASH_KNOT(38, ABSTRACT_HANGING),
+    ITEM_FRAME(36, ABSTRACT_HANGING),
+    PAINTING(52, ABSTRACT_HANGING),
+
+    ABSTRACT_LIGHTNING(-1, ENTITY),
+    LIGHTNING_BOLT(100, ABSTRACT_LIGHTNING),
+
+    // Arrows
+    ABSTRACT_ARROW(-1, ENTITY),
+    ARROW(2, ABSTRACT_ARROW),
+    SPECTRAL_ARROW(72, ABSTRACT_ARROW),
+    TRIDENT(83, ABSTRACT_ARROW),
+
+    // Fireballs
+    ABSTRACT_FIREBALL(-1, ENTITY),
+    DRAGON_FIREBALL(15, ABSTRACT_FIREBALL),
+    FIREBALL(37, ABSTRACT_FIREBALL),
+    SMALL_FIREBALL(69, ABSTRACT_FIREBALL),
+    WITHER_SKULL(93, ABSTRACT_FIREBALL),
+
+    // Projectiles
+    PROJECTILE_ABSTRACT(-1, ENTITY),
+    SNOWBALL(71, PROJECTILE_ABSTRACT),
+    ENDER_PEARL(80, PROJECTILE_ABSTRACT),
+    EGG(79, PROJECTILE_ABSTRACT),
+    POTION(82, PROJECTILE_ABSTRACT),
+    EXPERIENCE_BOTTLE(81, PROJECTILE_ABSTRACT),
+
+    // Vehicles
+    MINECART_ABSTRACT(-1, ENTITY),
+    CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
+    CHEST_MINECART(43, CHESTED_MINECART_ABSTRACT),
+    HOPPER_MINECART(46, CHESTED_MINECART_ABSTRACT),
+    MINECART(42, MINECART_ABSTRACT),
+    FURNACE_MINECART(45, MINECART_ABSTRACT),
+    COMMAND_BLOCK_MINECART(44, MINECART_ABSTRACT),
+    TNT_MINECART(48, MINECART_ABSTRACT),
+    SPAWNER_MINECART(47, MINECART_ABSTRACT),
+    BOAT(6, ENTITY);
+
+    private static final EntityType[] TYPES;
+
+    private final int id;
+    private final EntityType parent;
+
+    Entity1_15Types(int id) {
+        this.id = id;
+        this.parent = null;
     }
 
-    public enum EntityType implements us.myles.ViaVersion.api.entities.EntityType {
-        ENTITY(-1),
+    Entity1_15Types(int id, EntityType parent) {
+        this.id = id;
+        this.parent = parent;
+    }
 
-        AREA_EFFECT_CLOUD(0, ENTITY),
-        END_CRYSTAL(18, ENTITY),
-        EVOKER_FANGS(22, ENTITY),
-        EXPERIENCE_ORB(24, ENTITY),
-        EYE_OF_ENDER(25, ENTITY),
-        FALLING_BLOCK(26, ENTITY),
-        FIREWORK_ROCKET(27, ENTITY),
-        ITEM(35, ENTITY),
-        LLAMA_SPIT(40, ENTITY),
-        TNT(59, ENTITY),
-        SHULKER_BULLET(64, ENTITY),
-        FISHING_BOBBER(102, ENTITY),
+    @Override
+    public int getId() {
+        return id;
+    }
 
-        LIVINGENTITY(-1, ENTITY),
-        ARMOR_STAND(1, LIVINGENTITY),
-        PLAYER(101, LIVINGENTITY),
+    @Override
+    public EntityType getParent() {
+        return parent;
+    }
 
-        ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
-        ENDER_DRAGON(19, ABSTRACT_INSENTIENT),
-
-        BEE(4, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
-        VILLAGER(85, ABSTRACT_AGEABLE),
-        WANDERING_TRADER(89, ABSTRACT_AGEABLE),
-
-        // Animals
-        ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
-        DOLPHIN(14, ABSTRACT_INSENTIENT),
-        CHICKEN(9, ABSTRACT_ANIMAL),
-        COW(11, ABSTRACT_ANIMAL),
-        MOOSHROOM(50, COW),
-        PANDA(53, ABSTRACT_INSENTIENT),
-        PIG(55, ABSTRACT_ANIMAL),
-        POLAR_BEAR(58, ABSTRACT_ANIMAL),
-        RABBIT(60, ABSTRACT_ANIMAL),
-        SHEEP(62, ABSTRACT_ANIMAL),
-        TURTLE(78, ABSTRACT_ANIMAL),
-        FOX(28, ABSTRACT_ANIMAL),
-
-        ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
-        CAT(7, ABSTRACT_TAMEABLE_ANIMAL),
-        OCELOT(51, ABSTRACT_TAMEABLE_ANIMAL),
-        WOLF(94, ABSTRACT_TAMEABLE_ANIMAL),
-
-        ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
-        PARROT(54, ABSTRACT_PARROT),
-
-        // Horses
-        ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
-        CHESTED_HORSE(-1, ABSTRACT_HORSE),
-        DONKEY(13, CHESTED_HORSE),
-        MULE(49, CHESTED_HORSE),
-        LLAMA(39, CHESTED_HORSE),
-        TRADER_LLAMA(76, CHESTED_HORSE),
-        HORSE(32, ABSTRACT_HORSE),
-        SKELETON_HORSE(67, ABSTRACT_HORSE),
-        ZOMBIE_HORSE(96, ABSTRACT_HORSE),
-
-        // Golem
-        ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
-        SNOW_GOLEM(70, ABSTRACT_GOLEM),
-        IRON_GOLEM(86, ABSTRACT_GOLEM),
-        SHULKER(63, ABSTRACT_GOLEM),
-
-        // Fish
-        ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
-        COD(10, ABSTRACT_FISHES),
-        PUFFERFISH(56, ABSTRACT_FISHES),
-        SALMON(61, ABSTRACT_FISHES),
-        TROPICAL_FISH(77, ABSTRACT_FISHES),
-
-        // Monsters
-        ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
-        BLAZE(5, ABSTRACT_MONSTER),
-        CREEPER(12, ABSTRACT_MONSTER),
-        ENDERMITE(21, ABSTRACT_MONSTER),
-        ENDERMAN(20, ABSTRACT_MONSTER),
-        GIANT(30, ABSTRACT_MONSTER),
-        SILVERFISH(65, ABSTRACT_MONSTER),
-        VEX(84, ABSTRACT_MONSTER),
-        WITCH(90, ABSTRACT_MONSTER),
-        WITHER(91, ABSTRACT_MONSTER),
-        RAVAGER(99, ABSTRACT_MONSTER),
-
-        // Illagers
-        ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
-        ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
-        EVOKER(23, ABSTRACT_EVO_ILLU_ILLAGER),
-        ILLUSIONER(34, ABSTRACT_EVO_ILLU_ILLAGER),
-        VINDICATOR(87, ABSTRACT_ILLAGER_BASE),
-        PILLAGER(88, ABSTRACT_ILLAGER_BASE),
-
-        // Skeletons
-        ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
-        SKELETON(66, ABSTRACT_SKELETON),
-        STRAY(75, ABSTRACT_SKELETON),
-        WITHER_SKELETON(92, ABSTRACT_SKELETON),
-
-        // Guardians
-        GUARDIAN(31, ABSTRACT_MONSTER),
-        ELDER_GUARDIAN(17, GUARDIAN),
-
-        // Spiders
-        SPIDER(73, ABSTRACT_MONSTER),
-        CAVE_SPIDER(8, SPIDER),
-
-        // Zombies
-        ZOMBIE(95, ABSTRACT_MONSTER),
-        DROWNED(16, ZOMBIE),
-        HUSK(33, ZOMBIE),
-        ZOMBIE_PIGMAN(57, ZOMBIE),
-        ZOMBIE_VILLAGER(97, ZOMBIE),
-
-        // Flying entities
-        ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
-        GHAST(29, ABSTRACT_FLYING),
-        PHANTOM(98, ABSTRACT_FLYING),
-
-        ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
-        BAT(3, ABSTRACT_AMBIENT),
-
-        ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
-        SQUID(74, ABSTRACT_WATERMOB),
-
-        // Slimes
-        SLIME(68, ABSTRACT_INSENTIENT),
-        MAGMA_CUBE(41, SLIME),
-
-        // Hangable objects
-        ABSTRACT_HANGING(-1, ENTITY),
-        LEASH_KNOT(38, ABSTRACT_HANGING),
-        ITEM_FRAME(36, ABSTRACT_HANGING),
-        PAINTING(52, ABSTRACT_HANGING),
-
-        ABSTRACT_LIGHTNING(-1, ENTITY),
-        LIGHTNING_BOLT(100, ABSTRACT_LIGHTNING),
-
-        // Arrows
-        ABSTRACT_ARROW(-1, ENTITY),
-        ARROW(2, ABSTRACT_ARROW),
-        SPECTRAL_ARROW(72, ABSTRACT_ARROW),
-        TRIDENT(83, ABSTRACT_ARROW),
-
-        // Fireballs
-        ABSTRACT_FIREBALL(-1, ENTITY),
-        DRAGON_FIREBALL(15, ABSTRACT_FIREBALL),
-        FIREBALL(37, ABSTRACT_FIREBALL),
-        SMALL_FIREBALL(69, ABSTRACT_FIREBALL),
-        WITHER_SKULL(93, ABSTRACT_FIREBALL),
-
-        // Projectiles
-        PROJECTILE_ABSTRACT(-1, ENTITY),
-        SNOWBALL(71, PROJECTILE_ABSTRACT),
-        ENDER_PEARL(80, PROJECTILE_ABSTRACT),
-        EGG(79, PROJECTILE_ABSTRACT),
-        POTION(82, PROJECTILE_ABSTRACT),
-        EXPERIENCE_BOTTLE(81, PROJECTILE_ABSTRACT),
-
-        // Vehicles
-        MINECART_ABSTRACT(-1, ENTITY),
-        CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
-        CHEST_MINECART(43, CHESTED_MINECART_ABSTRACT),
-        HOPPER_MINECART(46, CHESTED_MINECART_ABSTRACT),
-        MINECART(42, MINECART_ABSTRACT),
-        FURNACE_MINECART(45, MINECART_ABSTRACT),
-        COMMAND_BLOCK_MINECART(44, MINECART_ABSTRACT),
-        TNT_MINECART(48, MINECART_ABSTRACT),
-        SPAWNER_MINECART(47, MINECART_ABSTRACT),
-        BOAT(6, ENTITY);
-
-        private static final Map<Integer, EntityType> TYPES = new HashMap<>();
-
-        private final int id;
-        private final EntityType parent;
-
-        EntityType(int id) {
-            this.id = id;
-            this.parent = null;
-        }
-
-        EntityType(int id, EntityType parent) {
-            this.id = id;
-            this.parent = parent;
-        }
-
-        @Override
-        public int getId() {
-            return id;
-        }
-
-        @Override
-        public EntityType getParent() {
-            return parent;
-        }
-
-        static {
-            for (EntityType type : EntityType.values()) {
-                TYPES.put(type.id, type);
+    static {
+        List<Entity1_15Types> types = new ArrayList<>();
+        for (Entity1_15Types type : values()) {
+            if (type.id != -1) {
+                types.add(type);
             }
         }
 
-        public static Optional<EntityType> findById(int id) {
-            if (id == -1)
-                return Optional.empty();
-            return Optional.ofNullable(TYPES.get(id));
+        types.sort(Comparator.comparingInt(Entity1_15Types::getId));
+        TYPES = types.toArray(new EntityType[0]);
+    }
+
+    public static EntityType getTypeFromId(int typeId) {
+        EntityType type;
+        if (typeId < 0 || typeId >= TYPES.length || (type = TYPES[typeId]) == null) {
+            Via.getPlatform().getLogger().severe("Could not find 1.15 type id " + typeId);
+            return ENTITY;
         }
+        return type;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_16Types.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_16Types.java
@@ -2,240 +2,235 @@ package us.myles.ViaVersion.api.entities;
 
 import us.myles.ViaVersion.api.Via;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
+public enum Entity1_16Types implements EntityType {
 
-public class Entity1_16Types {
+    ENTITY(-1),
 
-    public static EntityType getTypeFromId(int typeID) {
-        Optional<EntityType> type = EntityType.findById(typeID);
+    AREA_EFFECT_CLOUD(0, ENTITY),
+    END_CRYSTAL(18, ENTITY),
+    EVOKER_FANGS(23, ENTITY),
+    EXPERIENCE_ORB(24, ENTITY),
+    EYE_OF_ENDER(25, ENTITY),
+    FALLING_BLOCK(26, ENTITY),
+    FIREWORK_ROCKET(27, ENTITY),
+    ITEM(37, ENTITY),
+    LLAMA_SPIT(43, ENTITY),
+    TNT(63, ENTITY),
+    SHULKER_BULLET(70, ENTITY),
+    FISHING_BOBBER(106, ENTITY),
 
-        if (!type.isPresent()) {
-            Via.getPlatform().getLogger().severe("Could not find 1.16 type id " + typeID);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
-        }
+    LIVINGENTITY(-1, ENTITY),
+    ARMOR_STAND(1, LIVINGENTITY),
+    PLAYER(105, LIVINGENTITY),
 
-        return type.get();
+    ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
+    ENDER_DRAGON(19, ABSTRACT_INSENTIENT),
+
+    BEE(4, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
+    VILLAGER(92, ABSTRACT_AGEABLE),
+    WANDERING_TRADER(94, ABSTRACT_AGEABLE),
+
+    // Animals
+    ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
+    DOLPHIN(13, ABSTRACT_INSENTIENT),
+    CHICKEN(9, ABSTRACT_ANIMAL),
+    COW(11, ABSTRACT_ANIMAL),
+    MOOSHROOM(53, COW),
+    PANDA(56, ABSTRACT_INSENTIENT),
+    PIG(59, ABSTRACT_ANIMAL),
+    POLAR_BEAR(62, ABSTRACT_ANIMAL),
+    RABBIT(65, ABSTRACT_ANIMAL),
+    SHEEP(68, ABSTRACT_ANIMAL),
+    TURTLE(90, ABSTRACT_ANIMAL),
+    FOX(28, ABSTRACT_ANIMAL),
+
+    ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
+    CAT(7, ABSTRACT_TAMEABLE_ANIMAL),
+    OCELOT(54, ABSTRACT_TAMEABLE_ANIMAL),
+    WOLF(99, ABSTRACT_TAMEABLE_ANIMAL),
+
+    ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
+    PARROT(57, ABSTRACT_PARROT),
+
+    // Horses
+    ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
+    CHESTED_HORSE(-1, ABSTRACT_HORSE),
+    DONKEY(14, CHESTED_HORSE),
+    MULE(52, CHESTED_HORSE),
+    LLAMA(42, CHESTED_HORSE),
+    TRADER_LLAMA(88, CHESTED_HORSE),
+    HORSE(33, ABSTRACT_HORSE),
+    SKELETON_HORSE(73, ABSTRACT_HORSE),
+    ZOMBIE_HORSE(102, ABSTRACT_HORSE),
+
+    // Golem
+    ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
+    SNOW_GOLEM(76, ABSTRACT_GOLEM),
+    IRON_GOLEM(36, ABSTRACT_GOLEM),
+    SHULKER(69, ABSTRACT_GOLEM),
+
+    // Fish
+    ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
+    COD(10, ABSTRACT_FISHES),
+    PUFFERFISH(64, ABSTRACT_FISHES),
+    SALMON(67, ABSTRACT_FISHES),
+    TROPICAL_FISH(89, ABSTRACT_FISHES),
+
+    // Monsters
+    ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
+    BLAZE(5, ABSTRACT_MONSTER),
+    CREEPER(12, ABSTRACT_MONSTER),
+    ENDERMITE(21, ABSTRACT_MONSTER),
+    ENDERMAN(20, ABSTRACT_MONSTER),
+    GIANT(30, ABSTRACT_MONSTER),
+    SILVERFISH(71, ABSTRACT_MONSTER),
+    VEX(91, ABSTRACT_MONSTER),
+    WITCH(95, ABSTRACT_MONSTER),
+    WITHER(96, ABSTRACT_MONSTER),
+    RAVAGER(66, ABSTRACT_MONSTER),
+    PIGLIN(60, ABSTRACT_MONSTER),
+
+    HOGLIN(32, ABSTRACT_ANIMAL),
+    STRIDER(82, ABSTRACT_ANIMAL),
+    ZOGLIN(100, ABSTRACT_MONSTER),
+
+    // Illagers
+    ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
+    ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
+    EVOKER(22, ABSTRACT_EVO_ILLU_ILLAGER),
+    ILLUSIONER(35, ABSTRACT_EVO_ILLU_ILLAGER),
+    VINDICATOR(93, ABSTRACT_ILLAGER_BASE),
+    PILLAGER(61, ABSTRACT_ILLAGER_BASE),
+
+    // Skeletons
+    ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
+    SKELETON(72, ABSTRACT_SKELETON),
+    STRAY(81, ABSTRACT_SKELETON),
+    WITHER_SKELETON(97, ABSTRACT_SKELETON),
+
+    // Guardians
+    GUARDIAN(31, ABSTRACT_MONSTER),
+    ELDER_GUARDIAN(17, GUARDIAN),
+
+    // Spiders
+    SPIDER(79, ABSTRACT_MONSTER),
+    CAVE_SPIDER(8, SPIDER),
+
+    // Zombies
+    ZOMBIE(101, ABSTRACT_MONSTER),
+    DROWNED(16, ZOMBIE),
+    HUSK(34, ZOMBIE),
+    ZOMBIFIED_PIGLIN(104, ZOMBIE),
+    ZOMBIE_VILLAGER(103, ZOMBIE),
+
+    // Flying entities
+    ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
+    GHAST(29, ABSTRACT_FLYING),
+    PHANTOM(58, ABSTRACT_FLYING),
+
+    ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
+    BAT(3, ABSTRACT_AMBIENT),
+
+    ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
+    SQUID(80, ABSTRACT_WATERMOB),
+
+    // Slimes
+    SLIME(74, ABSTRACT_INSENTIENT),
+    MAGMA_CUBE(44, SLIME),
+
+    // Hangable objects
+    ABSTRACT_HANGING(-1, ENTITY),
+    LEASH_KNOT(40, ABSTRACT_HANGING),
+    ITEM_FRAME(38, ABSTRACT_HANGING),
+    PAINTING(55, ABSTRACT_HANGING),
+
+    ABSTRACT_LIGHTNING(-1, ENTITY),
+    LIGHTNING_BOLT(41, ABSTRACT_LIGHTNING),
+
+    // Arrows
+    ABSTRACT_ARROW(-1, ENTITY),
+    ARROW(2, ABSTRACT_ARROW),
+    SPECTRAL_ARROW(78, ABSTRACT_ARROW),
+    TRIDENT(87, ABSTRACT_ARROW),
+
+    // Fireballs
+    ABSTRACT_FIREBALL(-1, ENTITY),
+    DRAGON_FIREBALL(15, ABSTRACT_FIREBALL),
+    FIREBALL(39, ABSTRACT_FIREBALL),
+    SMALL_FIREBALL(75, ABSTRACT_FIREBALL),
+    WITHER_SKULL(98, ABSTRACT_FIREBALL),
+
+    // Projectiles
+    PROJECTILE_ABSTRACT(-1, ENTITY),
+    SNOWBALL(77, PROJECTILE_ABSTRACT),
+    ENDER_PEARL(84, PROJECTILE_ABSTRACT),
+    EGG(83, PROJECTILE_ABSTRACT),
+    POTION(86, PROJECTILE_ABSTRACT),
+    EXPERIENCE_BOTTLE(85, PROJECTILE_ABSTRACT),
+
+    // Vehicles
+    MINECART_ABSTRACT(-1, ENTITY),
+    CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
+    CHEST_MINECART(46, CHESTED_MINECART_ABSTRACT),
+    HOPPER_MINECART(49, CHESTED_MINECART_ABSTRACT),
+    MINECART(45, MINECART_ABSTRACT),
+    FURNACE_MINECART(48, MINECART_ABSTRACT),
+    COMMAND_BLOCK_MINECART(47, MINECART_ABSTRACT),
+    TNT_MINECART(51, MINECART_ABSTRACT),
+    SPAWNER_MINECART(50, MINECART_ABSTRACT),
+    BOAT(6, ENTITY);
+
+    private static final EntityType[] TYPES;
+
+    private final int id;
+    private final EntityType parent;
+
+    Entity1_16Types(int id) {
+        this.id = id;
+        this.parent = null;
     }
 
-    public enum EntityType implements us.myles.ViaVersion.api.entities.EntityType {
-        ENTITY(-1),
+    Entity1_16Types(int id, EntityType parent) {
+        this.id = id;
+        this.parent = parent;
+    }
 
-        AREA_EFFECT_CLOUD(0, ENTITY),
-        END_CRYSTAL(18, ENTITY),
-        EVOKER_FANGS(23, ENTITY),
-        EXPERIENCE_ORB(24, ENTITY),
-        EYE_OF_ENDER(25, ENTITY),
-        FALLING_BLOCK(26, ENTITY),
-        FIREWORK_ROCKET(27, ENTITY),
-        ITEM(37, ENTITY),
-        LLAMA_SPIT(43, ENTITY),
-        TNT(63, ENTITY),
-        SHULKER_BULLET(70, ENTITY),
-        FISHING_BOBBER(106, ENTITY),
+    @Override
+    public int getId() {
+        return id;
+    }
 
-        LIVINGENTITY(-1, ENTITY),
-        ARMOR_STAND(1, LIVINGENTITY),
-        PLAYER(105, LIVINGENTITY),
+    @Override
+    public EntityType getParent() {
+        return parent;
+    }
 
-        ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
-        ENDER_DRAGON(19, ABSTRACT_INSENTIENT),
-
-        BEE(4, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
-        VILLAGER(92, ABSTRACT_AGEABLE),
-        WANDERING_TRADER(94, ABSTRACT_AGEABLE),
-
-        // Animals
-        ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
-        DOLPHIN(13, ABSTRACT_INSENTIENT),
-        CHICKEN(9, ABSTRACT_ANIMAL),
-        COW(11, ABSTRACT_ANIMAL),
-        MOOSHROOM(53, COW),
-        PANDA(56, ABSTRACT_INSENTIENT),
-        PIG(59, ABSTRACT_ANIMAL),
-        POLAR_BEAR(62, ABSTRACT_ANIMAL),
-        RABBIT(65, ABSTRACT_ANIMAL),
-        SHEEP(68, ABSTRACT_ANIMAL),
-        TURTLE(90, ABSTRACT_ANIMAL),
-        FOX(28, ABSTRACT_ANIMAL),
-
-        ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
-        CAT(7, ABSTRACT_TAMEABLE_ANIMAL),
-        OCELOT(54, ABSTRACT_TAMEABLE_ANIMAL),
-        WOLF(99, ABSTRACT_TAMEABLE_ANIMAL),
-
-        ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
-        PARROT(57, ABSTRACT_PARROT),
-
-        // Horses
-        ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
-        CHESTED_HORSE(-1, ABSTRACT_HORSE),
-        DONKEY(14, CHESTED_HORSE),
-        MULE(52, CHESTED_HORSE),
-        LLAMA(42, CHESTED_HORSE),
-        TRADER_LLAMA(88, CHESTED_HORSE),
-        HORSE(33, ABSTRACT_HORSE),
-        SKELETON_HORSE(73, ABSTRACT_HORSE),
-        ZOMBIE_HORSE(102, ABSTRACT_HORSE),
-
-        // Golem
-        ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
-        SNOW_GOLEM(76, ABSTRACT_GOLEM),
-        IRON_GOLEM(36, ABSTRACT_GOLEM),
-        SHULKER(69, ABSTRACT_GOLEM),
-
-        // Fish
-        ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
-        COD(10, ABSTRACT_FISHES),
-        PUFFERFISH(64, ABSTRACT_FISHES),
-        SALMON(67, ABSTRACT_FISHES),
-        TROPICAL_FISH(89, ABSTRACT_FISHES),
-
-        // Monsters
-        ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
-        BLAZE(5, ABSTRACT_MONSTER),
-        CREEPER(12, ABSTRACT_MONSTER),
-        ENDERMITE(21, ABSTRACT_MONSTER),
-        ENDERMAN(20, ABSTRACT_MONSTER),
-        GIANT(30, ABSTRACT_MONSTER),
-        SILVERFISH(71, ABSTRACT_MONSTER),
-        VEX(91, ABSTRACT_MONSTER),
-        WITCH(95, ABSTRACT_MONSTER),
-        WITHER(96, ABSTRACT_MONSTER),
-        RAVAGER(66, ABSTRACT_MONSTER),
-        PIGLIN(60, ABSTRACT_MONSTER),
-
-        HOGLIN(32, ABSTRACT_ANIMAL),
-        STRIDER(82, ABSTRACT_ANIMAL),
-        ZOGLIN(100, ABSTRACT_MONSTER),
-
-        // Illagers
-        ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
-        ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
-        EVOKER(22, ABSTRACT_EVO_ILLU_ILLAGER),
-        ILLUSIONER(35, ABSTRACT_EVO_ILLU_ILLAGER),
-        VINDICATOR(93, ABSTRACT_ILLAGER_BASE),
-        PILLAGER(61, ABSTRACT_ILLAGER_BASE),
-
-        // Skeletons
-        ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
-        SKELETON(72, ABSTRACT_SKELETON),
-        STRAY(81, ABSTRACT_SKELETON),
-        WITHER_SKELETON(97, ABSTRACT_SKELETON),
-
-        // Guardians
-        GUARDIAN(31, ABSTRACT_MONSTER),
-        ELDER_GUARDIAN(17, GUARDIAN),
-
-        // Spiders
-        SPIDER(79, ABSTRACT_MONSTER),
-        CAVE_SPIDER(8, SPIDER),
-
-        // Zombies
-        ZOMBIE(101, ABSTRACT_MONSTER),
-        DROWNED(16, ZOMBIE),
-        HUSK(34, ZOMBIE),
-        ZOMBIFIED_PIGLIN(104, ZOMBIE),
-        ZOMBIE_VILLAGER(103, ZOMBIE),
-
-        // Flying entities
-        ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
-        GHAST(29, ABSTRACT_FLYING),
-        PHANTOM(58, ABSTRACT_FLYING),
-
-        ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
-        BAT(3, ABSTRACT_AMBIENT),
-
-        ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
-        SQUID(80, ABSTRACT_WATERMOB),
-
-        // Slimes
-        SLIME(74, ABSTRACT_INSENTIENT),
-        MAGMA_CUBE(44, SLIME),
-
-        // Hangable objects
-        ABSTRACT_HANGING(-1, ENTITY),
-        LEASH_KNOT(40, ABSTRACT_HANGING),
-        ITEM_FRAME(38, ABSTRACT_HANGING),
-        PAINTING(55, ABSTRACT_HANGING),
-
-        ABSTRACT_LIGHTNING(-1, ENTITY),
-        LIGHTNING_BOLT(41, ABSTRACT_LIGHTNING),
-
-        // Arrows
-        ABSTRACT_ARROW(-1, ENTITY),
-        ARROW(2, ABSTRACT_ARROW),
-        SPECTRAL_ARROW(78, ABSTRACT_ARROW),
-        TRIDENT(87, ABSTRACT_ARROW),
-
-        // Fireballs
-        ABSTRACT_FIREBALL(-1, ENTITY),
-        DRAGON_FIREBALL(15, ABSTRACT_FIREBALL),
-        FIREBALL(39, ABSTRACT_FIREBALL),
-        SMALL_FIREBALL(75, ABSTRACT_FIREBALL),
-        WITHER_SKULL(98, ABSTRACT_FIREBALL),
-
-        // Projectiles
-        PROJECTILE_ABSTRACT(-1, ENTITY),
-        SNOWBALL(77, PROJECTILE_ABSTRACT),
-        ENDER_PEARL(84, PROJECTILE_ABSTRACT),
-        EGG(83, PROJECTILE_ABSTRACT),
-        POTION(86, PROJECTILE_ABSTRACT),
-        EXPERIENCE_BOTTLE(85, PROJECTILE_ABSTRACT),
-
-        // Vehicles
-        MINECART_ABSTRACT(-1, ENTITY),
-        CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
-        CHEST_MINECART(46, CHESTED_MINECART_ABSTRACT),
-        HOPPER_MINECART(49, CHESTED_MINECART_ABSTRACT),
-        MINECART(45, MINECART_ABSTRACT),
-        FURNACE_MINECART(48, MINECART_ABSTRACT),
-        COMMAND_BLOCK_MINECART(47, MINECART_ABSTRACT),
-        TNT_MINECART(51, MINECART_ABSTRACT),
-        SPAWNER_MINECART(50, MINECART_ABSTRACT),
-        BOAT(6, ENTITY);
-
-        private static final Map<Integer, EntityType> TYPES = new HashMap<>();
-
-        private final int id;
-        private final EntityType parent;
-
-        EntityType(int id) {
-            this.id = id;
-            this.parent = null;
-        }
-
-        EntityType(int id, EntityType parent) {
-            this.id = id;
-            this.parent = parent;
-        }
-
-        @Override
-        public int getId() {
-            return id;
-        }
-
-        @Override
-        public EntityType getParent() {
-            return parent;
-        }
-
-        static {
-            for (EntityType type : EntityType.values()) {
-                TYPES.put(type.id, type);
+    static {
+        List<Entity1_16Types> types = new ArrayList<>();
+        for (Entity1_16Types type : values()) {
+            if (type.id != -1) {
+                types.add(type);
             }
         }
 
-        public static Optional<EntityType> findById(int id) {
-            if (id == -1)
-                return Optional.empty();
-            return Optional.ofNullable(TYPES.get(id));
+        types.sort(Comparator.comparingInt(Entity1_16Types::getId));
+        TYPES = types.toArray(new EntityType[0]);
+    }
+
+    public static us.myles.ViaVersion.api.entities.EntityType getTypeFromId(int typeId) {
+        us.myles.ViaVersion.api.entities.EntityType type;
+        if (typeId < 0 || typeId >= TYPES.length || (type = TYPES[typeId]) == null) {
+            Via.getPlatform().getLogger().severe("Could not find 1.16 type id " + typeId);
+            return ENTITY;
         }
+        return type;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_16_2Types.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_16_2Types.java
@@ -2,242 +2,239 @@ package us.myles.ViaVersion.api.entities;
 
 import us.myles.ViaVersion.api.Via;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
+public enum Entity1_16_2Types implements EntityType {
 
-public class Entity1_16_2Types {
+    ENTITY(-1),
 
-    public static EntityType getTypeFromId(int typeID) {
-        Optional<EntityType> type = EntityType.findById(typeID);
-        if (!type.isPresent()) {
-            Via.getPlatform().getLogger().severe("Could not find 1.16.2 type id " + typeID);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
-        }
-        return type.get();
+    AREA_EFFECT_CLOUD(0, ENTITY),
+    END_CRYSTAL(18, ENTITY),
+    EVOKER_FANGS(23, ENTITY),
+    EXPERIENCE_ORB(24, ENTITY),
+    EYE_OF_ENDER(25, ENTITY),
+    FALLING_BLOCK(26, ENTITY),
+    FIREWORK_ROCKET(27, ENTITY),
+    ITEM(37, ENTITY),
+    LLAMA_SPIT(43, ENTITY),
+    TNT(64, ENTITY),
+    SHULKER_BULLET(71, ENTITY),
+    FISHING_BOBBER(107, ENTITY),
+
+    LIVINGENTITY(-1, ENTITY),
+    ARMOR_STAND(1, LIVINGENTITY),
+    PLAYER(106, LIVINGENTITY),
+
+    ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
+    ENDER_DRAGON(19, ABSTRACT_INSENTIENT),
+
+    BEE(4, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
+    VILLAGER(93, ABSTRACT_AGEABLE),
+    WANDERING_TRADER(95, ABSTRACT_AGEABLE),
+
+    // Animals
+    ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
+    DOLPHIN(13, ABSTRACT_INSENTIENT),
+    CHICKEN(9, ABSTRACT_ANIMAL),
+    COW(11, ABSTRACT_ANIMAL),
+    MOOSHROOM(53, COW),
+    PANDA(56, ABSTRACT_INSENTIENT),
+    PIG(59, ABSTRACT_ANIMAL),
+    POLAR_BEAR(63, ABSTRACT_ANIMAL),
+    RABBIT(66, ABSTRACT_ANIMAL),
+    SHEEP(69, ABSTRACT_ANIMAL),
+    TURTLE(91, ABSTRACT_ANIMAL),
+    FOX(28, ABSTRACT_ANIMAL),
+
+    ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
+    CAT(7, ABSTRACT_TAMEABLE_ANIMAL),
+    OCELOT(54, ABSTRACT_TAMEABLE_ANIMAL),
+    WOLF(100, ABSTRACT_TAMEABLE_ANIMAL),
+
+    ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
+    PARROT(57, ABSTRACT_PARROT),
+
+    // Horses
+    ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
+    CHESTED_HORSE(-1, ABSTRACT_HORSE),
+    DONKEY(14, CHESTED_HORSE),
+    MULE(52, CHESTED_HORSE),
+    LLAMA(42, CHESTED_HORSE),
+    TRADER_LLAMA(89, CHESTED_HORSE),
+    HORSE(33, ABSTRACT_HORSE),
+    SKELETON_HORSE(74, ABSTRACT_HORSE),
+    ZOMBIE_HORSE(103, ABSTRACT_HORSE),
+
+    // Golem
+    ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
+    SNOW_GOLEM(77, ABSTRACT_GOLEM),
+    IRON_GOLEM(36, ABSTRACT_GOLEM),
+    SHULKER(70, ABSTRACT_GOLEM),
+
+    // Fish
+    ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
+    COD(10, ABSTRACT_FISHES),
+    PUFFERFISH(65, ABSTRACT_FISHES),
+    SALMON(68, ABSTRACT_FISHES),
+    TROPICAL_FISH(90, ABSTRACT_FISHES),
+
+    // Monsters
+    ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
+    BLAZE(5, ABSTRACT_MONSTER),
+    CREEPER(12, ABSTRACT_MONSTER),
+    ENDERMITE(21, ABSTRACT_MONSTER),
+    ENDERMAN(20, ABSTRACT_MONSTER),
+    GIANT(30, ABSTRACT_MONSTER),
+    SILVERFISH(72, ABSTRACT_MONSTER),
+    VEX(92, ABSTRACT_MONSTER),
+    WITCH(96, ABSTRACT_MONSTER),
+    WITHER(97, ABSTRACT_MONSTER),
+    RAVAGER(67, ABSTRACT_MONSTER),
+
+    ABSTRACT_PIGLIN(-1, ABSTRACT_MONSTER),
+
+    PIGLIN(60, ABSTRACT_PIGLIN),
+    PIGLIN_BRUTE(61, ABSTRACT_PIGLIN),
+
+    HOGLIN(32, ABSTRACT_ANIMAL),
+    STRIDER(83, ABSTRACT_ANIMAL),
+    ZOGLIN(101, ABSTRACT_MONSTER),
+
+    // Illagers
+    ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
+    ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
+    EVOKER(22, ABSTRACT_EVO_ILLU_ILLAGER),
+    ILLUSIONER(35, ABSTRACT_EVO_ILLU_ILLAGER),
+    VINDICATOR(94, ABSTRACT_ILLAGER_BASE),
+    PILLAGER(62, ABSTRACT_ILLAGER_BASE),
+
+    // Skeletons
+    ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
+    SKELETON(73, ABSTRACT_SKELETON),
+    STRAY(82, ABSTRACT_SKELETON),
+    WITHER_SKELETON(98, ABSTRACT_SKELETON),
+
+    // Guardians
+    GUARDIAN(31, ABSTRACT_MONSTER),
+    ELDER_GUARDIAN(17, GUARDIAN),
+
+    // Spiders
+    SPIDER(80, ABSTRACT_MONSTER),
+    CAVE_SPIDER(8, SPIDER),
+
+    // Zombies
+    ZOMBIE(102, ABSTRACT_MONSTER),
+    DROWNED(16, ZOMBIE),
+    HUSK(34, ZOMBIE),
+    ZOMBIFIED_PIGLIN(105, ZOMBIE),
+    ZOMBIE_VILLAGER(104, ZOMBIE),
+
+    // Flying entities
+    ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
+    GHAST(29, ABSTRACT_FLYING),
+    PHANTOM(58, ABSTRACT_FLYING),
+
+    ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
+    BAT(3, ABSTRACT_AMBIENT),
+
+    ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
+    SQUID(81, ABSTRACT_WATERMOB),
+
+    // Slimes
+    SLIME(75, ABSTRACT_INSENTIENT),
+    MAGMA_CUBE(44, SLIME),
+
+    // Hangable objects
+    ABSTRACT_HANGING(-1, ENTITY),
+    LEASH_KNOT(40, ABSTRACT_HANGING),
+    ITEM_FRAME(38, ABSTRACT_HANGING),
+    PAINTING(55, ABSTRACT_HANGING),
+
+    ABSTRACT_LIGHTNING(-1, ENTITY),
+    LIGHTNING_BOLT(41, ABSTRACT_LIGHTNING),
+
+    // Arrows
+    ABSTRACT_ARROW(-1, ENTITY),
+    ARROW(2, ABSTRACT_ARROW),
+    SPECTRAL_ARROW(79, ABSTRACT_ARROW),
+    TRIDENT(88, ABSTRACT_ARROW),
+
+    // Fireballs
+    ABSTRACT_FIREBALL(-1, ENTITY),
+    DRAGON_FIREBALL(15, ABSTRACT_FIREBALL),
+    FIREBALL(39, ABSTRACT_FIREBALL),
+    SMALL_FIREBALL(76, ABSTRACT_FIREBALL),
+    WITHER_SKULL(99, ABSTRACT_FIREBALL),
+
+    // Projectiles
+    PROJECTILE_ABSTRACT(-1, ENTITY),
+    SNOWBALL(78, PROJECTILE_ABSTRACT),
+    ENDER_PEARL(85, PROJECTILE_ABSTRACT),
+    EGG(84, PROJECTILE_ABSTRACT),
+    POTION(87, PROJECTILE_ABSTRACT),
+    EXPERIENCE_BOTTLE(86, PROJECTILE_ABSTRACT),
+
+    // Vehicles
+    MINECART_ABSTRACT(-1, ENTITY),
+    CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
+    CHEST_MINECART(46, CHESTED_MINECART_ABSTRACT),
+    HOPPER_MINECART(49, CHESTED_MINECART_ABSTRACT),
+    MINECART(45, MINECART_ABSTRACT),
+    FURNACE_MINECART(48, MINECART_ABSTRACT),
+    COMMAND_BLOCK_MINECART(47, MINECART_ABSTRACT),
+    TNT_MINECART(51, MINECART_ABSTRACT),
+    SPAWNER_MINECART(50, MINECART_ABSTRACT),
+    BOAT(6, ENTITY);
+
+    private static final EntityType[] TYPES;
+
+    private final int id;
+    private final EntityType parent;
+
+    Entity1_16_2Types(int id) {
+        this.id = id;
+        this.parent = null;
     }
 
-    public enum EntityType implements us.myles.ViaVersion.api.entities.EntityType {
-        ENTITY(-1),
+    Entity1_16_2Types(int id, EntityType parent) {
+        this.id = id;
+        this.parent = parent;
+    }
 
-        AREA_EFFECT_CLOUD(0, ENTITY),
-        END_CRYSTAL(18, ENTITY),
-        EVOKER_FANGS(23, ENTITY),
-        EXPERIENCE_ORB(24, ENTITY),
-        EYE_OF_ENDER(25, ENTITY),
-        FALLING_BLOCK(26, ENTITY),
-        FIREWORK_ROCKET(27, ENTITY),
-        ITEM(37, ENTITY),
-        LLAMA_SPIT(43, ENTITY),
-        TNT(64, ENTITY),
-        SHULKER_BULLET(71, ENTITY),
-        FISHING_BOBBER(107, ENTITY),
+    @Override
+    public int getId() {
+        return id;
+    }
 
-        LIVINGENTITY(-1, ENTITY),
-        ARMOR_STAND(1, LIVINGENTITY),
-        PLAYER(106, LIVINGENTITY),
+    @Override
+    public EntityType getParent() {
+        return parent;
+    }
 
-        ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
-        ENDER_DRAGON(19, ABSTRACT_INSENTIENT),
-
-        BEE(4, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
-        VILLAGER(93, ABSTRACT_AGEABLE),
-        WANDERING_TRADER(95, ABSTRACT_AGEABLE),
-
-        // Animals
-        ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
-        DOLPHIN(13, ABSTRACT_INSENTIENT),
-        CHICKEN(9, ABSTRACT_ANIMAL),
-        COW(11, ABSTRACT_ANIMAL),
-        MOOSHROOM(53, COW),
-        PANDA(56, ABSTRACT_INSENTIENT),
-        PIG(59, ABSTRACT_ANIMAL),
-        POLAR_BEAR(63, ABSTRACT_ANIMAL),
-        RABBIT(66, ABSTRACT_ANIMAL),
-        SHEEP(69, ABSTRACT_ANIMAL),
-        TURTLE(91, ABSTRACT_ANIMAL),
-        FOX(28, ABSTRACT_ANIMAL),
-
-        ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
-        CAT(7, ABSTRACT_TAMEABLE_ANIMAL),
-        OCELOT(54, ABSTRACT_TAMEABLE_ANIMAL),
-        WOLF(100, ABSTRACT_TAMEABLE_ANIMAL),
-
-        ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
-        PARROT(57, ABSTRACT_PARROT),
-
-        // Horses
-        ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
-        CHESTED_HORSE(-1, ABSTRACT_HORSE),
-        DONKEY(14, CHESTED_HORSE),
-        MULE(52, CHESTED_HORSE),
-        LLAMA(42, CHESTED_HORSE),
-        TRADER_LLAMA(89, CHESTED_HORSE),
-        HORSE(33, ABSTRACT_HORSE),
-        SKELETON_HORSE(74, ABSTRACT_HORSE),
-        ZOMBIE_HORSE(103, ABSTRACT_HORSE),
-
-        // Golem
-        ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
-        SNOW_GOLEM(77, ABSTRACT_GOLEM),
-        IRON_GOLEM(36, ABSTRACT_GOLEM),
-        SHULKER(70, ABSTRACT_GOLEM),
-
-        // Fish
-        ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
-        COD(10, ABSTRACT_FISHES),
-        PUFFERFISH(65, ABSTRACT_FISHES),
-        SALMON(68, ABSTRACT_FISHES),
-        TROPICAL_FISH(90, ABSTRACT_FISHES),
-
-        // Monsters
-        ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
-        BLAZE(5, ABSTRACT_MONSTER),
-        CREEPER(12, ABSTRACT_MONSTER),
-        ENDERMITE(21, ABSTRACT_MONSTER),
-        ENDERMAN(20, ABSTRACT_MONSTER),
-        GIANT(30, ABSTRACT_MONSTER),
-        SILVERFISH(72, ABSTRACT_MONSTER),
-        VEX(92, ABSTRACT_MONSTER),
-        WITCH(96, ABSTRACT_MONSTER),
-        WITHER(97, ABSTRACT_MONSTER),
-        RAVAGER(67, ABSTRACT_MONSTER),
-
-        ABSTRACT_PIGLIN(-1, ABSTRACT_MONSTER),
-
-        PIGLIN(60, ABSTRACT_PIGLIN),
-        PIGLIN_BRUTE(61, ABSTRACT_PIGLIN),
-
-        HOGLIN(32, ABSTRACT_ANIMAL),
-        STRIDER(83, ABSTRACT_ANIMAL),
-        ZOGLIN(101, ABSTRACT_MONSTER),
-
-        // Illagers
-        ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
-        ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
-        EVOKER(22, ABSTRACT_EVO_ILLU_ILLAGER),
-        ILLUSIONER(35, ABSTRACT_EVO_ILLU_ILLAGER),
-        VINDICATOR(94, ABSTRACT_ILLAGER_BASE),
-        PILLAGER(62, ABSTRACT_ILLAGER_BASE),
-
-        // Skeletons
-        ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
-        SKELETON(73, ABSTRACT_SKELETON),
-        STRAY(82, ABSTRACT_SKELETON),
-        WITHER_SKELETON(98, ABSTRACT_SKELETON),
-
-        // Guardians
-        GUARDIAN(31, ABSTRACT_MONSTER),
-        ELDER_GUARDIAN(17, GUARDIAN),
-
-        // Spiders
-        SPIDER(80, ABSTRACT_MONSTER),
-        CAVE_SPIDER(8, SPIDER),
-
-        // Zombies
-        ZOMBIE(102, ABSTRACT_MONSTER),
-        DROWNED(16, ZOMBIE),
-        HUSK(34, ZOMBIE),
-        ZOMBIFIED_PIGLIN(105, ZOMBIE),
-        ZOMBIE_VILLAGER(104, ZOMBIE),
-
-        // Flying entities
-        ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
-        GHAST(29, ABSTRACT_FLYING),
-        PHANTOM(58, ABSTRACT_FLYING),
-
-        ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
-        BAT(3, ABSTRACT_AMBIENT),
-
-        ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
-        SQUID(81, ABSTRACT_WATERMOB),
-
-        // Slimes
-        SLIME(75, ABSTRACT_INSENTIENT),
-        MAGMA_CUBE(44, SLIME),
-
-        // Hangable objects
-        ABSTRACT_HANGING(-1, ENTITY),
-        LEASH_KNOT(40, ABSTRACT_HANGING),
-        ITEM_FRAME(38, ABSTRACT_HANGING),
-        PAINTING(55, ABSTRACT_HANGING),
-
-        ABSTRACT_LIGHTNING(-1, ENTITY),
-        LIGHTNING_BOLT(41, ABSTRACT_LIGHTNING),
-
-        // Arrows
-        ABSTRACT_ARROW(-1, ENTITY),
-        ARROW(2, ABSTRACT_ARROW),
-        SPECTRAL_ARROW(79, ABSTRACT_ARROW),
-        TRIDENT(88, ABSTRACT_ARROW),
-
-        // Fireballs
-        ABSTRACT_FIREBALL(-1, ENTITY),
-        DRAGON_FIREBALL(15, ABSTRACT_FIREBALL),
-        FIREBALL(39, ABSTRACT_FIREBALL),
-        SMALL_FIREBALL(76, ABSTRACT_FIREBALL),
-        WITHER_SKULL(99, ABSTRACT_FIREBALL),
-
-        // Projectiles
-        PROJECTILE_ABSTRACT(-1, ENTITY),
-        SNOWBALL(78, PROJECTILE_ABSTRACT),
-        ENDER_PEARL(85, PROJECTILE_ABSTRACT),
-        EGG(84, PROJECTILE_ABSTRACT),
-        POTION(87, PROJECTILE_ABSTRACT),
-        EXPERIENCE_BOTTLE(86, PROJECTILE_ABSTRACT),
-
-        // Vehicles
-        MINECART_ABSTRACT(-1, ENTITY),
-        CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
-        CHEST_MINECART(46, CHESTED_MINECART_ABSTRACT),
-        HOPPER_MINECART(49, CHESTED_MINECART_ABSTRACT),
-        MINECART(45, MINECART_ABSTRACT),
-        FURNACE_MINECART(48, MINECART_ABSTRACT),
-        COMMAND_BLOCK_MINECART(47, MINECART_ABSTRACT),
-        TNT_MINECART(51, MINECART_ABSTRACT),
-        SPAWNER_MINECART(50, MINECART_ABSTRACT),
-        BOAT(6, ENTITY);
-
-        private static final Map<Integer, EntityType> TYPES = new HashMap<>();
-
-        private final int id;
-        private final EntityType parent;
-
-        EntityType(int id) {
-            this.id = id;
-            this.parent = null;
-        }
-
-        EntityType(int id, EntityType parent) {
-            this.id = id;
-            this.parent = parent;
-        }
-
-        @Override
-        public int getId() {
-            return id;
-        }
-
-        @Override
-        public EntityType getParent() {
-            return parent;
-        }
-
-        static {
-            for (EntityType type : EntityType.values()) {
-                TYPES.put(type.id, type);
+    static {
+        List<Entity1_16_2Types> types = new ArrayList<>();
+        for (Entity1_16_2Types type : values()) {
+            if (type.id != -1) {
+                types.add(type);
             }
         }
 
-        public static Optional<EntityType> findById(int id) {
-            if (id == -1)
-                return Optional.empty();
-            return Optional.ofNullable(TYPES.get(id));
+        types.sort(Comparator.comparingInt(Entity1_16_2Types::getId));
+        TYPES = types.toArray(new EntityType[0]);
+    }
+
+    public static us.myles.ViaVersion.api.entities.EntityType getTypeFromId(int typeId) {
+        EntityType type;
+        if (typeId < 0 || typeId >= TYPES.length || (type = TYPES[typeId]) == null) {
+            Via.getPlatform().getLogger().severe("Could not find 1.16.2 type id " + typeId);
+            return ENTITY;
         }
+        return type;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_17Types.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/entities/Entity1_17Types.java
@@ -2,244 +2,243 @@ package us.myles.ViaVersion.api.entities;
 
 import us.myles.ViaVersion.api.Via;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
-public class Entity1_17Types {
+public enum Entity1_17Types implements EntityType {
 
-    public static EntityType getTypeFromId(int typeID) {
-        Optional<EntityType> type = EntityType.findById(typeID);
-        if (!type.isPresent()) {
-            Via.getPlatform().getLogger().severe("Could not find 1.17 type id " + typeID);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
-        }
-        return type.get();
+    ENTITY(-1),
+
+    AREA_EFFECT_CLOUD(0, ENTITY),
+    END_CRYSTAL(19, ENTITY),
+    EVOKER_FANGS(24, ENTITY),
+    EXPERIENCE_ORB(25, ENTITY),
+    EYE_OF_ENDER(26, ENTITY),
+    FALLING_BLOCK(27, ENTITY),
+    FIREWORK_ROCKET(28, ENTITY),
+    ITEM(40, ENTITY),
+    LLAMA_SPIT(46, ENTITY),
+    TNT(67, ENTITY),
+    SHULKER_BULLET(74, ENTITY),
+    FISHING_BOBBER(110, ENTITY),
+
+    LIVINGENTITY(-1, ENTITY),
+    ARMOR_STAND(1, LIVINGENTITY),
+    PLAYER(109, LIVINGENTITY),
+
+    ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
+    ENDER_DRAGON(20, ABSTRACT_INSENTIENT),
+
+    BEE(5, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
+
+    ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
+    VILLAGER(96, ABSTRACT_AGEABLE),
+    WANDERING_TRADER(98, ABSTRACT_AGEABLE),
+
+    // Animals
+    ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
+    AXOLOTL(3, ABSTRACT_ANIMAL),
+    DOLPHIN(14, ABSTRACT_INSENTIENT),
+    CHICKEN(10, ABSTRACT_ANIMAL),
+    COW(12, ABSTRACT_ANIMAL),
+    MOOSHROOM(56, COW),
+    PANDA(59, ABSTRACT_INSENTIENT),
+    PIG(62, ABSTRACT_ANIMAL),
+    POLAR_BEAR(66, ABSTRACT_ANIMAL),
+    RABBIT(69, ABSTRACT_ANIMAL),
+    SHEEP(72, ABSTRACT_ANIMAL),
+    TURTLE(94, ABSTRACT_ANIMAL),
+    FOX(29, ABSTRACT_ANIMAL),
+
+    ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
+    CAT(8, ABSTRACT_TAMEABLE_ANIMAL),
+    OCELOT(57, ABSTRACT_TAMEABLE_ANIMAL),
+    WOLF(103, ABSTRACT_TAMEABLE_ANIMAL),
+
+    ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
+    PARROT(60, ABSTRACT_PARROT),
+
+    // Horses
+    ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
+    CHESTED_HORSE(-1, ABSTRACT_HORSE),
+    DONKEY(15, CHESTED_HORSE),
+    MULE(55, CHESTED_HORSE),
+    LLAMA(45, CHESTED_HORSE),
+    TRADER_LLAMA(92, CHESTED_HORSE),
+    HORSE(36, ABSTRACT_HORSE),
+    SKELETON_HORSE(77, ABSTRACT_HORSE),
+    ZOMBIE_HORSE(106, ABSTRACT_HORSE),
+
+    // Golem
+    ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
+    SNOW_GOLEM(80, ABSTRACT_GOLEM),
+    IRON_GOLEM(39, ABSTRACT_GOLEM),
+    SHULKER(73, ABSTRACT_GOLEM),
+
+    // Fish
+    ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
+    COD(11, ABSTRACT_FISHES),
+    PUFFERFISH(68, ABSTRACT_FISHES),
+    SALMON(71, ABSTRACT_FISHES),
+    TROPICAL_FISH(93, ABSTRACT_FISHES),
+
+    // Monsters
+    ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
+    BLAZE(6, ABSTRACT_MONSTER),
+    CREEPER(13, ABSTRACT_MONSTER),
+    ENDERMITE(22, ABSTRACT_MONSTER),
+    ENDERMAN(21, ABSTRACT_MONSTER),
+    GIANT(31, ABSTRACT_MONSTER),
+    SILVERFISH(75, ABSTRACT_MONSTER),
+    VEX(95, ABSTRACT_MONSTER),
+    WITCH(99, ABSTRACT_MONSTER),
+    WITHER(100, ABSTRACT_MONSTER),
+    RAVAGER(70, ABSTRACT_MONSTER),
+
+    ABSTRACT_PIGLIN(-1, ABSTRACT_MONSTER),
+
+    PIGLIN(63, ABSTRACT_PIGLIN),
+    PIGLIN_BRUTE(64, ABSTRACT_PIGLIN),
+
+    HOGLIN(35, ABSTRACT_ANIMAL),
+    STRIDER(86, ABSTRACT_ANIMAL),
+    ZOGLIN(104, ABSTRACT_MONSTER),
+
+    // Illagers
+    ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
+    ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
+    EVOKER(23, ABSTRACT_EVO_ILLU_ILLAGER),
+    ILLUSIONER(38, ABSTRACT_EVO_ILLU_ILLAGER),
+    VINDICATOR(97, ABSTRACT_ILLAGER_BASE),
+    PILLAGER(65, ABSTRACT_ILLAGER_BASE),
+
+    // Skeletons
+    ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
+    SKELETON(76, ABSTRACT_SKELETON),
+    STRAY(85, ABSTRACT_SKELETON),
+    WITHER_SKELETON(101, ABSTRACT_SKELETON),
+
+    // Guardians
+    GUARDIAN(34, ABSTRACT_MONSTER),
+    ELDER_GUARDIAN(18, GUARDIAN),
+
+    // Spiders
+    SPIDER(83, ABSTRACT_MONSTER),
+    CAVE_SPIDER(9, SPIDER),
+
+    // Zombies
+    ZOMBIE(105, ABSTRACT_MONSTER),
+    DROWNED(17, ZOMBIE),
+    HUSK(37, ZOMBIE),
+    ZOMBIFIED_PIGLIN(108, ZOMBIE),
+    ZOMBIE_VILLAGER(107, ZOMBIE),
+
+    // Flying entities
+    ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
+    GHAST(30, ABSTRACT_FLYING),
+    PHANTOM(61, ABSTRACT_FLYING),
+
+    ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
+    BAT(4, ABSTRACT_AMBIENT),
+
+    ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
+    SQUID(84, ABSTRACT_WATERMOB),
+    GLOW_SQUID(33, SQUID),
+
+    // Slimes
+    SLIME(78, ABSTRACT_INSENTIENT),
+    MAGMA_CUBE(47, SLIME),
+
+    // Hangable objects
+    ABSTRACT_HANGING(-1, ENTITY),
+    LEASH_KNOT(43, ABSTRACT_HANGING),
+    ITEM_FRAME(41, ABSTRACT_HANGING),
+    GLOW_ITEM_FRAME(32, ITEM_FRAME),
+    PAINTING(58, ABSTRACT_HANGING),
+
+    ABSTRACT_LIGHTNING(-1, ENTITY),
+    LIGHTNING_BOLT(44, ABSTRACT_LIGHTNING),
+
+    // Arrows
+    ABSTRACT_ARROW(-1, ENTITY),
+    ARROW(2, ABSTRACT_ARROW),
+    SPECTRAL_ARROW(82, ABSTRACT_ARROW),
+    TRIDENT(91, ABSTRACT_ARROW),
+
+    // Fireballs
+    ABSTRACT_FIREBALL(-1, ENTITY),
+    DRAGON_FIREBALL(16, ABSTRACT_FIREBALL),
+    FIREBALL(42, ABSTRACT_FIREBALL),
+    SMALL_FIREBALL(79, ABSTRACT_FIREBALL),
+    WITHER_SKULL(102, ABSTRACT_FIREBALL),
+
+    // Projectiles
+    PROJECTILE_ABSTRACT(-1, ENTITY),
+    SNOWBALL(81, PROJECTILE_ABSTRACT),
+    ENDER_PEARL(88, PROJECTILE_ABSTRACT),
+    EGG(87, PROJECTILE_ABSTRACT),
+    POTION(90, PROJECTILE_ABSTRACT),
+    EXPERIENCE_BOTTLE(89, PROJECTILE_ABSTRACT),
+
+    // Vehicles
+    MINECART_ABSTRACT(-1, ENTITY),
+    CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
+    CHEST_MINECART(49, CHESTED_MINECART_ABSTRACT),
+    HOPPER_MINECART(52, CHESTED_MINECART_ABSTRACT),
+    MINECART(48, MINECART_ABSTRACT),
+    FURNACE_MINECART(51, MINECART_ABSTRACT),
+    COMMAND_BLOCK_MINECART(50, MINECART_ABSTRACT),
+    TNT_MINECART(54, MINECART_ABSTRACT),
+    SPAWNER_MINECART(53, MINECART_ABSTRACT),
+    BOAT(7, ENTITY);
+
+    private static final EntityType[] TYPES;
+
+    private final int id;
+    private final EntityType parent;
+
+    Entity1_17Types(int id) {
+        this.id = id;
+        this.parent = null;
     }
 
-    public enum EntityType implements us.myles.ViaVersion.api.entities.EntityType {
-        ENTITY(-1),
+    Entity1_17Types(int id, EntityType parent) {
+        this.id = id;
+        this.parent = parent;
+    }
 
-        AREA_EFFECT_CLOUD(0, ENTITY),
-        END_CRYSTAL(19, ENTITY),
-        EVOKER_FANGS(24, ENTITY),
-        EXPERIENCE_ORB(25, ENTITY),
-        EYE_OF_ENDER(26, ENTITY),
-        FALLING_BLOCK(27, ENTITY),
-        FIREWORK_ROCKET(28, ENTITY),
-        ITEM(40, ENTITY),
-        LLAMA_SPIT(46, ENTITY),
-        TNT(67, ENTITY),
-        SHULKER_BULLET(74, ENTITY),
-        FISHING_BOBBER(110, ENTITY),
+    @Override
+    public int getId() {
+        return id;
+    }
 
-        LIVINGENTITY(-1, ENTITY),
-        ARMOR_STAND(1, LIVINGENTITY),
-        PLAYER(109, LIVINGENTITY),
+    @Override
+    public EntityType getParent() {
+        return parent;
+    }
 
-        ABSTRACT_INSENTIENT(-1, LIVINGENTITY),
-        ENDER_DRAGON(20, ABSTRACT_INSENTIENT),
-
-        BEE(5, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_CREATURE(-1, ABSTRACT_INSENTIENT),
-
-        ABSTRACT_AGEABLE(-1, ABSTRACT_CREATURE),
-        VILLAGER(96, ABSTRACT_AGEABLE),
-        WANDERING_TRADER(98, ABSTRACT_AGEABLE),
-
-        // Animals
-        ABSTRACT_ANIMAL(-1, ABSTRACT_AGEABLE),
-        AXOLOTL(3, ABSTRACT_ANIMAL),
-        DOLPHIN(14, ABSTRACT_INSENTIENT),
-        CHICKEN(10, ABSTRACT_ANIMAL),
-        COW(12, ABSTRACT_ANIMAL),
-        MOOSHROOM(56, COW),
-        PANDA(59, ABSTRACT_INSENTIENT),
-        PIG(62, ABSTRACT_ANIMAL),
-        POLAR_BEAR(66, ABSTRACT_ANIMAL),
-        RABBIT(69, ABSTRACT_ANIMAL),
-        SHEEP(72, ABSTRACT_ANIMAL),
-        TURTLE(94, ABSTRACT_ANIMAL),
-        FOX(29, ABSTRACT_ANIMAL),
-
-        ABSTRACT_TAMEABLE_ANIMAL(-1, ABSTRACT_ANIMAL),
-        CAT(8, ABSTRACT_TAMEABLE_ANIMAL),
-        OCELOT(57, ABSTRACT_TAMEABLE_ANIMAL),
-        WOLF(103, ABSTRACT_TAMEABLE_ANIMAL),
-
-        ABSTRACT_PARROT(-1, ABSTRACT_TAMEABLE_ANIMAL),
-        PARROT(60, ABSTRACT_PARROT),
-
-        // Horses
-        ABSTRACT_HORSE(-1, ABSTRACT_ANIMAL),
-        CHESTED_HORSE(-1, ABSTRACT_HORSE),
-        DONKEY(15, CHESTED_HORSE),
-        MULE(55, CHESTED_HORSE),
-        LLAMA(45, CHESTED_HORSE),
-        TRADER_LLAMA(92, CHESTED_HORSE),
-        HORSE(36, ABSTRACT_HORSE),
-        SKELETON_HORSE(77, ABSTRACT_HORSE),
-        ZOMBIE_HORSE(106, ABSTRACT_HORSE),
-
-        // Golem
-        ABSTRACT_GOLEM(-1, ABSTRACT_CREATURE),
-        SNOW_GOLEM(80, ABSTRACT_GOLEM),
-        IRON_GOLEM(39, ABSTRACT_GOLEM),
-        SHULKER(73, ABSTRACT_GOLEM),
-
-        // Fish
-        ABSTRACT_FISHES(-1, ABSTRACT_CREATURE),
-        COD(11, ABSTRACT_FISHES),
-        PUFFERFISH(68, ABSTRACT_FISHES),
-        SALMON(71, ABSTRACT_FISHES),
-        TROPICAL_FISH(93, ABSTRACT_FISHES),
-
-        // Monsters
-        ABSTRACT_MONSTER(-1, ABSTRACT_CREATURE),
-        BLAZE(6, ABSTRACT_MONSTER),
-        CREEPER(13, ABSTRACT_MONSTER),
-        ENDERMITE(22, ABSTRACT_MONSTER),
-        ENDERMAN(21, ABSTRACT_MONSTER),
-        GIANT(31, ABSTRACT_MONSTER),
-        SILVERFISH(75, ABSTRACT_MONSTER),
-        VEX(95, ABSTRACT_MONSTER),
-        WITCH(99, ABSTRACT_MONSTER),
-        WITHER(100, ABSTRACT_MONSTER),
-        RAVAGER(70, ABSTRACT_MONSTER),
-
-        ABSTRACT_PIGLIN(-1, ABSTRACT_MONSTER),
-
-        PIGLIN(63, ABSTRACT_PIGLIN),
-        PIGLIN_BRUTE(64, ABSTRACT_PIGLIN),
-
-        HOGLIN(35, ABSTRACT_ANIMAL),
-        STRIDER(86, ABSTRACT_ANIMAL),
-        ZOGLIN(104, ABSTRACT_MONSTER),
-
-        // Illagers
-        ABSTRACT_ILLAGER_BASE(-1, ABSTRACT_MONSTER),
-        ABSTRACT_EVO_ILLU_ILLAGER(-1, ABSTRACT_ILLAGER_BASE),
-        EVOKER(23, ABSTRACT_EVO_ILLU_ILLAGER),
-        ILLUSIONER(38, ABSTRACT_EVO_ILLU_ILLAGER),
-        VINDICATOR(97, ABSTRACT_ILLAGER_BASE),
-        PILLAGER(65, ABSTRACT_ILLAGER_BASE),
-
-        // Skeletons
-        ABSTRACT_SKELETON(-1, ABSTRACT_MONSTER),
-        SKELETON(76, ABSTRACT_SKELETON),
-        STRAY(85, ABSTRACT_SKELETON),
-        WITHER_SKELETON(101, ABSTRACT_SKELETON),
-
-        // Guardians
-        GUARDIAN(34, ABSTRACT_MONSTER),
-        ELDER_GUARDIAN(18, GUARDIAN),
-
-        // Spiders
-        SPIDER(83, ABSTRACT_MONSTER),
-        CAVE_SPIDER(9, SPIDER),
-
-        // Zombies
-        ZOMBIE(105, ABSTRACT_MONSTER),
-        DROWNED(17, ZOMBIE),
-        HUSK(37, ZOMBIE),
-        ZOMBIFIED_PIGLIN(108, ZOMBIE),
-        ZOMBIE_VILLAGER(107, ZOMBIE),
-
-        // Flying entities
-        ABSTRACT_FLYING(-1, ABSTRACT_INSENTIENT),
-        GHAST(30, ABSTRACT_FLYING),
-        PHANTOM(61, ABSTRACT_FLYING),
-
-        ABSTRACT_AMBIENT(-1, ABSTRACT_INSENTIENT),
-        BAT(4, ABSTRACT_AMBIENT),
-
-        ABSTRACT_WATERMOB(-1, ABSTRACT_INSENTIENT),
-        SQUID(84, ABSTRACT_WATERMOB),
-        GLOW_SQUID(33, SQUID),
-
-        // Slimes
-        SLIME(78, ABSTRACT_INSENTIENT),
-        MAGMA_CUBE(47, SLIME),
-
-        // Hangable objects
-        ABSTRACT_HANGING(-1, ENTITY),
-        LEASH_KNOT(43, ABSTRACT_HANGING),
-        ITEM_FRAME(41, ABSTRACT_HANGING),
-        GLOW_ITEM_FRAME(32, ITEM_FRAME),
-        PAINTING(58, ABSTRACT_HANGING),
-
-        ABSTRACT_LIGHTNING(-1, ENTITY),
-        LIGHTNING_BOLT(44, ABSTRACT_LIGHTNING),
-
-        // Arrows
-        ABSTRACT_ARROW(-1, ENTITY),
-        ARROW(2, ABSTRACT_ARROW),
-        SPECTRAL_ARROW(82, ABSTRACT_ARROW),
-        TRIDENT(91, ABSTRACT_ARROW),
-
-        // Fireballs
-        ABSTRACT_FIREBALL(-1, ENTITY),
-        DRAGON_FIREBALL(16, ABSTRACT_FIREBALL),
-        FIREBALL(42, ABSTRACT_FIREBALL),
-        SMALL_FIREBALL(79, ABSTRACT_FIREBALL),
-        WITHER_SKULL(102, ABSTRACT_FIREBALL),
-
-        // Projectiles
-        PROJECTILE_ABSTRACT(-1, ENTITY),
-        SNOWBALL(81, PROJECTILE_ABSTRACT),
-        ENDER_PEARL(88, PROJECTILE_ABSTRACT),
-        EGG(87, PROJECTILE_ABSTRACT),
-        POTION(90, PROJECTILE_ABSTRACT),
-        EXPERIENCE_BOTTLE(89, PROJECTILE_ABSTRACT),
-
-        // Vehicles
-        MINECART_ABSTRACT(-1, ENTITY),
-        CHESTED_MINECART_ABSTRACT(-1, MINECART_ABSTRACT),
-        CHEST_MINECART(49, CHESTED_MINECART_ABSTRACT),
-        HOPPER_MINECART(52, CHESTED_MINECART_ABSTRACT),
-        MINECART(48, MINECART_ABSTRACT),
-        FURNACE_MINECART(51, MINECART_ABSTRACT),
-        COMMAND_BLOCK_MINECART(50, MINECART_ABSTRACT),
-        TNT_MINECART(54, MINECART_ABSTRACT),
-        SPAWNER_MINECART(53, MINECART_ABSTRACT),
-        BOAT(7, ENTITY);
-
-        private static final Map<Integer, EntityType> TYPES = new HashMap<>();
-
-        private final int id;
-        private final EntityType parent;
-
-        EntityType(int id) {
-            this.id = id;
-            this.parent = null;
-        }
-
-        EntityType(int id, EntityType parent) {
-            this.id = id;
-            this.parent = parent;
-        }
-
-        @Override
-        public int getId() {
-            return id;
-        }
-
-        @Override
-        public EntityType getParent() {
-            return parent;
-        }
-
-        static {
-            for (EntityType type : EntityType.values()) {
-                TYPES.put(type.id, type);
+    static {
+        List<Entity1_17Types> types = new ArrayList<>();
+        for (Entity1_17Types type : values()) {
+            if (type.id != -1) {
+                types.add(type);
             }
         }
 
-        public static Optional<EntityType> findById(int id) {
-            if (id == -1)
-                return Optional.empty();
-            return Optional.ofNullable(TYPES.get(id));
+        types.sort(Comparator.comparingInt(Entity1_17Types::getId));
+        TYPES = types.toArray(new EntityType[0]);
+    }
+
+    public static EntityType getTypeFromId(int typeId) {
+        EntityType type;
+        if (typeId < 0 || typeId >= TYPES.length || (type = TYPES[typeId]) == null) {
+            Via.getPlatform().getLogger().severe("Could not find 1.17 type id " + typeId);
+            return ENTITY;
         }
+        return type;
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/entities/EntityType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/entities/EntityType.java
@@ -4,8 +4,14 @@ import org.jetbrains.annotations.Nullable;
 
 public interface EntityType {
 
+    /**
+     * @return entity id
+     */
     int getId();
 
+    /**
+     * @return parent entity type if present
+     */
     @Nullable
     EntityType getParent();
 
@@ -23,6 +29,10 @@ public interface EntityType {
         return this == type;
     }
 
+    /**
+     * @param type entity type to check against
+     * @return true if the current type is equal to the given type, or has it as a parent type
+     */
     default boolean isOrHasParent(EntityType type) {
         EntityType parent = this;
 

--- a/common/src/main/java/us/myles/ViaVersion/api/entities/ObjectType.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/entities/ObjectType.java
@@ -1,5 +1,8 @@
 package us.myles.ViaVersion.api.entities;
 
+/**
+ * Represents a legacy object entity type.
+ */
 public interface ObjectType {
 
     int getId();

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_1to1_14/metadata/MetadataRewriter1_14_1To1_14.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_1to1_14/metadata/MetadataRewriter1_14_1To1_14.java
@@ -20,7 +20,7 @@ public class MetadataRewriter1_14_1To1_14 extends MetadataRewriter {
     public void handleMetadata(int entityId, EntityType type, Metadata metadata, List<Metadata> metadatas, UserConnection connection) {
         if (type == null) return;
 
-        if (type == Entity1_14Types.EntityType.VILLAGER || type == Entity1_14Types.EntityType.WANDERING_TRADER) {
+        if (type == Entity1_14Types.VILLAGER || type == Entity1_14Types.WANDERING_TRADER) {
             if (metadata.getId() >= 15) {
                 metadata.setId(metadata.getId() + 1);
             }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_1to1_14/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_1to1_14/packets/EntityPackets.java
@@ -48,7 +48,7 @@ public class EntityPackets {
                 map(Type.BYTE); // 6 - Pitch
                 map(Types1_14.METADATA_LIST); // 7 - Metadata
 
-                handler(metadataRewriter.getTrackerAndRewriter(Types1_14.METADATA_LIST, Entity1_14Types.EntityType.PLAYER));
+                handler(metadataRewriter.getTrackerAndRewriter(Types1_14.METADATA_LIST, Entity1_14Types.PLAYER));
             }
         });
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_1to1_14/storage/EntityTracker1_14_1.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14_1to1_14/storage/EntityTracker1_14_1.java
@@ -1,12 +1,12 @@
 package us.myles.ViaVersion.protocols.protocol1_14_1to1_14.storage;
 
 import us.myles.ViaVersion.api.data.UserConnection;
-import us.myles.ViaVersion.api.entities.Entity1_14Types.EntityType;
+import us.myles.ViaVersion.api.entities.Entity1_14Types;
 import us.myles.ViaVersion.api.storage.EntityTracker;
 
 public class EntityTracker1_14_1 extends EntityTracker {
 
     public EntityTracker1_14_1(UserConnection user) {
-        super(user, EntityType.PLAYER);
+        super(user, Entity1_14Types.PLAYER);
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/metadata/MetadataRewriter1_14To1_13_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/metadata/MetadataRewriter1_14To1_13_2.java
@@ -23,8 +23,8 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
 
     public MetadataRewriter1_14To1_13_2(Protocol1_14To1_13_2 protocol) {
         super(protocol, EntityTracker1_14.class);
-        mapTypes(Entity1_13Types.EntityType.values(), Entity1_14Types.EntityType.class);
-        mapType(Entity1_13Types.EntityType.OCELOT, Entity1_14Types.EntityType.CAT); //TODO remap untamed ocelots to ocelots?
+        mapTypes(Entity1_13Types.EntityType.values(), Entity1_14Types.class);
+        mapType(Entity1_13Types.EntityType.OCELOT, Entity1_14Types.CAT); //TODO remap untamed ocelots to ocelots?
     }
 
     @Override
@@ -49,7 +49,7 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
         if (metadata.getId() > 5) {
             metadata.setId(metadata.getId() + 1);
         }
-        if (metadata.getId() == 8 && type.isOrHasParent(Entity1_14Types.EntityType.LIVINGENTITY)) {
+        if (metadata.getId() == 8 && type.isOrHasParent(Entity1_14Types.LIVINGENTITY)) {
             final float v = ((Number) metadata.getValue()).floatValue();
             if (Float.isNaN(v) && Via.getConfig().is1_14HealthNaNFix()) {
                 metadata.setValue(1F);
@@ -57,11 +57,11 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
         }
 
         //Metadata 12 added to living_entity
-        if (metadata.getId() > 11 && type.isOrHasParent(Entity1_14Types.EntityType.LIVINGENTITY)) {
+        if (metadata.getId() > 11 && type.isOrHasParent(Entity1_14Types.LIVINGENTITY)) {
             metadata.setId(metadata.getId() + 1);
         }
 
-        if (type.isOrHasParent(Entity1_14Types.EntityType.ABSTRACT_INSENTIENT)) {
+        if (type.isOrHasParent(Entity1_14Types.ABSTRACT_INSENTIENT)) {
             if (metadata.getId() == 13) {
                 tracker.setInsentientData(entityId, (byte) ((((Number) metadata.getValue()).byteValue() & ~0x4)
                         | (tracker.getInsentientData(entityId) & 0x4))); // New attacking metadata
@@ -69,7 +69,7 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
             }
         }
 
-        if (type.isOrHasParent(Entity1_14Types.EntityType.PLAYER)) {
+        if (type.isOrHasParent(Entity1_14Types.PLAYER)) {
             if (entityId != tracker.getClientEntityId()) {
                 if (metadata.getId() == 0) {
                     byte flags = ((Number) metadata.getValue()).byteValue();
@@ -82,7 +82,7 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
                     metadatas.add(new Metadata(6, MetaType1_14.Pose, recalculatePlayerPose(entityId, tracker)));
                 }
             }
-        } else if (type.isOrHasParent(Entity1_14Types.EntityType.ZOMBIE)) {
+        } else if (type.isOrHasParent(Entity1_14Types.ZOMBIE)) {
             if (metadata.getId() == 16) {
                 tracker.setInsentientData(entityId, (byte) ((tracker.getInsentientData(entityId) & ~0x4)
                         | ((boolean) metadata.getValue() ? 0x4 : 0))); // New attacking
@@ -93,13 +93,13 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
             }
         }
 
-        if (type.isOrHasParent(Entity1_14Types.EntityType.MINECART_ABSTRACT)) {
+        if (type.isOrHasParent(Entity1_14Types.MINECART_ABSTRACT)) {
             if (metadata.getId() == 10) {
                 // New block format
                 int data = (int) metadata.getValue();
                 metadata.setValue(protocol.getMappingData().getNewBlockStateId(data));
             }
-        } else if (type.is(Entity1_14Types.EntityType.HORSE)) {
+        } else if (type.is(Entity1_14Types.HORSE)) {
             if (metadata.getId() == 18) {
                 metadatas.remove(metadata);
 
@@ -119,29 +119,29 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
                 equipmentPacket.write(Type.FLAT_VAR_INT_ITEM, armorItem);
                 equipmentPacket.send(Protocol1_14To1_13_2.class);
             }
-        } else if (type.is(Entity1_14Types.EntityType.VILLAGER)) {
+        } else if (type.is(Entity1_14Types.VILLAGER)) {
             if (metadata.getId() == 15) {
                 // plains
                 metadata.setValue(new VillagerData(2, getNewProfessionId((int) metadata.getValue()), 0));
                 metadata.setMetaType(MetaType1_14.VillagerData);
             }
-        } else if (type.is(Entity1_14Types.EntityType.ZOMBIE_VILLAGER)) {
+        } else if (type.is(Entity1_14Types.ZOMBIE_VILLAGER)) {
             if (metadata.getId() == 18) {
                 // plains
                 metadata.setValue(new VillagerData(2, getNewProfessionId((int) metadata.getValue()), 0));
                 metadata.setMetaType(MetaType1_14.VillagerData);
             }
-        } else if (type.isOrHasParent(Entity1_14Types.EntityType.ABSTRACT_ARROW)) {
+        } else if (type.isOrHasParent(Entity1_14Types.ABSTRACT_ARROW)) {
             if (metadata.getId() >= 9) { // New piercing
                 metadata.setId(metadata.getId() + 1);
             }
-        } else if (type.is(Entity1_14Types.EntityType.FIREWORK_ROCKET)) {
+        } else if (type.is(Entity1_14Types.FIREWORK_ROCKET)) {
             if (metadata.getId() == 8) {
                 if (metadata.getValue().equals(0))
                     metadata.setValue(null); // https://bugs.mojang.com/browse/MC-111480
                 metadata.setMetaType(MetaType1_14.OptVarInt);
             }
-        } else if (type.isOrHasParent(Entity1_14Types.EntityType.ABSTRACT_SKELETON)) {
+        } else if (type.isOrHasParent(Entity1_14Types.ABSTRACT_SKELETON)) {
             if (metadata.getId() == 14) {
                 tracker.setInsentientData(entityId, (byte) ((tracker.getInsentientData(entityId) & ~0x4)
                         | ((boolean) metadata.getValue() ? 0x4 : 0))); // New attacking
@@ -150,7 +150,7 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
             }
         }
 
-        if (type.isOrHasParent(Entity1_14Types.EntityType.ABSTRACT_ILLAGER_BASE)) {
+        if (type.isOrHasParent(Entity1_14Types.ABSTRACT_ILLAGER_BASE)) {
             if (metadata.getId() == 14) {
                 tracker.setInsentientData(entityId, (byte) ((tracker.getInsentientData(entityId) & ~0x4)
                         | (((Number) metadata.getValue()).byteValue() != 0 ? 0x4 : 0))); // New attacking
@@ -160,7 +160,7 @@ public class MetadataRewriter1_14To1_13_2 extends MetadataRewriter {
         }
 
         // TODO Are witch and ravager also abstract illagers? They all inherit the new metadata 14 added in 19w13a
-        if (type.is(Entity1_14Types.EntityType.WITCH) || type.is(Entity1_14Types.EntityType.RAVAGER) || type.isOrHasParent(Entity1_14Types.EntityType.ABSTRACT_ILLAGER_BASE)) {
+        if (type.is(Entity1_14Types.WITCH) || type.is(Entity1_14Types.RAVAGER) || type.isOrHasParent(Entity1_14Types.ABSTRACT_ILLAGER_BASE)) {
             if (metadata.getId() >= 14) {  // TODO 19w13 added a new boolean (raid participant - is celebrating) with id 14
                 metadata.setId(metadata.getId() + 1);
             }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/EntityPackets.java
@@ -3,6 +3,7 @@ package us.myles.ViaVersion.protocols.protocol1_14to1_13_2.packets;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.entities.Entity1_13Types;
 import us.myles.ViaVersion.api.entities.Entity1_14Types;
+import us.myles.ViaVersion.api.entities.EntityType;
 import us.myles.ViaVersion.api.minecraft.Position;
 import us.myles.ViaVersion.api.minecraft.metadata.Metadata;
 import us.myles.ViaVersion.api.minecraft.metadata.types.MetaType1_14;
@@ -50,37 +51,37 @@ public class EntityPackets {
 
                         Entity1_13Types.EntityType type1_13 = Entity1_13Types.getTypeFromId(typeId, true);
                         typeId = metadataRewriter.getNewEntityId(type1_13.getId());
-                        Entity1_14Types.EntityType type1_14 = Entity1_14Types.getTypeFromId(typeId);
+                        EntityType type1_14 = Entity1_14Types.getTypeFromId(typeId);
 
                         if (type1_14 != null) {
                             int data = wrapper.get(Type.INT, 0);
-                            if (type1_14.is(Entity1_14Types.EntityType.FALLING_BLOCK)) {
+                            if (type1_14.is(Entity1_14Types.FALLING_BLOCK)) {
                                 wrapper.set(Type.INT, 0, protocol.getMappingData().getNewBlockStateId(data));
-                            } else if (type1_14.is(Entity1_14Types.EntityType.MINECART)) {
+                            } else if (type1_14.is(Entity1_14Types.MINECART)) {
                                 // default is 0 = rideable minecart
                                 switch (data) {
                                     case 1:
-                                        typeId = Entity1_14Types.EntityType.CHEST_MINECART.getId();
+                                        typeId = Entity1_14Types.CHEST_MINECART.getId();
                                         break;
                                     case 2:
-                                        typeId = Entity1_14Types.EntityType.FURNACE_MINECART.getId();
+                                        typeId = Entity1_14Types.FURNACE_MINECART.getId();
                                         break;
                                     case 3:
-                                        typeId = Entity1_14Types.EntityType.TNT_MINECART.getId();
+                                        typeId = Entity1_14Types.TNT_MINECART.getId();
                                         break;
                                     case 4:
-                                        typeId = Entity1_14Types.EntityType.SPAWNER_MINECART.getId();
+                                        typeId = Entity1_14Types.SPAWNER_MINECART.getId();
                                         break;
                                     case 5:
-                                        typeId = Entity1_14Types.EntityType.HOPPER_MINECART.getId();
+                                        typeId = Entity1_14Types.HOPPER_MINECART.getId();
                                         break;
                                     case 6:
-                                        typeId = Entity1_14Types.EntityType.COMMAND_BLOCK_MINECART.getId();
+                                        typeId = Entity1_14Types.COMMAND_BLOCK_MINECART.getId();
                                         break;
                                 }
-                            } else if ((type1_14.is(Entity1_14Types.EntityType.ITEM) && data > 0)
-                                    || type1_14.isOrHasParent(Entity1_14Types.EntityType.ABSTRACT_ARROW)) {
-                                if (type1_14.isOrHasParent(Entity1_14Types.EntityType.ABSTRACT_ARROW)) {
+                            } else if ((type1_14.is(Entity1_14Types.ITEM) && data > 0)
+                                    || type1_14.isOrHasParent(Entity1_14Types.ABSTRACT_ARROW)) {
+                                if (type1_14.isOrHasParent(Entity1_14Types.ABSTRACT_ARROW)) {
                                     wrapper.set(Type.INT, 0, data - 1);
                                 }
                                 // send velocity in separate packet, 1.14 is now ignoring the velocity
@@ -146,7 +147,7 @@ public class EntityPackets {
                 map(Type.BYTE); // 6 - Pitch
                 map(Types1_13_2.METADATA_LIST, Types1_14.METADATA_LIST); // 7 - Metadata
 
-                handler(metadataRewriter.getTrackerAndRewriter(Types1_14.METADATA_LIST, Entity1_14Types.EntityType.PLAYER));
+                handler(metadataRewriter.getTrackerAndRewriter(Types1_14.METADATA_LIST, Entity1_14Types.PLAYER));
             }
         });
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
@@ -288,7 +288,7 @@ public class WorldPackets {
 
                         int entityId = wrapper.get(Type.INT, 0);
 
-                        Entity1_14Types.EntityType entType = Entity1_14Types.EntityType.PLAYER;
+                        Entity1_14Types entType = Entity1_14Types.PLAYER;
                         // Register Type ID
                         EntityTracker1_14 tracker = wrapper.user().get(EntityTracker1_14.class);
                         tracker.addEntity(entityId, entType);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/storage/EntityTracker1_14.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/storage/EntityTracker1_14.java
@@ -2,7 +2,7 @@ package us.myles.ViaVersion.protocols.protocol1_14to1_13_2.storage;
 
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.data.UserConnection;
-import us.myles.ViaVersion.api.entities.Entity1_14Types.EntityType;
+import us.myles.ViaVersion.api.entities.Entity1_14Types;
 import us.myles.ViaVersion.api.storage.EntityTracker;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.protocols.protocol1_14to1_13_2.Protocol1_14To1_13_2;
@@ -21,7 +21,7 @@ public class EntityTracker1_14 extends EntityTracker {
     private int chunkCenterX, chunkCenterZ;
 
     public EntityTracker1_14(UserConnection user) {
-        super(user, EntityType.PLAYER);
+        super(user, Entity1_14Types.PLAYER);
     }
 
     @Override

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/metadata/MetadataRewriter1_15To1_14_4.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/metadata/MetadataRewriter1_15To1_14_4.java
@@ -37,7 +37,7 @@ public class MetadataRewriter1_15To1_14_4 extends MetadataRewriter {
         if (type == null) return;
 
         // Metadata 12 added to abstract_living
-        if (metadata.getId() > 11 && type.isOrHasParent(Entity1_15Types.EntityType.LIVINGENTITY)) {
+        if (metadata.getId() > 11 && type.isOrHasParent(Entity1_15Types.LIVINGENTITY)) {
             metadata.setId(metadata.getId() + 1); //TODO is it 11 or 12? what is it for?
         }
 
@@ -45,7 +45,7 @@ public class MetadataRewriter1_15To1_14_4 extends MetadataRewriter {
         //new boolean with id 11 for trident, default = false, added in 19w45a
         //new boolean with id 17 for enderman
 
-        if (type.isOrHasParent(Entity1_15Types.EntityType.WOLF)) {
+        if (type.isOrHasParent(Entity1_15Types.WOLF)) {
             if (metadata.getId() == 18) {
                 metadatas.remove(metadata);
             } else if (metadata.getId() > 18) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/packets/EntityPackets.java
@@ -18,7 +18,7 @@ public class EntityPackets {
     public static void register(Protocol1_15To1_14_4 protocol) {
         MetadataRewriter1_15To1_14_4 metadataRewriter = protocol.get(MetadataRewriter1_15To1_14_4.class);
 
-        metadataRewriter.registerSpawnTrackerWithData(ClientboundPackets1_14.SPAWN_ENTITY, Entity1_15Types.EntityType.FALLING_BLOCK);
+        metadataRewriter.registerSpawnTrackerWithData(ClientboundPackets1_14.SPAWN_ENTITY, Entity1_15Types.FALLING_BLOCK);
 
         protocol.registerOutgoing(ClientboundPackets1_14.SPAWN_MOB, new PacketRemapper() {
             @Override
@@ -62,7 +62,7 @@ public class EntityPackets {
 
                 handler(wrapper -> {
                     int entityId = wrapper.get(Type.VAR_INT, 0);
-                    Entity1_15Types.EntityType entityType = Entity1_15Types.EntityType.PLAYER;
+                    Entity1_15Types entityType = Entity1_15Types.PLAYER;
                     wrapper.user().get(EntityTracker1_15.class).addEntity(entityId, entityType);
 
                     List<Metadata> metadata = wrapper.read(Types1_14.METADATA_LIST);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/packets/PlayerPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/packets/PlayerPackets.java
@@ -30,7 +30,7 @@ public class PlayerPackets {
                     // Register Type ID
                     EntityTracker1_15 tracker = wrapper.user().get(EntityTracker1_15.class);
                     int entityId = wrapper.get(Type.INT, 0);
-                    tracker.addEntity(entityId, Entity1_15Types.EntityType.PLAYER);
+                    tracker.addEntity(entityId, Entity1_15Types.PLAYER);
                 });
                 create(wrapper -> wrapper.write(Type.LONG, 0L)); // Level Seed
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/storage/EntityTracker1_15.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_15to1_14_4/storage/EntityTracker1_15.java
@@ -1,12 +1,12 @@
 package us.myles.ViaVersion.protocols.protocol1_15to1_14_4.storage;
 
 import us.myles.ViaVersion.api.data.UserConnection;
-import us.myles.ViaVersion.api.entities.Entity1_15Types.EntityType;
+import us.myles.ViaVersion.api.entities.Entity1_15Types;
 import us.myles.ViaVersion.api.storage.EntityTracker;
 
 public class EntityTracker1_15 extends EntityTracker {
 
     public EntityTracker1_15(UserConnection user) {
-        super(user, EntityType.PLAYER);
+        super(user, Entity1_15Types.PLAYER);
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16_2to1_16_1/metadata/MetadataRewriter1_16_2To1_16_1.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16_2to1_16_1/metadata/MetadataRewriter1_16_2To1_16_1.java
@@ -19,7 +19,7 @@ public class MetadataRewriter1_16_2To1_16_1 extends MetadataRewriter {
 
     public MetadataRewriter1_16_2To1_16_1(Protocol1_16_2To1_16_1 protocol) {
         super(protocol, EntityTracker1_16_2.class);
-        mapTypes(Entity1_16Types.EntityType.values(), Entity1_16_2Types.EntityType.class);
+        mapTypes(Entity1_16Types.values(), Entity1_16_2Types.class);
     }
 
     @Override
@@ -35,7 +35,7 @@ public class MetadataRewriter1_16_2To1_16_1 extends MetadataRewriter {
 
         if (type == null) return;
 
-        if (type.isOrHasParent(Entity1_16_2Types.EntityType.ABSTRACT_PIGLIN)) {
+        if (type.isOrHasParent(Entity1_16_2Types.ABSTRACT_PIGLIN)) {
             if (metadata.getId() == 15) {
                 metadata.setId(16);
             } else if (metadata.getId() == 16) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16_2to1_16_1/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16_2to1_16_1/packets/EntityPackets.java
@@ -15,9 +15,9 @@ public class EntityPackets {
 
     public static void register(Protocol1_16_2To1_16_1 protocol) {
         MetadataRewriter1_16_2To1_16_1 metadataRewriter = protocol.get(MetadataRewriter1_16_2To1_16_1.class);
-        metadataRewriter.registerSpawnTrackerWithData(ClientboundPackets1_16.SPAWN_ENTITY, Entity1_16_2Types.EntityType.FALLING_BLOCK);
+        metadataRewriter.registerSpawnTrackerWithData(ClientboundPackets1_16.SPAWN_ENTITY, Entity1_16_2Types.FALLING_BLOCK);
         metadataRewriter.registerTracker(ClientboundPackets1_16.SPAWN_MOB);
-        metadataRewriter.registerTracker(ClientboundPackets1_16.SPAWN_PLAYER, Entity1_16_2Types.EntityType.PLAYER);
+        metadataRewriter.registerTracker(ClientboundPackets1_16.SPAWN_PLAYER, Entity1_16_2Types.PLAYER);
         metadataRewriter.registerMetadataRewriter(ClientboundPackets1_16.ENTITY_METADATA, Types1_14.METADATA_LIST);
         metadataRewriter.registerEntityDestroy(ClientboundPackets1_16.DESTROY_ENTITIES);
 
@@ -48,7 +48,7 @@ public class EntityPackets {
                 map(Type.UNSIGNED_BYTE, Type.VAR_INT); // Max players
                 // ...
                 handler(wrapper -> {
-                    wrapper.user().get(EntityTracker1_16_2.class).addEntity(wrapper.get(Type.INT, 0), Entity1_16_2Types.EntityType.PLAYER);
+                    wrapper.user().get(EntityTracker1_16_2.class).addEntity(wrapper.get(Type.INT, 0), Entity1_16_2Types.PLAYER);
                 });
             }
         });

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16_2to1_16_1/storage/EntityTracker1_16_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16_2to1_16_1/storage/EntityTracker1_16_2.java
@@ -1,12 +1,12 @@
 package us.myles.ViaVersion.protocols.protocol1_16_2to1_16_1.storage;
 
 import us.myles.ViaVersion.api.data.UserConnection;
-import us.myles.ViaVersion.api.entities.Entity1_16_2Types.EntityType;
+import us.myles.ViaVersion.api.entities.Entity1_16_2Types;
 import us.myles.ViaVersion.api.storage.EntityTracker;
 
 public class EntityTracker1_16_2 extends EntityTracker {
 
     public EntityTracker1_16_2(UserConnection user) {
-        super(user, EntityType.PLAYER);
+        super(user, Entity1_16_2Types.PLAYER);
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/metadata/MetadataRewriter1_16To1_15_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/metadata/MetadataRewriter1_16To1_15_2.java
@@ -19,8 +19,8 @@ public class MetadataRewriter1_16To1_15_2 extends MetadataRewriter {
 
     public MetadataRewriter1_16To1_15_2(Protocol1_16To1_15_2 protocol) {
         super(protocol, EntityTracker1_16.class);
-        mapType(Entity1_15Types.EntityType.ZOMBIE_PIGMAN, Entity1_16Types.EntityType.ZOMBIFIED_PIGLIN);
-        mapTypes(Entity1_15Types.EntityType.values(), Entity1_16Types.EntityType.class);
+        mapType(Entity1_15Types.ZOMBIE_PIGMAN, Entity1_16Types.ZOMBIFIED_PIGLIN);
+        mapTypes(Entity1_15Types.values(), Entity1_16Types.class);
     }
 
     @Override
@@ -36,7 +36,7 @@ public class MetadataRewriter1_16To1_15_2 extends MetadataRewriter {
 
         if (type == null) return;
 
-        if (type.isOrHasParent(Entity1_16Types.EntityType.ABSTRACT_ARROW)) {
+        if (type.isOrHasParent(Entity1_16Types.ABSTRACT_ARROW)) {
             if (metadata.getId() == 8) {
                 metadatas.remove(metadata);
             } else if (metadata.getId() > 8) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
@@ -135,10 +135,10 @@ public class EntityPackets {
             public void registerMap() {
                 handler(wrapper -> {
                     int entityId = wrapper.passthrough(Type.VAR_INT);
-                    wrapper.user().get(EntityTracker1_16.class).addEntity(entityId, Entity1_16Types.EntityType.LIGHTNING_BOLT);
+                    wrapper.user().get(EntityTracker1_16.class).addEntity(entityId, Entity1_16Types.LIGHTNING_BOLT);
 
                     wrapper.write(Type.UUID, UUID.randomUUID()); // uuid
-                    wrapper.write(Type.VAR_INT, Entity1_16Types.EntityType.LIGHTNING_BOLT.getId()); // entity type
+                    wrapper.write(Type.VAR_INT, Entity1_16Types.LIGHTNING_BOLT.getId()); // entity type
 
                     wrapper.read(Type.BYTE); // remove type
 
@@ -155,9 +155,9 @@ public class EntityPackets {
             }
         });
 
-        metadataRewriter.registerSpawnTrackerWithData(ClientboundPackets1_15.SPAWN_ENTITY, Entity1_16Types.EntityType.FALLING_BLOCK);
+        metadataRewriter.registerSpawnTrackerWithData(ClientboundPackets1_15.SPAWN_ENTITY, Entity1_16Types.FALLING_BLOCK);
         metadataRewriter.registerTracker(ClientboundPackets1_15.SPAWN_MOB);
-        metadataRewriter.registerTracker(ClientboundPackets1_15.SPAWN_PLAYER, Entity1_16Types.EntityType.PLAYER);
+        metadataRewriter.registerTracker(ClientboundPackets1_15.SPAWN_PLAYER, Entity1_16Types.PLAYER);
         metadataRewriter.registerMetadataRewriter(ClientboundPackets1_15.ENTITY_METADATA, Types1_14.METADATA_LIST);
         metadataRewriter.registerEntityDestroy(ClientboundPackets1_15.DESTROY_ENTITIES);
 
@@ -192,7 +192,7 @@ public class EntityPackets {
                 map(Type.LONG); // Seed
                 map(Type.UNSIGNED_BYTE); // Max players
                 handler(wrapper -> {
-                    wrapper.user().get(EntityTracker1_16.class).addEntity(wrapper.get(Type.INT, 0), Entity1_16Types.EntityType.PLAYER);
+                    wrapper.user().get(EntityTracker1_16.class).addEntity(wrapper.get(Type.INT, 0), Entity1_16Types.PLAYER);
 
                     final String type = wrapper.read(Type.STRING);// level type
                     wrapper.passthrough(Type.VAR_INT); // View distance

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/storage/EntityTracker1_16.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_16to1_15_2/storage/EntityTracker1_16.java
@@ -1,12 +1,12 @@
 package us.myles.ViaVersion.protocols.protocol1_16to1_15_2.storage;
 
 import us.myles.ViaVersion.api.data.UserConnection;
-import us.myles.ViaVersion.api.entities.Entity1_16Types.EntityType;
+import us.myles.ViaVersion.api.entities.Entity1_16Types;
 import us.myles.ViaVersion.api.storage.EntityTracker;
 
 public class EntityTracker1_16 extends EntityTracker {
 
     public EntityTracker1_16(UserConnection user) {
-        super(user, EntityType.PLAYER);
+        super(user, Entity1_16Types.PLAYER);
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/metadata/MetadataRewriter1_17To1_16_4.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/metadata/MetadataRewriter1_17To1_16_4.java
@@ -19,7 +19,7 @@ public class MetadataRewriter1_17To1_16_4 extends MetadataRewriter {
 
     public MetadataRewriter1_17To1_16_4(Protocol1_17To1_16_4 protocol) {
         super(protocol, EntityTracker1_17.class);
-        mapTypes(Entity1_16_2Types.EntityType.values(), Entity1_17Types.EntityType.class);
+        mapTypes(Entity1_16_2Types.values(), Entity1_17Types.class);
     }
 
     @Override
@@ -36,13 +36,13 @@ public class MetadataRewriter1_17To1_16_4 extends MetadataRewriter {
 
         if (type == null) return;
 
-        if (type.isOrHasParent(Entity1_17Types.EntityType.ENTITY)) {
+        if (type.isOrHasParent(Entity1_17Types.ENTITY)) {
             if (metadata.getId() >= 7) {
                 metadata.setId(metadata.getId() + 1); // Ticks frozen added with id 7
             }
         }
 
-        if (type == Entity1_17Types.EntityType.SHULKER) {
+        if (type == Entity1_17Types.SHULKER) {
             // Attachment position removed
             if (metadata.getId() == 16) {
                 metadatas.remove(metadata);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/packets/EntityPackets.java
@@ -13,9 +13,9 @@ public class EntityPackets {
 
     public static void register(Protocol1_17To1_16_4 protocol) {
         MetadataRewriter1_17To1_16_4 metadataRewriter = protocol.get(MetadataRewriter1_17To1_16_4.class);
-        metadataRewriter.registerSpawnTrackerWithData(ClientboundPackets1_16_2.SPAWN_ENTITY, Entity1_17Types.EntityType.FALLING_BLOCK);
+        metadataRewriter.registerSpawnTrackerWithData(ClientboundPackets1_16_2.SPAWN_ENTITY, Entity1_17Types.FALLING_BLOCK);
         metadataRewriter.registerTracker(ClientboundPackets1_16_2.SPAWN_MOB);
-        metadataRewriter.registerTracker(ClientboundPackets1_16_2.SPAWN_PLAYER, Entity1_17Types.EntityType.PLAYER);
+        metadataRewriter.registerTracker(ClientboundPackets1_16_2.SPAWN_PLAYER, Entity1_17Types.PLAYER);
         metadataRewriter.registerMetadataRewriter(ClientboundPackets1_16_2.ENTITY_METADATA, Types1_14.METADATA_LIST, Types1_17.METADATA_LIST);
         metadataRewriter.registerEntityDestroy(ClientboundPackets1_16_2.DESTROY_ENTITIES);
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/packets/WorldPackets.java
@@ -141,7 +141,7 @@ public class WorldPackets {
 
                     UserConnection user = wrapper.user();
                     user.get(BiomeStorage.class).setWorld(world);
-                    user.get(EntityTracker1_17.class).addEntity(wrapper.get(Type.INT, 0), Entity1_17Types.EntityType.PLAYER);
+                    user.get(EntityTracker1_17.class).addEntity(wrapper.get(Type.INT, 0), Entity1_17Types.PLAYER);
                 });
             }
         });

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/storage/EntityTracker1_17.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_17to1_16_4/storage/EntityTracker1_17.java
@@ -1,12 +1,12 @@
 package us.myles.ViaVersion.protocols.protocol1_17to1_16_4.storage;
 
 import us.myles.ViaVersion.api.data.UserConnection;
-import us.myles.ViaVersion.api.entities.Entity1_17Types.EntityType;
+import us.myles.ViaVersion.api.entities.Entity1_17Types;
 import us.myles.ViaVersion.api.storage.EntityTracker;
 
 public class EntityTracker1_17 extends EntityTracker {
 
     public EntityTracker1_17(UserConnection user) {
-        super(user, EntityType.PLAYER);
+        super(user, Entity1_17Types.PLAYER);
     }
 }

--- a/common/src/test/java/us/myles/ViaVersion/common/entities/EntityTypesTest.java
+++ b/common/src/test/java/us/myles/ViaVersion/common/entities/EntityTypesTest.java
@@ -1,0 +1,35 @@
+package us.myles.ViaVersion.common.entities;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import us.myles.ViaVersion.api.entities.Entity1_14Types;
+import us.myles.ViaVersion.api.entities.Entity1_15Types;
+import us.myles.ViaVersion.api.entities.Entity1_16Types;
+import us.myles.ViaVersion.api.entities.Entity1_16_2Types;
+import us.myles.ViaVersion.api.entities.Entity1_17Types;
+import us.myles.ViaVersion.api.entities.EntityType;
+
+import java.util.function.Function;
+
+/**
+ * Test to make sure the array storage approach of entity types works correctly.
+ */
+public class EntityTypesTest {
+
+    @Test
+    void testArrayOrder() {
+        testArrayOrder(Entity1_14Types.values(), Entity1_14Types::getTypeFromId);
+        testArrayOrder(Entity1_15Types.values(), Entity1_15Types::getTypeFromId);
+        testArrayOrder(Entity1_16Types.values(), Entity1_16Types::getTypeFromId);
+        testArrayOrder(Entity1_16_2Types.values(), Entity1_16_2Types::getTypeFromId);
+        testArrayOrder(Entity1_17Types.values(), Entity1_17Types::getTypeFromId);
+    }
+
+    private void testArrayOrder(EntityType[] types, Function<Integer, EntityType> returnFunction) {
+        for (EntityType type : types) {
+            if (type.getId() != -1) {
+                Assertions.assertEquals(type, returnFunction.apply(type.getId()));
+            }
+        }
+    }
+}

--- a/common/src/test/java/us/myles/ViaVersion/common/type/ItemTypeTest.java
+++ b/common/src/test/java/us/myles/ViaVersion/common/type/ItemTypeTest.java
@@ -1,4 +1,4 @@
-package us.myles.ViaVersion.common.test.type;
+package us.myles.ViaVersion.common.type;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/common/src/test/java/us/myles/ViaVersion/common/type/StringTypeTest.java
+++ b/common/src/test/java/us/myles/ViaVersion/common/type/StringTypeTest.java
@@ -1,4 +1,4 @@
-package us.myles.ViaVersion.common.test.type;
+package us.myles.ViaVersion.common.type;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;


### PR DESCRIPTION
Gets rid of the nested EntityX_YTypes.EntityType enum (which was done because of ObjectType vs. EntityType in pre 1.14 versions) and improves type getting by using a simple array instead of a map + boxing