### PR TITLE
fix showShieldWhenSwordInHand issues

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java
@@ -301,13 +301,17 @@ public class WorldPackets {
                             // Check if the shield is already there or if we have to give it here
                             boolean showShieldWhenSwordInHand = Via.getConfig().isShowShieldWhenSwordInHand();
 
-                            if (item != null && Protocol1_9To1_8.isSword(item.getIdentifier())) {
+                            // Method to identify the sword in hand
+                            boolean isSword = showShieldWhenSwordInHand ? tracker.hasSwordInHand()
+                                    : item != null && Protocol1_9To1_8.isSword(item.getIdentifier());
+
+                            if (isSword) {
                                 if (hand == 0) {
                                     if (!tracker.isBlocking()) {
                                         tracker.setBlocking(true);
 
                                         // Check if the shield is already in the offhand
-                                        if (!showShieldWhenSwordInHand || tracker.getItemInSecondHand() == null) {
+                                        if (!showShieldWhenSwordInHand && tracker.getItemInSecondHand() == null) {
 
                                             // Set shield in offhand when interacting with main hand
                                             Item shield = new Item(442, (byte) 1, (short) 0, null);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
@@ -108,20 +108,28 @@ public class EntityTracker1_9 extends EntityTracker {
      * The item in the offhand will be cleared if there is no sword in the main hand.
      */
     public void syncShieldWithSword() {
+        boolean swordInHand = hasSwordInHand();
+
+        // Update if there is no sword in the main hand or if the player has no shield in the second hand but a sword in the main hand
+        if (!swordInHand || this.itemInSecondHand == null) {
+
+            // Update shield in off hand depending if a sword is in the main hand
+            setSecondHand(swordInHand ? new Item(442, (byte) 1, (short) 0, null) : null);
+        }
+    }
+
+    /**
+     * Returns true if the item in the held inventory slot is a sword.
+     * @return player has a sword in the main hand
+     */
+    public boolean hasSwordInHand() {
         InventoryTracker inventoryTracker = getUser().get(InventoryTracker.class);
 
         // Get item in new selected slot
         int inventorySlot = this.heldItemSlot + 36; // Hotbar slot index to inventory slot
         int itemIdentifier = inventoryTracker.getItemId((short) 0, (short) inventorySlot);
 
-        boolean isSword = Protocol1_9To1_8.isSword(itemIdentifier);
-
-        // Update if the state changed
-        if (isSword == (this.itemInSecondHand == null)) {
-
-            // Update shield in off hand depending if a sword is in the main hand
-            setSecondHand(isSword ? new Item(442, (byte) 1, (short) 0, null) : null);
-        }
+        return Protocol1_9To1_8.isSword(itemIdentifier);
     }
 
     @Override


### PR DESCRIPTION
I fixed two issues of the **showShieldWhenSwordInHand** feature:
- For some reason the shield sometimes remained as a ghost item in the second hand after changing the held item slot.
  The shield sync of the InventoryTracker works without any problems. [Video](https://i.imgur.com/4S9dMeG.mp4)
   **Solution:** The item in the second hand will now be removed more frequently and not only when you switch off a sword.

- You could not interact with items when you quickly switch from a sword to another item. [Video](https://www.youtube.com/watch?v=IMCHrj2Do9M)
   **Solution:** The item cache of the InventoryTracker will now be used to check if the player interacts with a sword because it updates way faster.