### PR TITLE
Modified ProtocolVersion to properly reflect the fact that Minecraft versions 1.16.5 and 1.16.4 use the same underlying network protocol ID.

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolVersion.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolVersion.java
@@ -53,7 +53,7 @@ public class ProtocolVersion {
     public static final ProtocolVersion v1_16_1 = register(736, "1.16.1");
     public static final ProtocolVersion v1_16_2 = register(751, "1.16.2");
     public static final ProtocolVersion v1_16_3 = register(753, "1.16.3");
-    public static final ProtocolVersion v1_16_4 = register(754, "1.16.4");
+    public static final ProtocolVersion v1_16_4 = register(754, "1.16.4/5", new VersionRange("1.16", 4, 5));
     public static final ProtocolVersion unknown = register(-1, "UNKNOWN");
 
     public static ProtocolVersion register(int version, String name) {


### PR DESCRIPTION
Modified ProtocolVersion to properly reflect the fact that Minecraft versions 1.16.5 and 1.16.4 use the same underlying network protocol ID.

… Not much else to say about this, it's a pretty simple modification ;P