### PR TITLE
Remove IDLE_PACKET_LIMIT

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/MovementTracker.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/MovementTracker.java
@@ -5,7 +5,6 @@ import us.myles.ViaVersion.api.data.UserConnection;
 
 public class MovementTracker extends StoredObject {
     private static final long IDLE_PACKET_DELAY = 50L; // Update every 50ms (20tps)
-    private static final long IDLE_PACKET_LIMIT = 20; // Max 20 ticks behind
     private long nextIdlePacket = 0L;
     private boolean ground = true;
 
@@ -16,7 +15,7 @@ public class MovementTracker extends StoredObject {
     public void incrementIdlePacket() {
         // Notify of next update
         // Allow a maximum lag spike of 1 second (20 ticks/updates)
-        this.nextIdlePacket = Math.max(nextIdlePacket + IDLE_PACKET_DELAY, System.currentTimeMillis() - IDLE_PACKET_DELAY * IDLE_PACKET_LIMIT);
+        this.nextIdlePacket = Math.max(nextIdlePacket + IDLE_PACKET_DELAY, System.currentTimeMillis());
     }
 
     public long getNextIdlePacket() {


### PR DESCRIPTION
This makes the server receive two movement packets for 20 ticks when player starts to move