### PR TITLE
Don't inject if inactive

### DIFF
--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeChannelInitializer.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/handlers/BungeeChannelInitializer.java
@@ -29,6 +29,7 @@ public class BungeeChannelInitializer extends ChannelInitializer<Channel> {
         // Add originals
         this.method.invoke(this.original, socketChannel);
 
+        if (!socketChannel.isActive()) return; // Don't inject if inactive
         if (socketChannel.pipeline().get("packet-encoder") == null) return; // Don't inject if no packet-encoder
         if (socketChannel.pipeline().get("packet-decoder") == null) return; // Don't inject if no packet-decoder
         // Add our transformers


### PR DESCRIPTION
Bungee checks like throttle lay on the initializer. To prevent attacks or exploits we check if the channel is active before injecting.