### PR TITLE
[1.9 -> 1.8] Fix handling of animation 3

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/EntityPackets.java
@@ -318,6 +318,22 @@ public class EntityPackets {
             }
         });
 
+        protocol.registerOutgoing(ClientboundPackets1_8.ENTITY_ANIMATION, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // 0 - Entity ID
+                map(Type.UNSIGNED_BYTE); // 1 - Animation
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        if(wrapper.get(Type.UNSIGNED_BYTE, 0) == 3) {
+                            wrapper.cancel();
+                        }
+                    }
+                });
+            }
+        });
+
 
         /* Incoming Packets */
         protocol.registerIncoming(ServerboundPackets1_9.ENTITY_ACTION, new PacketRemapper() {


### PR DESCRIPTION
This fixes 1.9 players seeing offhand swing animation when 1.8 player starts eating. 1.8 servers send an animation packet with animateionId 3 which doesn't even get handled by 1.8 clients (https://prnt.sc/100qn81). 1.9 reused this id for offhand swing animation