### PR TITLE
Load protocols only on demand

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
@@ -37,6 +37,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 public interface ProtocolManager {
 
@@ -125,6 +126,28 @@ public interface ProtocolManager {
      * @throws IllegalArgumentException if a supported client protocol version is equal to the server protocol version
      */
     void registerProtocol(Protocol protocol, List<Integer> supportedClientVersion, int serverVersion);
+
+    /**
+     * Registers a protocol for later initialisation.
+     *
+     * @param protocolClass          class of the protocol to register
+     * @param provider               supplier of a protocol for initialisation on demand
+     * @param clientVersion supported client protocol versions
+     * @param serverVersion output server protocol version the protocol converts to
+     * @throws IllegalArgumentException if a supported client protocol version is equal to the server protocol version
+     */
+    void registerProtocolSupplier(Class<? extends Protocol> protocolClass, Supplier<Protocol> provider, ProtocolVersion clientVersion, ProtocolVersion serverVersion);
+
+    /**
+     * Registers a protocol for later initialisation.
+     *
+     * @param protocolClass          class of the protocol to register
+     * @param provider               supplier of a protocol for initialisation on demand
+     * @param supportedClientVersion supported client protocol versions
+     * @param serverVersion          output server protocol version the protocol converts to
+     * @throws IllegalArgumentException if a supported client protocol version is equal to the server protocol version
+     */
+    void registerProtocolSupplier(Class<? extends Protocol> protocolClass, Supplier<Protocol> provider, List<Integer> supportedClientVersion, int serverVersion);
 
     /**
      * Registers and initializes a base protocol. Base Protocols registered later have higher priority.

--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
@@ -267,13 +267,6 @@ public interface ProtocolManager {
     void completeMappingDataLoading(Class<? extends Protocol> protocolClass) throws Exception;
 
     /**
-     * Shuts down the executor and uncaches mappings if all futures have been completed.
-     *
-     * @return true if the executor has now been shut down
-     */
-    boolean checkForMappingCompletion();
-
-    /**
      * Executes the given runnable asynchronously, adding a {@link CompletableFuture}
      * to the list of data to load bound to their protocols.
      *

--- a/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
@@ -57,7 +57,6 @@ public class ViaManagerImpl implements ViaManager {
     private final ViaPlatformLoader loader;
     private final Set<String> subPlatforms = new HashSet<>();
     private List<Runnable> enableListeners = new ArrayList<>();
-    private PlatformTask mappingLoadingTask;
     private boolean debug;
 
     public ViaManagerImpl(ViaPlatform<?> platform, ViaInjector injector, ViaCommandHandler commandHandler, ViaPlatformLoader loader) {
@@ -153,12 +152,7 @@ public class ViaManagerImpl implements ViaManager {
         // Load Platform
         loader.load();
         // Common tasks
-        mappingLoadingTask = Via.getPlatform().runRepeatingSync(() -> {
-            if (protocolManager.checkForMappingCompletion()) {
-                mappingLoadingTask.cancel();
-                mappingLoadingTask = null;
-            }
-        }, 10L);
+        Via.getPlatform().runRepeatingSync(protocolManager::checkForMappingCompletion, 10L);
 
         int serverProtocolVersion = protocolManager.getServerProtocolVersion().lowestSupportedVersion();
         if (serverProtocolVersion < ProtocolVersion.v1_9.getVersion()) {

--- a/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
@@ -20,7 +20,6 @@ package com.viaversion.viaversion;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.ViaManager;
 import com.viaversion.viaversion.api.connection.ConnectionManager;
-import com.viaversion.viaversion.api.platform.PlatformTask;
 import com.viaversion.viaversion.api.platform.UnsupportedSoftware;
 import com.viaversion.viaversion.api.platform.ViaInjector;
 import com.viaversion.viaversion.api.platform.ViaPlatform;
@@ -151,9 +150,8 @@ public class ViaManagerImpl implements ViaManager {
 
         // Load Platform
         loader.load();
-        // Common tasks
-        Via.getPlatform().runRepeatingSync(protocolManager::checkForMappingCompletion, 10L);
 
+        // Common tasks
         int serverProtocolVersion = protocolManager.getServerProtocolVersion().lowestSupportedVersion();
         if (serverProtocolVersion < ProtocolVersion.v1_9.getVersion()) {
             if (Via.getConfig().isSimulatePlayerTick()) {

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -210,12 +210,6 @@ public class ProtocolManagerImpl implements ProtocolManager {
         if (protocol.hasMappingDataToLoad()) {
             // Submit mapping data loading
             addMappingLoaderFuture(protocol.getClass(), protocol::loadMappingData);
-            try {
-                completeMappingDataLoading(protocol.getClass());
-            } catch (Exception e) {
-                Via.getPlatform().getLogger().severe("Could not wait for mapping loading of " + protocol.getClass().getSimpleName());
-                e.printStackTrace();
-            }
         }
     }
 
@@ -408,27 +402,6 @@ public class ProtocolManagerImpl implements ProtocolManager {
         if (future != null) {
             // Wait for completion
             future.get();
-        }
-    }
-
-    @Override
-    public boolean checkForMappingCompletion() {
-        mappingLoaderLock.readLock().lock();
-        try {
-            for (CompletableFuture<Void> future : mappingLoaderFutures.values()) {
-                // Return if any future hasn't completed yet
-                if (!future.isDone()) {
-                    return false;
-                }
-            }
-
-            // Clear cached json files
-            if (MappingDataLoader.isCacheJsonMappings()) {
-                MappingDataLoader.getMappingsCache().clear();
-            }
-            return true;
-        } finally {
-            mappingLoaderLock.readLock().unlock();
         }
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -98,8 +98,8 @@ public class ProtocolManagerImpl implements ProtocolManager {
     private static final Protocol BASE_PROTOCOL = new BaseProtocol();
 
     // Input Version -> Output Version & Protocol (Allows fast lookup)
-    private final Int2ObjectMap<Int2ObjectMap<CachedProtocolSupplier>> registryMap = new Int2ObjectOpenHashMap<>(32);
-    private final Map<Class<? extends Protocol>, CachedProtocolSupplier> protocols = new HashMap<>();
+    private final Int2ObjectMap<Int2ObjectMap<ProtocolSupplier>> registryMap = new Int2ObjectOpenHashMap<>(32);
+    private final Map<Class<? extends Protocol>, ProtocolSupplier> protocols = new HashMap<>();
     private final Map<ProtocolPathKey, List<ProtocolPathEntry>> pathCache = new ConcurrentHashMap<>();
     private final Set<Integer> supportedVersions = new HashSet<>();
     private final List<Pair<Range<Integer>, Protocol>> baseProtocols = Lists.newCopyOnWriteArrayList();
@@ -171,8 +171,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
     @Override
     public void registerProtocol(Protocol protocol, List<Integer> supportedClientVersion, int serverVersion) {
-        registerProtocolSupplier(protocol.getClass(), () -> protocol, supportedClientVersion, serverVersion);
-        getProtocol(protocol.getClass());  // Api guarantees initialisation
+        registerProtocolSupplier(protocol.getClass(), new DirectProtocolSupplier(protocol), supportedClientVersion, serverVersion);
     }
 
     @Override
@@ -182,21 +181,23 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
     @Override
     public void registerProtocolSupplier(Class<? extends Protocol> protocolClass, Supplier<Protocol> provider, List<Integer> supportedClientVersion, int serverVersion) {
-        CachedProtocolSupplier wrapped = new CachedProtocolSupplier(provider);
+        registerProtocolSupplier(protocolClass, new CachedProtocolSupplier(provider), supportedClientVersion, serverVersion);
+    }
 
+    private void registerProtocolSupplier(Class<? extends Protocol> protocolClass, ProtocolSupplier provider, List<Integer> supportedClientVersion, int serverVersion) {
         // Clear cache as this may make new routes.
         if (!pathCache.isEmpty()) {
             pathCache.clear();
         }
 
-        protocols.put(protocolClass, wrapped);
+        protocols.put(protocolClass, provider);
 
         for (int clientVersion : supportedClientVersion) {
             // Throw an error if supported client version = server version
             Preconditions.checkArgument(clientVersion != serverVersion);
 
-            Int2ObjectMap<CachedProtocolSupplier> protocolMap = registryMap.computeIfAbsent(clientVersion, s -> new Int2ObjectOpenHashMap<>(2));
-            protocolMap.put(serverVersion, wrapped);
+            Int2ObjectMap<ProtocolSupplier> protocolMap = registryMap.computeIfAbsent(clientVersion, s -> new Int2ObjectOpenHashMap<>(2));
+            protocolMap.put(serverVersion, provider);
         }
     }
 
@@ -236,13 +237,13 @@ public class ProtocolManagerImpl implements ProtocolManager {
         }
 
         // Calculate path
-        Int2ObjectSortedMap<CachedProtocolSupplier> outputPath = getProtocolPath(new Int2ObjectLinkedOpenHashMap<>(), clientVersion, serverVersion);
+        Int2ObjectSortedMap<ProtocolSupplier> outputPath = getProtocolPath(new Int2ObjectLinkedOpenHashMap<>(), clientVersion, serverVersion);
         if (outputPath == null) {
             return null;
         }
 
         List<ProtocolPathEntry> path = new ArrayList<>(outputPath.size());
-        for (Int2ObjectMap.Entry<CachedProtocolSupplier> entry : outputPath.int2ObjectEntrySet()) {
+        for (Int2ObjectMap.Entry<ProtocolSupplier> entry : outputPath.int2ObjectEntrySet()) {
             path.add(new ProtocolPathEntryImpl(entry.getIntKey(), entry.getValue().get()));
         }
         pathCache.put(protocolKey, path);
@@ -267,25 +268,25 @@ public class ProtocolManagerImpl implements ProtocolManager {
      * @param serverVersion desired output version
      * @return path that has been generated, null if failed
      */
-    private @Nullable Int2ObjectSortedMap<CachedProtocolSupplier> getProtocolPath(Int2ObjectSortedMap<CachedProtocolSupplier> current, int clientVersion, int serverVersion) {
+    private @Nullable Int2ObjectSortedMap<ProtocolSupplier> getProtocolPath(Int2ObjectSortedMap<ProtocolSupplier> current, int clientVersion, int serverVersion) {
         if (current.size() > maxProtocolPathSize) return null; // Fail-safe, protocol too complicated.
 
         // First, check if there is any protocols for this
-        Int2ObjectMap<CachedProtocolSupplier> toServerProtocolMap = registryMap.get(clientVersion);
+        Int2ObjectMap<ProtocolSupplier> toServerProtocolMap = registryMap.get(clientVersion);
         if (toServerProtocolMap == null) {
             return null; // Not supported
         }
 
         // Next, check if there is a direct, single Protocol path
-        CachedProtocolSupplier protocol = toServerProtocolMap.get(serverVersion);
+        ProtocolSupplier protocol = toServerProtocolMap.get(serverVersion);
         if (protocol != null) {
             current.put(serverVersion, protocol);
             return current; // Easy solution
         }
 
         // There might be a more advanced solution... So we'll see if any of the others can get us there
-        Int2ObjectSortedMap<CachedProtocolSupplier> shortest = null;
-        for (Int2ObjectMap.Entry<CachedProtocolSupplier> entry : toServerProtocolMap.int2ObjectEntrySet()) {
+        Int2ObjectSortedMap<ProtocolSupplier> shortest = null;
+        for (Int2ObjectMap.Entry<ProtocolSupplier> entry : toServerProtocolMap.int2ObjectEntrySet()) {
             // Ensure we don't go back to already contained versions
             int translatedToVersion = entry.getIntKey();
             if (current.containsKey(translatedToVersion)) continue;
@@ -296,7 +297,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
             }
 
             // Create a copy
-            Int2ObjectSortedMap<CachedProtocolSupplier> newCurrent = new Int2ObjectLinkedOpenHashMap<>(current);
+            Int2ObjectSortedMap<ProtocolSupplier> newCurrent = new Int2ObjectLinkedOpenHashMap<>(current);
             newCurrent.put(translatedToVersion, entry.getValue());
 
             // Calculate the rest of the protocol starting from translatedToVersion and take the shortest
@@ -316,7 +317,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
     @Override
     public @Nullable Protocol getProtocol(int clientVersion, int serverVersion) {
-        Int2ObjectMap<CachedProtocolSupplier> map = registryMap.get(clientVersion);
+        Int2ObjectMap<ProtocolSupplier> map = registryMap.get(clientVersion);
         return map != null ? map.get(serverVersion).get() : null;
     }
 
@@ -343,7 +344,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
     @Override
     public boolean isWorkingPipe() {
-        for (Int2ObjectMap<CachedProtocolSupplier> map : registryMap.values()) {
+        for (Int2ObjectMap<ProtocolSupplier> map : registryMap.values()) {
             for (int protocolVersion : serverProtocolVersion.supportedVersions()) {
                 if (map.containsKey(protocolVersion)) {
                     return true;
@@ -487,9 +488,31 @@ public class ProtocolManagerImpl implements ProtocolManager {
         };
     }
 
-    private class CachedProtocolSupplier implements Supplier<Protocol> {
+
+    private abstract class ProtocolSupplier implements Supplier<Protocol> {
+
+        protected void init(Protocol protocol) {
+            // Register the protocol's handlers
+            protocol.initialize();
+            registerProtocol(protocol);
+
+            if (protocol.hasMappingDataToLoad()) {
+                // Submit mapping data loading
+                addMappingLoaderFuture(protocol.getClass(), protocol::loadMappingData);
+                try {
+                    completeMappingDataLoading(protocol.getClass());
+                } catch (Exception e) {
+                    Via.getPlatform().getLogger().severe("Could not wait for mapping loading of " + protocol.getClass().getSimpleName());
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+
+    private final class CachedProtocolSupplier extends ProtocolSupplier {
         private final Supplier<Protocol> provider;
-        private Protocol protocol = null;
+        private Protocol protocol;
 
         public CachedProtocolSupplier(Supplier<Protocol> provider) {
             this.provider = provider;
@@ -498,25 +521,29 @@ public class ProtocolManagerImpl implements ProtocolManager {
         @Override
         public Protocol get() {
             synchronized (provider) {
-                if (protocol == null) {
-                    protocol = provider.get();
-
-                    // Register the protocol's handlers
-                    protocol.initialize();
-                    registerProtocol(protocol);
-
-                    if (protocol.hasMappingDataToLoad()) {
-                        // Submit mapping data loading
-                        addMappingLoaderFuture(protocol.getClass(), protocol::loadMappingData);
-                        try {
-                            completeMappingDataLoading(protocol.getClass());
-                        } catch (Exception e) {
-                            Via.getPlatform().getLogger().severe("Could not wait for mapping loading of " + protocol.getClass().getSimpleName());
-                            e.printStackTrace();
-                        }
-                    }
+                if (protocol != null) {
+                    return protocol;
                 }
+
+                protocol = provider.get();
+                init(protocol);
             }
+            return protocol;
+        }
+    }
+
+
+    private final class DirectProtocolSupplier extends ProtocolSupplier {
+        private final Protocol protocol;
+
+        private DirectProtocolSupplier(Protocol protocol) {
+            this.protocol = protocol;
+            init(protocol);
+        }
+
+
+        @Override
+        public Protocol get() {
             return protocol;
         }
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -442,8 +442,9 @@ public class ProtocolManagerImpl implements ProtocolManager {
     @Override
     public @Nullable CompletableFuture<Void> getMappingLoaderFuture(Class<? extends Protocol> protocolClass) {
         CompletableFuture<Void> future = internalGetMappingLoaderFuture(protocolClass);
-        if (future != null)
+        if (future != null) {
             return future;
+        }
 
         //Force loading
         protocols.get(protocolClass).get();


### PR DESCRIPTION
**Rationale**: ViaVersion takes a long time (on my server ~1.5s) to initialize and likely initializes protocols never required.

This branch was tested on a Spigot 1.15.2 server behind a Waterfall proxy with Client versions 1.12.2, 1.15.2 and 1.17.1. Tests were done with and without ProtocolLib and ViaBackwards.

Calling the registerProtocol method still initializes the protocol (and all required protocols) due to the ProtocolManager.registerProtocol documentation. This could be changed (it was possible to join with 1.12.2 and ViaBackwards without enforcing initialization during registration). The repeating task for checking running mappingloaders and potential json cache clear is debatable.

I can think of the following (untested) potential issues with this implementation:
- (Main)Thread blocking during delayed initialization on other platforms than Spigot
- Bad ping during first server list ping with uninitialized protocol version