### PR TITLE
Fix channel name validation in 1.13 to 1.12.2 protocol

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/MappingData.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/MappingData.java
@@ -147,7 +147,7 @@ public class MappingData extends MappingDataBase {
     }
 
     public static boolean isValid1_13Channel(String channelId) {
-        return channelId.matches("[0-9a-z_.-]*:?[0-9a-z_/.-]*");
+        return channelId.matches("([0-9a-z_.-]+:)?[0-9a-z_/.-]+");
     }
 
     private void loadTags(Map<String, Integer[]> output, JsonObject newTags) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/MappingData.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/MappingData.java
@@ -137,15 +137,17 @@ public class MappingData extends MappingDataBase {
             return null; // Not valid
         }
         int separatorIndex = newId.indexOf(':');
-        // Vanilla parses ``:`` and ```` as ``minecraft:`` (also ensure there's enough space)
-        if ((separatorIndex == -1 || separatorIndex == 0) && newId.length() <= 10) {
+        // Vanilla parses an empty and a missing namespace as the minecraft namespace
+        if (separatorIndex == -1) {
             newId = "minecraft:" + newId;
+        } else if (separatorIndex == 0) {
+            newId = "minecraft" + newId;
         }
         return newId;
     }
 
     public static boolean isValid1_13Channel(String channelId) {
-        return channelId.matches("([0-9a-z_.-]+):([0-9a-z_/.-]+)");
+        return channelId.matches("[0-9a-z_.-]*:?[0-9a-z_/.-]*");
     }
 
     private void loadTags(Map<String, Integer[]> output, JsonObject newTags) {


### PR DESCRIPTION
As partially described in #2187 the following channel names are valid but not recognized as valid:
- an empty string
- ``:``
- ``no_namespace`` (parsed as minecraft namespace)
- ``empty_path:``
- ``:empty_namespace`` (parsed as minecraft namespace)

This PR fixes all of these cases.

This PR also fixes a different issue which couldn't occur at runtime due to the first issue.
The ``protocol1_13to1_12_2.data.MappingData#validateNewChannel`` method would transform ``:path`` to ``minecraft::path`` which is invalid.
I did also remove the length check in that method because it was not necessary. The only place where this method is used does limit the length itself:
https://github.com/ViaVersion/ViaVersion/blob/e64a0fb62e8573096bee85581c2e5f263654591d/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java#L679-L703
The removed length check would only result in ``debug/neighbors_update`` falling through the switch case here.

I did check if everything is still working with a 1.12.2 server and 1.17.1 client. Everything is working fine.
I added the examples listed above to ``channelmappings-1.13.json`` and all of them are recognized as valid.