### PR TITLE
Fix #2532

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/InventoryPackets.java
@@ -77,8 +77,9 @@ public final class InventoryPackets extends ItemRewriter<Protocol1_17To1_16_4> {
                     // 1.17 clients send the then carried item, but 1.16 expects the clicked one
                     Item item = wrapper.read(Type.FLAT_VAR_INT_ITEM);
                     int action = wrapper.get(Type.VAR_INT, 0);
-                    if (action == 5) {
+                    if (action == 5 || action == 1) {
                         // Quick craft (= dragging / mouse movement while clicking on an empty slot)
+                        // OR Quick move (= shift click to move a whole stack to the other inventory)
                         // The server always expects an empty item here
                         item = null;
                     } else {


### PR DESCRIPTION
Did some testing and it appears that the pre 1.17 clients always send an empty slot when quick moving.
This fixes the mass quick move and the normal quick move is still working (with and without another item on the cursor).
And I couldn't find anything else that broke with this change.