### PR TITLE
Fixed a metadata bug (1.17 Client, 1.14 or less Server)

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_15to1_14_4/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_15to1_14_4/packets/EntityPackets.java
@@ -21,12 +21,14 @@ import com.viaversion.viaversion.api.minecraft.entities.Entity1_15Types;
 import com.viaversion.viaversion.api.minecraft.metadata.Metadata;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketRemapper;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.version.Types1_14;
 import com.viaversion.viaversion.protocols.protocol1_14to1_13_2.ClientboundPackets1_14;
 import com.viaversion.viaversion.protocols.protocol1_15to1_14_4.Protocol1_15To1_14_4;
 import com.viaversion.viaversion.protocols.protocol1_15to1_14_4.metadata.MetadataRewriter1_15To1_14_4;
 import com.viaversion.viaversion.protocols.protocol1_15to1_14_4.storage.EntityTracker1_15;
+import com.viaversion.viaversion.rewriter.MetadataRewriter;
 
 import java.util.List;
 
@@ -84,6 +86,8 @@ public class EntityPackets {
 
                     List<Metadata> metadata = wrapper.read(Types1_14.METADATA_LIST);
                     metadataRewriter.handleMetadata(entityId, metadata, wrapper.user());
+                    if (wrapper.user().getProtocolInfo().getProtocolVersion() >= ProtocolVersion.v1_17.getVersion())
+                        metadata.add(MetadataRewriter.DUMMY_META_FOR_1_17);
                     PacketWrapper metadataUpdate = wrapper.create(0x44);
                     metadataUpdate.write(Type.VAR_INT, entityId);
                     metadataUpdate.write(Types1_14.METADATA_LIST, metadata);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/metadata/MetadataRewriter1_17To1_16_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/metadata/MetadataRewriter1_17To1_16_4.java
@@ -58,6 +58,10 @@ public class MetadataRewriter1_17To1_16_4 extends MetadataRewriter {
         }
 
         if (type == null) return;
+        if (metadata == MetadataRewriter.DUMMY_META_FOR_1_17) {
+            metadatas.remove(metadata);
+            return;
+        }
 
         if (type.isOrHasParent(Entity1_17Types.ENTITY)) {
             if (metadata.getId() >= 7) {

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/MetadataRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/MetadataRewriter.java
@@ -20,12 +20,15 @@ package com.viaversion.viaversion.rewriter;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.ParticleMappings;
+import com.viaversion.viaversion.api.minecraft.entities.Entity1_17Types;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.minecraft.metadata.Metadata;
+import com.viaversion.viaversion.api.minecraft.metadata.types.MetaType1_17;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
 import com.viaversion.viaversion.api.protocol.remapper.PacketRemapper;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.Particle;
 import com.viaversion.viaversion.data.EntityTracker;
@@ -38,6 +41,7 @@ import java.util.logging.Logger;
 
 public abstract class MetadataRewriter {
     private static final Metadata[] EMPTY_ARRAY = new Metadata[0];
+    public static final Metadata DUMMY_META_FOR_1_17 = new Metadata(-1, MetaType1_17.Byte, null);
     private final Class<? extends EntityTracker> entityTrackerClass;
     protected final Protocol protocol;
     private Int2IntMap typeMapping;
@@ -50,6 +54,11 @@ public abstract class MetadataRewriter {
 
     public final void handleMetadata(int entityId, List<Metadata> metadatas, UserConnection connection) {
         EntityType type = connection.get(entityTrackerClass).getEntity(entityId);
+
+        if (connection.getProtocolInfo().getProtocolVersion() >= ProtocolVersion.v1_17.getVersion()
+                && metadatas.contains(DUMMY_META_FOR_1_17))
+            type = Entity1_17Types.PLAYER;
+
         for (Metadata metadata : metadatas.toArray(EMPTY_ARRAY)) {
             try {
                 handleMetadata(entityId, type, metadata, metadatas, connection);


### PR DESCRIPTION
Below are client errors that occur when 1.17 clients connect to a server of 1.14 or earlier (or when the server sends SPAWN_PLAYER packets).
This PR solves the error below.

```log
[21:53:53] [Render thread/FATAL]: Error executing task on Client
java.lang.IllegalStateException: Invalid entity data item type for field 7 on entity eld['CherryCaramel_'/2, l='ClientLevel', x=-2.50, y=1.00, z=-8.50]: old=0(class java.lang.Integer), new=0(class java.lang.Byte)
	at wb.a(SourceFile:242) ~[21w18a.jar:?]
	at wb.a(SourceFile:229) ~[21w18a.jar:?]
	at eif.a(SourceFile:455) ~[21w18a.jar:?]
	at sf.a(SourceFile:39) ~[21w18a.jar:?]
	at sf.a(SourceFile:11) ~[21w18a.jar:?]
	at ph.a(SourceFile:21) ~[21w18a.jar:?]
	at ph$$Lambda$4235/1432367987.run(Unknown Source) ~[?:?]
	at aqd.c(SourceFile:152) [21w18a.jar:?]
	at aqh.c(SourceFile:23) [21w18a.jar:?]
	at aqd.z(SourceFile:126) [21w18a.jar:?]
	at aqd.bp(SourceFile:111) [21w18a.jar:?]
	at dus.f(SourceFile:1050) [21w18a.jar:?]
	at dus.e(SourceFile:705) [21w18a.jar:?]
	at net.minecraft.client.main.Main.main(SourceFile:217) [21w18a.jar:?]
```


_I am not good at English, so I will attach photos(GIF)._ 😢 

![err](https://user-images.githubusercontent.com/45729082/117573226-b0944700-b111-11eb-977f-144002be0ac0.gif)


I've been looking at the project code since yesterday to contribute to this plugin that I love a lot.

<hr />

When a 1.15 or later client contacts a server of 1.14 or lower, it sends the [ENTITY_METADATA](https://github.com/ViaVersion/ViaVersion/blob/cb7a7254a6bab281f94e66202c50b0519c0bc4da/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_15to1_14_4/packets/EntityPackets.java#L85-L90) packet separately when it sends the SPAWN_PLAYER packet. 

It's not accurate, but it seems to have been caused by an attempt to rewrite Metadata before [addEntity on 1_16 To1_15_2](https://github.com/ViaVersion/ViaVersion/blob/cb7a7254a6bab281f94e66202c50b0519c0bc4da/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java#L212)


The reason why I thought like this was that after remapping JOIN_GAME, there was no error related to EntityType.

Other reasons are described in the picture below. _(This picture is a logger that I made to see the rewrite process of ViaVersion.)_

![image](https://user-images.githubusercontent.com/45729082/117574493-4501a800-b118-11eb-932d-3e7b24820eaa.png)


As you can see from the code below, my code design is very bad.

If there is a better solution (ex.remapping priority), please close this PR.

_(I know this PR doesn't seem a very good solution. I hope this will help find a solution to this error.)_

<hr />

It is not related to this PR, it seems that EntityType is not recorded in 1.14.1.

![image](https://user-images.githubusercontent.com/45729082/117574635-11734d80-b119-11eb-8706-a4f564b0329c.png)



Thank you all the time to time.


++ [I think there's a typo here.    packedt -> packet](https://github.com/ViaVersion/ViaVersion/blob/cb7a7254a6bab281f94e66202c50b0519c0bc4da/api/src/main/java/com/viaversion/viaversion/api/protocol/packet/PacketWrapper.java#L231)
