### PR TITLE
Bungee Fixes

### DIFF
--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeChannelInitializer.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeChannelInitializer.java
@@ -4,6 +4,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.ProtocolPipeline;
+import us.myles.ViaVersion.exception.CancelException;
 
 import java.lang.reflect.Method;
 
@@ -24,7 +25,7 @@ public class BungeeChannelInitializer extends ChannelInitializer<Channel> {
     @Override
     protected void initChannel(Channel socketChannel) throws Exception {
         if (!socketChannel.isActive()) {
-            return;
+            throw new CancelException("Connection inactive");
         }
 
         UserConnection info = new UserConnection(socketChannel);

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeChannelInitializer.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeChannelInitializer.java
@@ -4,7 +4,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.ProtocolPipeline;
-import us.myles.ViaVersion.exception.CancelException;
 
 import java.lang.reflect.Method;
 
@@ -25,7 +24,7 @@ public class BungeeChannelInitializer extends ChannelInitializer<Channel> {
     @Override
     protected void initChannel(Channel socketChannel) throws Exception {
         if (!socketChannel.isActive()) {
-            throw new CancelException("Connection inactive");
+            return;
         }
 
         UserConnection info = new UserConnection(socketChannel);

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeChannelInitializer.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeChannelInitializer.java
@@ -23,6 +23,10 @@ public class BungeeChannelInitializer extends ChannelInitializer<Channel> {
 
     @Override
     protected void initChannel(Channel socketChannel) throws Exception {
+        if (!socketChannel.isActive()) {
+            return;
+        }
+
         UserConnection info = new UserConnection(socketChannel);
         // init protocol
         new ProtocolPipeline(info);

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeDecodeHandler.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeDecodeHandler.java
@@ -21,7 +21,7 @@ public class BungeeDecodeHandler extends MessageToMessageDecoder<ByteBuf> {
     @Override
     protected void decode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
         if (!ctx.channel().isActive()) {
-            throw new CancelDecoderException("Connection inactive");
+            throw CancelDecoderException.generate(null);
         }
 
         if (!info.checkIncomingPacket()) throw CancelDecoderException.generate(null);

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeDecodeHandler.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeDecodeHandler.java
@@ -20,6 +20,10 @@ public class BungeeDecodeHandler extends MessageToMessageDecoder<ByteBuf> {
 
     @Override
     protected void decode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
+        if (!ctx.channel().isActive()) {
+            return;
+        }
+
         if (!info.checkIncomingPacket()) throw CancelDecoderException.generate(null);
         if (!info.shouldTransformPacket()) {
             out.add(bytebuf.retain());

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeDecodeHandler.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeDecodeHandler.java
@@ -7,6 +7,7 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.exception.CancelDecoderException;
 import us.myles.ViaVersion.exception.CancelCodecException;
+import us.myles.ViaVersion.exception.CancelException;
 
 import java.util.List;
 
@@ -21,7 +22,7 @@ public class BungeeDecodeHandler extends MessageToMessageDecoder<ByteBuf> {
     @Override
     protected void decode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
         if (!ctx.channel().isActive()) {
-            return;
+            throw new CancelException("Connection inactive");
         }
 
         if (!info.checkIncomingPacket()) throw CancelDecoderException.generate(null);

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeDecodeHandler.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeDecodeHandler.java
@@ -7,7 +7,6 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.exception.CancelDecoderException;
 import us.myles.ViaVersion.exception.CancelCodecException;
-import us.myles.ViaVersion.exception.CancelException;
 
 import java.util.List;
 
@@ -22,7 +21,7 @@ public class BungeeDecodeHandler extends MessageToMessageDecoder<ByteBuf> {
     @Override
     protected void decode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
         if (!ctx.channel().isActive()) {
-            throw new CancelException("Connection inactive");
+            throw new CancelDecoderException("Connection inactive");
         }
 
         if (!info.checkIncomingPacket()) throw CancelDecoderException.generate(null);

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeEncodeHandler.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeEncodeHandler.java
@@ -22,6 +22,10 @@ public class BungeeEncodeHandler extends MessageToMessageEncoder<ByteBuf> {
 
     @Override
     protected void encode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
+        if (!ctx.channel().isActive()) {
+            return;
+        }
+
         if (!info.checkOutgoingPacket()) throw CancelEncoderException.generate(null);
         if (!info.shouldTransformPacket()) {
             out.add(bytebuf.retain());

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeEncodeHandler.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeEncodeHandler.java
@@ -23,7 +23,7 @@ public class BungeeEncodeHandler extends MessageToMessageEncoder<ByteBuf> {
     @Override
     protected void encode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
         if (!ctx.channel().isActive()) {
-            throw new CancelEncoderException("Connection inactive");
+            throw CancelEncoderException.generate(null);
         }
 
         if (!info.checkOutgoingPacket()) throw CancelEncoderException.generate(null);

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeEncodeHandler.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeEncodeHandler.java
@@ -8,7 +8,6 @@ import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.bungee.util.BungeePipelineUtil;
 import us.myles.ViaVersion.exception.CancelEncoderException;
 import us.myles.ViaVersion.exception.CancelCodecException;
-import us.myles.ViaVersion.exception.CancelException;
 
 import java.util.List;
 
@@ -24,7 +23,7 @@ public class BungeeEncodeHandler extends MessageToMessageEncoder<ByteBuf> {
     @Override
     protected void encode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
         if (!ctx.channel().isActive()) {
-            throw new CancelException("Connection inactive");
+            throw new CancelEncoderException("Connection inactive");
         }
 
         if (!info.checkOutgoingPacket()) throw CancelEncoderException.generate(null);

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeEncodeHandler.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeEncodeHandler.java
@@ -8,6 +8,7 @@ import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.bungee.util.BungeePipelineUtil;
 import us.myles.ViaVersion.exception.CancelEncoderException;
 import us.myles.ViaVersion.exception.CancelCodecException;
+import us.myles.ViaVersion.exception.CancelException;
 
 import java.util.List;
 
@@ -23,7 +24,7 @@ public class BungeeEncodeHandler extends MessageToMessageEncoder<ByteBuf> {
     @Override
     protected void encode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
         if (!ctx.channel().isActive()) {
-            return;
+            throw new CancelException("Connection inactive");
         }
 
         if (!info.checkOutgoingPacket()) throw CancelEncoderException.generate(null);


### PR DESCRIPTION
We check if the connection is active before doing anything to fix issues in Bungee servers.

We fix:
1. Exceptions if the connection is closed.
2. Support for Bungee AntiBot systems.

Testing Info:
Base: 1.8.8 (SportPaper & FlameCord (ViaRew. & ViaVer.))
Clients: 1.7, 1.8, 1.12
Errors: None at all