### PR TITLE
use a more fork-proof approach to enable Paper block place patch

### DIFF
--- a/bukkit-legacy/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_9to1_8/PaperPatch.java
+++ b/bukkit-legacy/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_9to1_8/PaperPatch.java
@@ -19,6 +19,7 @@ package com.viaversion.viaversion.bukkit.listeners.protocol1_9to1_8;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -43,18 +44,20 @@ public class PaperPatch extends ViaBukkitListener {
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onPlace(BlockPlaceEvent e) {
         if (isOnPipe(e.getPlayer())) {
-            Location location = e.getPlayer().getLocation();
-            Location diff = location.clone().subtract(e.getBlock().getLocation().add(0.5D, 0, 0.5D));
             Material block = e.getBlockPlaced().getType();
             if (isPlacable(block)) {
                 return;
             }
-            if (location.getBlock().equals(e.getBlock())) {
+            Location location = e.getPlayer().getLocation();
+            Block locationBlock = location.getBlock();
+
+            if (locationBlock.equals(e.getBlock())) {
                 e.setCancelled(true);
             } else {
-                if (location.getBlock().getRelative(BlockFace.UP).equals(e.getBlock())) {
+                if (locationBlock.getRelative(BlockFace.UP).equals(e.getBlock())) {
                     e.setCancelled(true);
                 } else {
+                    Location diff = location.clone().subtract(e.getBlock().getLocation().add(0.5D, 0, 0.5D));
                     // Within radius of block
                     if (Math.abs(diff.getX()) <= 0.8 && Math.abs(diff.getZ()) <= 0.8D) {
                         // Are they on the edge / shifting ish

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
@@ -117,11 +117,20 @@ public class BukkitViaLoader implements ViaPlatformLoader {
             }
         }
 
-        if ((Bukkit.getVersion().toLowerCase(Locale.ROOT).contains("paper")
-                || Bukkit.getVersion().toLowerCase(Locale.ROOT).contains("taco")
-                || Bukkit.getVersion().toLowerCase(Locale.ROOT).contains("torch"))
-                && serverProtocolVersion < ProtocolVersion.v1_12.getVersion()) {
-            storeListener(new PaperPatch(plugin)).register();
+        if (serverProtocolVersion < ProtocolVersion.v1_12.getVersion()) {
+            boolean paper = true;
+            try {
+                Class.forName("org.github.paperspigot.PaperSpigotConfig"); // Paper 1.8 ?
+            } catch (ClassNotFoundException ignored) {
+                try {
+                    Class.forName("com.destroystokyo.paper.PaperConfig"); // Paper 1.9+ ?
+                } catch (ClassNotFoundException alsoIgnored) {
+                    paper = false; // Definitely not Paper
+                }
+            }
+            if (paper) {
+                storeListener(new PaperPatch(plugin)).register();
+            }
         }
 
         /* Providers */

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
@@ -117,7 +117,7 @@ public class BukkitViaLoader implements ViaPlatformLoader {
             }
         }
 
-        if (serverProtocolVersion < ProtocolVersion.v1_12.getVersion()) {
+        if (serverProtocolVersion < ProtocolVersion.v1_12.getVersion() && !Boolean.getBoolean("com.viaversion.ignorePaperBlockPlacePatch")) {
             boolean paper = true;
             try {
                 Class.forName("org.github.paperspigot.PaperSpigotConfig"); // Paper 1.8 ?


### PR DESCRIPTION
tested with:
 - Paper 1.8.8, 1.9.4, 1.11.2 (enabling)
 - SportPaper 1.8.8 (enabling)
 - Spigot 1.8.8 (not enabling)