### PR TITLE
Cancel arm animation if in an open inventory for 1.16+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ nbdist/
 nbactions.xml
 nb-configuration.xml
 .nb-gradle/
+
+### MacOS ###
+.DS_Store

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
@@ -39,6 +39,7 @@ import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.metadata.Metadat
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.packets.EntityPackets;
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.packets.InventoryPackets;
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.packets.WorldPackets;
+import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.storage.InventoryTracker1_16;
 import com.viaversion.viaversion.rewriter.ComponentRewriter;
 import com.viaversion.viaversion.api.minecraft.RegistryType;
 import com.viaversion.viaversion.rewriter.SoundRewriter;
@@ -275,6 +276,7 @@ public class Protocol1_16To1_15_2 extends AbstractProtocol<ClientboundPackets1_1
     @Override
     public void init(UserConnection userConnection) {
         userConnection.addEntityTracker(this.getClass(), new EntityTrackerBase(userConnection, Entity1_16Types.PLAYER));
+        userConnection.put(new InventoryTracker1_16());
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
@@ -27,7 +27,6 @@ import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.minecraft.WorldIdentifiers;
 import com.viaversion.viaversion.api.minecraft.entities.Entity1_16Types;
-import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
 import com.viaversion.viaversion.api.protocol.remapper.PacketRemapper;
 import com.viaversion.viaversion.api.type.Type;
@@ -36,7 +35,9 @@ import com.viaversion.viaversion.api.type.types.version.Types1_16;
 import com.viaversion.viaversion.protocols.protocol1_15to1_14_4.ClientboundPackets1_15;
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.ClientboundPackets1_16;
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.Protocol1_16To1_15_2;
+import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.ServerboundPackets1_16;
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.metadata.MetadataRewriter1_16To1_15_2;
+import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.storage.InventoryTracker1_16;
 
 import java.util.UUID;
 
@@ -273,6 +274,19 @@ public class EntityPackets {
                     }
                     if (size != actualSize) {
                         wrapper.set(Type.INT, 0, actualSize);
+                    }
+                });
+            }
+        });
+
+        protocol.registerServerbound(ServerboundPackets1_16.ANIMATION, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                handler(wrapper -> {
+                    InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
+                    // Don't send an arm swing if the player has an inventory opened.
+                    if (inventoryTracker.getInventory() != -1) {
+                        wrapper.cancel();
                     }
                 });
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
@@ -35,6 +35,7 @@ import com.viaversion.viaversion.protocols.protocol1_15to1_14_4.ClientboundPacke
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.ClientboundPackets1_16;
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.Protocol1_16To1_15_2;
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.ServerboundPackets1_16;
+import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.storage.InventoryTracker1_16;
 import com.viaversion.viaversion.rewriter.ItemRewriter;
 
 import java.util.UUID;
@@ -63,13 +64,16 @@ public class InventoryPackets extends ItemRewriter<Protocol1_16To1_15_2> {
                 map(Type.VAR_INT); // Window Type
                 map(Type.COMPONENT); // Window Title
 
+                handler(cursorRemapper);
                 handler(wrapper -> {
+                    InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
+                    int windowId = wrapper.get(Type.VAR_INT, 0);
                     int windowType = wrapper.get(Type.VAR_INT, 1);
                     if (windowType >= 20) { // smithing added with id 20
                         wrapper.set(Type.VAR_INT, 1, ++windowType);
                     }
+                    inventoryTracker.setInventory((short) windowId);
                 });
-                handler(cursorRemapper);
             }
         });
 
@@ -77,6 +81,10 @@ public class InventoryPackets extends ItemRewriter<Protocol1_16To1_15_2> {
             @Override
             public void registerMap() {
                 handler(cursorRemapper);
+                handler(wrapper -> {
+                    InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
+                    inventoryTracker.setInventory((short) -1);
+                });
             }
         });
 
@@ -122,6 +130,16 @@ public class InventoryPackets extends ItemRewriter<Protocol1_16To1_15_2> {
 
         registerClickWindow(ServerboundPackets1_16.CLICK_WINDOW, Type.FLAT_VAR_INT_ITEM);
         registerCreativeInvAction(ServerboundPackets1_16.CREATIVE_INVENTORY_ACTION, Type.FLAT_VAR_INT_ITEM);
+
+        protocol.registerServerbound(ServerboundPackets1_16.CLOSE_WINDOW, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                handler(wrapper -> {
+                    InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
+                    inventoryTracker.setInventory((short) -1);
+                });
+            }
+        });
 
         protocol.registerServerbound(ServerboundPackets1_16.EDIT_BOOK, new PacketRemapper() {
             @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/storage/InventoryTracker1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/storage/InventoryTracker1_16.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2021 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.protocol1_16to1_15_2.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+
+public class InventoryTracker1_16 implements StorableObject {
+    private short inventory = -1;
+
+    public short getInventory() {
+        return this.inventory;
+    }
+
+    public void setInventory(short inventory) {
+        this.inventory = inventory;
+    }
+}


### PR DESCRIPTION
Partially revert #2528 to reintroduce #2031.

The reason of this revert is that even when the player is not navigating between inventories, item drop can happen by simply pressing the drop key or throwing out of the window the item in his cursor. These two situations triggers an arm animation as for any item drop, and this was the initial issue of all these PRs.

So the solution is to completely cancel any arm animation packet going to the server when the player has an inventory opened (by reintroducing #2031). I also kept what I introduced with #2528 to prevent the arm to swing client-side during navigation.

This is tested and working, all feedbacks are welcome :)