### PR TITLE
Fix Bunge Chat relocation (ExceptionInInitializerError)

### DIFF
--- a/buildSrc/src/main/kotlin/extensions.kt
+++ b/buildSrc/src/main/kotlin/extensions.kt
@@ -34,6 +34,7 @@ private fun ShadowJar.configureRelocations() {
     relocate("com.github.steveice10.opennbt", "us.myles.viaversion.libs.opennbt")
     relocate("net.md_5.bungee", "us.myles.viaversion.libs.bungeecordchat") {
         include("net.md_5.bungee.api.chat.*")
+        include("net.md_5.bungee.api.chat.hover.content.*")
         include("net.md_5.bungee.api.ChatColor")
         include("net.md_5.bungee.api.ChatMessageType")
         include("net.md_5.bungee.chat.*")


### PR DESCRIPTION
It is a deficient part of Bunge Chat relocation. (5e227cb)

![image](https://user-images.githubusercontent.com/45729082/109396526-63f3f900-7975-11eb-9a6b-d624febb0da1.png)
