### PR TITLE
Fixes delayed shield blocking

### DIFF
--- a/api/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
+++ b/api/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
@@ -77,6 +77,13 @@ public interface ViaVersionConfig {
     boolean isShieldBlocking();
 
     /**
+     * Whether the player can block with the shield without a delay.
+     *
+     * @return {@code true} if non delayed shield blocking is enabled.
+     */
+    boolean isNoDelayShieldBlocking();
+
+    /**
      * Get if armor stand positions are fixed so holograms show up at the correct height in 1.9 &amp; 1.10
      *
      * @return true if hologram patching is enabled

--- a/common/src/main/java/us/myles/ViaVersion/AbstractViaConfig.java
+++ b/common/src/main/java/us/myles/ViaVersion/AbstractViaConfig.java
@@ -32,6 +32,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private boolean useNewDeathmessages;
     private boolean suppressMetadataErrors;
     private boolean shieldBlocking;
+    private boolean noDelayShieldBlocking;
     private boolean hologramPatch;
     private boolean pistonAnimationPatch;
     private boolean bossbarPatch;
@@ -91,6 +92,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         useNewDeathmessages = getBoolean("use-new-deathmessages", true);
         suppressMetadataErrors = getBoolean("suppress-metadata-errors", false);
         shieldBlocking = getBoolean("shield-blocking", true);
+        noDelayShieldBlocking = getBoolean("no-delay-shield-blocking", false);
         hologramPatch = getBoolean("hologram-patch", false);
         pistonAnimationPatch = getBoolean("piston-animation-patch", false);
         bossbarPatch = getBoolean("bossbar-patch", true);
@@ -168,6 +170,11 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public boolean isShieldBlocking() {
         return shieldBlocking;
+    }
+
+    @Override
+    public boolean isNoDelayShieldBlocking() {
+        return noDelayShieldBlocking;
     }
 
     @Override

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java
@@ -294,11 +294,9 @@ public class WorldPackets {
                         Item item = Protocol1_9To1_8.getHandItem(wrapper.user());
                         // Blocking patch
                         if (Via.getConfig().isShieldBlocking()) {
-                            boolean noDelayBlocking = Via.getConfig().isNoDelayShieldBlocking();
                             EntityTracker1_9 tracker = wrapper.user().get(EntityTracker1_9.class);
 
                             if (item != null && Protocol1_9To1_8.isSword(item.getIdentifier())) {
-                                // Uses sword interaction as block action
                                 if (hand == 0) {
                                     if (!tracker.isBlocking()) {
                                         tracker.setBlocking(true);
@@ -306,8 +304,11 @@ public class WorldPackets {
                                         tracker.setSecondHand(shield);
                                     }
                                 }
+
+                                // Uses left or right hand to start blocking depending on the no delay setting
+                                boolean noDelayBlocking = Via.getConfig().isNoDelayShieldBlocking();
+
                                 if (noDelayBlocking && hand == 1 || !noDelayBlocking && hand == 0) {
-                                    // Cancel left hand interactions
                                     wrapper.cancel();
                                 }
                             } else {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java
@@ -294,15 +294,20 @@ public class WorldPackets {
                         Item item = Protocol1_9To1_8.getHandItem(wrapper.user());
                         // Blocking patch
                         if (Via.getConfig().isShieldBlocking()) {
+                            boolean noDelayBlocking = Via.getConfig().isNoDelayShieldBlocking();
                             EntityTracker1_9 tracker = wrapper.user().get(EntityTracker1_9.class);
 
                             if (item != null && Protocol1_9To1_8.isSword(item.getIdentifier())) {
+                                // Uses sword interaction as block action
                                 if (hand == 0) {
                                     if (!tracker.isBlocking()) {
                                         tracker.setBlocking(true);
                                         Item shield = new Item(442, (byte) 1, (short) 0, null);
                                         tracker.setSecondHand(shield);
                                     }
+                                }
+                                if (noDelayBlocking && hand == 1 || !noDelayBlocking && hand == 0) {
+                                    // Cancel left hand interactions
                                     wrapper.cancel();
                                 }
                             } else {

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -167,6 +167,9 @@ auto-team: true
 suppress-metadata-errors: false
 # When enabled 1.9+ will be able to block by using shields
 shield-blocking: true
+# If this setting is active, the main hand is used instead of the off hand to trigger the blocking of the player.
+# With the main hand the blocking starts way faster.
+no-delay-shield-blocking: false
 # Enable player tick simulation, this fixes eating, drinking, nether portals.
 simulate-pt: true
 # Should we use nms player to simulate packets, (may fix anti-cheat issues)


### PR DESCRIPTION
We have noticed that blocking through viaversion is delayed.
The reason for this is that you send an interaction to ViaVersion with the sword in the main hand,
which then puts a shield in the offhand and the client then
starts an interaction packet with the offhand blocking.

## no-delay-shield-blocking false
![unknown](https://user-images.githubusercontent.com/36857475/113325095-3a354580-9318-11eb-9c01-64b7cf6644b4.png)

A better solution would be to trigger the blocking directly via the main hand but additionally place the shield visually in the offhand.
This change also fixes the issue that sometimes the shield stays in your inventory when you block for a very short time.

## no-delay-shield-blocking true
![unknown_!](https://user-images.githubusercontent.com/36857475/113325099-3d303600-9318-11eb-8e5f-84b847ab0f92.png)
