### PR TITLE
Replace use of ConcurrentHashMap in entity tracker and block storage with SyncMap

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
         targetConfiguration = "shadow"
     }
     api(libs.fastutil)
+    api(libs.flare)
+    api(libs.flareFastutil)
     api(libs.openNBT)
     api(libs.gson)
 

--- a/api/src/main/java/com/viaversion/viaversion/api/data/MappingDataLoader.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/data/MappingDataLoader.java
@@ -217,7 +217,7 @@ public class MappingDataLoader {
      * @return map with indexes hashed by their id value
      */
     public static Object2IntMap<String> indexedObjectToMap(JsonObject object) {
-        Object2IntMap<String> map = new Object2IntOpenHashMap<>(object.size(), 1F);
+        Object2IntMap<String> map = new Object2IntOpenHashMap<>(object.size(), .99F);
         map.defaultReturnValue(-1);
         for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
             map.put(entry.getValue().getAsString(), Integer.parseInt(entry.getKey()));
@@ -232,7 +232,7 @@ public class MappingDataLoader {
      * @return map with indexes hashed by their id value
      */
     public static Object2IntMap<String> arrayToMap(JsonArray array) {
-        Object2IntMap<String> map = new Object2IntOpenHashMap<>(array.size(), 1F);
+        Object2IntMap<String> map = new Object2IntOpenHashMap<>(array.size(), .99F);
         map.defaultReturnValue(-1);
         for (int i = 0; i < array.size(); i++) {
             map.put(array.get(i).getAsString(), i);

--- a/build-logic/src/main/kotlin/via.shadow-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/via.shadow-conventions.gradle.kts
@@ -29,6 +29,7 @@ fun ShadowJar.configureRelocations() {
     relocate("com.google.gson", "com.viaversion.viaversion.libs.gson")
     relocate("com.github.steveice10.opennbt", "com.viaversion.viaversion.libs.opennbt")
     relocate("it.unimi.dsi.fastutil", "com.viaversion.viaversion.libs.fastutil")
+    relocate("space.vectrix.flare", "com.viaversion.viaversion.libs.flare")
 }
 
 fun ShadowJar.configureExcludes() {
@@ -52,4 +53,9 @@ fun ShadowJar.configureExcludes() {
     exclude("it/unimi/dsi/fastutil/*/*Synchronized*")
     exclude("it/unimi/dsi/fastutil/*/*Unmodifiable*")
     exclude("it/unimi/dsi/fastutil/io/*")
+    // Flare - only need int maps
+    exclude("space/vectrix/flare/fastutil/*Double*")
+    exclude("space/vectrix/flare/fastutil/*Float*")
+    exclude("space/vectrix/flare/fastutil/*Long*")
+    exclude("space/vectrix/flare/fastutil/*Short*")
 }

--- a/common/src/main/java/com/viaversion/viaversion/data/entity/EntityTrackerBase.java
+++ b/common/src/main/java/com/viaversion/viaversion/data/entity/EntityTrackerBase.java
@@ -24,14 +24,13 @@ import com.viaversion.viaversion.api.data.entity.ClientEntityIdChangeListener;
 import com.viaversion.viaversion.api.data.entity.EntityTracker;
 import com.viaversion.viaversion.api.data.entity.StoredEntityData;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import space.vectrix.flare.fastutil.Int2ObjectSyncMap;
 
 public class EntityTrackerBase implements EntityTracker, ClientEntityIdChangeListener {
-    private final Map<Integer, EntityType> entityTypes = new ConcurrentHashMap<>();
-    private final Map<Integer, StoredEntityData> entityData;
+    private final Int2ObjectMap<EntityType> entityTypes = Int2ObjectSyncMap.hashmap();
+    private final Int2ObjectMap<StoredEntityData> entityData;
     private final UserConnection connection;
     private final EntityType playerType;
     private int clientEntityId = -1;
@@ -46,7 +45,7 @@ public class EntityTrackerBase implements EntityTracker, ClientEntityIdChangeLis
     public EntityTrackerBase(UserConnection connection, @Nullable EntityType playerType, boolean storesEntityData) {
         this.connection = connection;
         this.playerType = playerType;
-        this.entityData = storesEntityData ? new ConcurrentHashMap<>() : null;
+        this.entityData = storesEntityData ? Int2ObjectSyncMap.hashmap() : null;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/metadata/MetadataRewriter1_11To1_10.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/metadata/MetadataRewriter1_11To1_10.java
@@ -126,8 +126,7 @@ public class MetadataRewriter1_11To1_10 extends EntityRewriter<Protocol1_11To1_1
                 if ((data & 0x20) == 0x20 && ((byte) flags.getValue() & 0x01) == 0x01
                         && !((String) customName.getValue()).isEmpty() && (boolean) customNameVisible.getValue()) {
                     EntityTracker1_11 tracker = tracker(connection);
-                    if (!tracker.isHologram(entityId)) {
-                        tracker.addHologram(entityId);
+                    if (tracker.addHologram(entityId)) {
                         try {
                             // Send movement
                             PacketWrapper wrapper = PacketWrapper.create(ClientboundPackets1_9_3.ENTITY_POSITION, null, connection);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/storage/EntityTracker1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/storage/EntityTracker1_11.java
@@ -17,15 +17,14 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_11to1_10.storage;
 
-import com.google.common.collect.Sets;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.entities.Entity1_11Types.EntityType;
 import com.viaversion.viaversion.data.entity.EntityTrackerBase;
-
-import java.util.Set;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import space.vectrix.flare.fastutil.Int2ObjectSyncMap;
 
 public class EntityTracker1_11 extends EntityTrackerBase {
-    private final Set<Integer> holograms = Sets.newConcurrentHashSet();
+    private final IntSet holograms = Int2ObjectSyncMap.hashset();
 
     public EntityTracker1_11(UserConnection user) {
         super(user, EntityType.PLAYER);
@@ -35,12 +34,11 @@ public class EntityTracker1_11 extends EntityTrackerBase {
     public void removeEntity(int entityId) {
         super.removeEntity(entityId);
 
-        if (isHologram(entityId))
-            removeHologram(entityId);
+        removeHologram(entityId);
     }
 
-    public void addHologram(int entId) {
-        holograms.add(entId);
+    public boolean addHologram(int entId) {
+        return holograms.add(entId);
     }
 
     public boolean isHologram(int entId) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/ConnectionData.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/ConnectionData.java
@@ -38,22 +38,22 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Map.Entry;
 
 public class ConnectionData {
     private static final BlockChangeRecord1_8[] EMPTY_RECORDS = new BlockChangeRecord1_8[0];
     public static BlockConnectionProvider blockConnectionProvider;
-    static Int2ObjectMap<String> idToKey = new Int2ObjectOpenHashMap<>(8582, 1F);
-    static Map<String, Integer> keyToId = new HashMap<>(8582, 1F);
+    static Int2ObjectMap<String> idToKey = new Int2ObjectOpenHashMap<>(8582, .99F);
+    static Object2IntMap<String> keyToId = new Object2IntOpenHashMap<>(8582, .99F);
     static Int2ObjectMap<ConnectionHandler> connectionHandlerMap = new Int2ObjectOpenHashMap<>(1);
     static Int2ObjectMap<BlockData> blockConnectionData = new Int2ObjectOpenHashMap<>(1);
-    static IntSet occludingStates = new IntOpenHashSet(377, 1F);
+    static IntSet occludingStates = new IntOpenHashSet(377, .99F);
 
     public static void update(UserConnection user, Position position) {
         for (BlockFace face : BlockFace.values()) {
@@ -231,10 +231,10 @@ public class ConnectionData {
             keyToId.put(key, id);
         }
 
-        connectionHandlerMap = new Int2ObjectOpenHashMap<>(3650, 1F);
+        connectionHandlerMap = new Int2ObjectOpenHashMap<>(3650, .99F);
 
         if (!Via.getConfig().isReduceBlockStorageMemory()) {
-            blockConnectionData = new Int2ObjectOpenHashMap<>(1146, 1F);
+            blockConnectionData = new Int2ObjectOpenHashMap<>(1146, .99F);
             JsonObject mappingBlockConnections = MappingDataLoader.loadData("blockConnections.json");
             for (Entry<String, JsonElement> entry : mappingBlockConnections.entrySet()) {
                 int id = keyToId.get(entry.getKey());

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/EntityTypeRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/EntityTypeRewriter.java
@@ -21,7 +21,7 @@ import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
 public class EntityTypeRewriter {
-    private static final Int2IntMap ENTITY_TYPES = new Int2IntOpenHashMap(83, 1F);
+    private static final Int2IntMap ENTITY_TYPES = new Int2IntOpenHashMap(83, .99F);
 
     static {
         ENTITY_TYPES.defaultReturnValue(-1);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -50,7 +50,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class WorldPackets {
-    private static final IntSet VALID_BIOMES = new IntOpenHashSet(70, 1F);
+    private static final IntSet VALID_BIOMES = new IntOpenHashSet(70, .99F);
 
     static {
         // Client will crash if it receives a invalid biome id

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockStorage.java
@@ -21,14 +21,15 @@ import com.viaversion.viaversion.api.connection.StorableObject;
 import com.viaversion.viaversion.api.minecraft.Position;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import space.vectrix.flare.SyncMap;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 // TODO Fix memory leak lolz (only a smol one tho)
 public class BlockStorage implements StorableObject {
-    private static final IntSet WHITELIST = new IntOpenHashSet(46, 1F);
-    private final Map<Position, ReplacementData> blocks = new ConcurrentHashMap<>();
+    private static final IntSet WHITELIST = new IntOpenHashSet(46, .99F);
+    private final Map<Position, ReplacementData> blocks = SyncMap.hashmap();
 
     static {
         // Flower pots

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/data/MappingData.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/data/MappingData.java
@@ -47,7 +47,7 @@ public class MappingData extends MappingDataBase {
 
         JsonObject heightMapData = MappingDataLoader.loadData("heightMapData-1.14.json");
         JsonArray motionBlocking = heightMapData.getAsJsonArray("MOTION_BLOCKING");
-        this.motionBlocking = new IntOpenHashSet(motionBlocking.size(), 1F);
+        this.motionBlocking = new IntOpenHashSet(motionBlocking.size(), .99F);
         for (JsonElement blockState : motionBlocking) {
             String key = blockState.getAsString();
             Integer id = blockStateMap.get(key);
@@ -59,7 +59,7 @@ public class MappingData extends MappingDataBase {
         }
 
         if (Via.getConfig().isNonFullBlockLightFix()) {
-            nonFullBlocks = new IntOpenHashSet(1611, 1F);
+            nonFullBlocks = new IntOpenHashSet(1611, .99F);
             for (Map.Entry<String, JsonElement> blockstates : oldMappings.getAsJsonObject("blockstates").entrySet()) {
                 final String state = blockstates.getValue().getAsString();
                 if (state.contains("_slab") || state.contains("_stairs") || state.contains("_wall[")) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/storage/EntityTracker1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/storage/EntityTracker1_14.java
@@ -20,15 +20,14 @@ package com.viaversion.viaversion.protocols.protocol1_14to1_13_2.storage;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.entities.Entity1_14Types;
 import com.viaversion.viaversion.data.entity.EntityTrackerBase;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import space.vectrix.flare.fastutil.Int2ObjectSyncMap;
 
 public class EntityTracker1_14 extends EntityTrackerBase {
-    private final Map<Integer, Byte> insentientData = new ConcurrentHashMap<>();
+    private final Int2ObjectMap<Byte> insentientData = Int2ObjectSyncMap.hashmap();
     // 0x1 = sleeping, 0x2 = riptide
-    private final Map<Integer, Byte> sleepingAndRiptideData = new ConcurrentHashMap<>();
-    private final Map<Integer, Byte> playerEntityFlags = new ConcurrentHashMap<>();
+    private final Int2ObjectMap<Byte> sleepingAndRiptideData = Int2ObjectSyncMap.hashmap();
+    private final Int2ObjectMap<Byte> playerEntityFlags = Int2ObjectSyncMap.hashmap();
     private int latestTradeWindowId;
     private boolean forceSendCenterChunk = true;
     private int chunkCenterX, chunkCenterZ;
@@ -52,7 +51,7 @@ public class EntityTracker1_14 extends EntityTrackerBase {
     }
 
     public void setInsentientData(int entity, byte value) {
-        insentientData.put(entity, value);
+        insentientData.put(entity, (Byte) value);
     }
 
     private static byte zeroIfNull(Byte val) {
@@ -69,7 +68,7 @@ public class EntityTracker1_14 extends EntityTrackerBase {
         if (newValue == 0) {
             sleepingAndRiptideData.remove(player);
         } else {
-            sleepingAndRiptideData.put(player, newValue);
+            sleepingAndRiptideData.put(player, (Byte) newValue);
         }
     }
 
@@ -82,7 +81,7 @@ public class EntityTracker1_14 extends EntityTrackerBase {
         if (newValue == 0) {
             sleepingAndRiptideData.remove(player);
         } else {
-            sleepingAndRiptideData.put(player, newValue);
+            sleepingAndRiptideData.put(player, (Byte) newValue);
         }
     }
 
@@ -91,7 +90,7 @@ public class EntityTracker1_14 extends EntityTrackerBase {
     }
 
     public void setEntityFlags(int player, byte data) {
-        playerEntityFlags.put(player, data);
+        playerEntityFlags.put(player, (Byte) data);
     }
 
     public int getLatestTradeWindowId() {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/ItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/ItemRewriter.java
@@ -36,7 +36,7 @@ public class ItemRewriter {
     private static final Map<String, Integer> POTION_NAME_TO_ID = new HashMap<>();
     private static final Map<Integer, String> POTION_ID_TO_NAME = new HashMap<>();
 
-    private static final Int2IntMap POTION_INDEX = new Int2IntOpenHashMap(36, 1F);
+    private static final Int2IntMap POTION_INDEX = new Int2IntOpenHashMap(36, .99F);
 
     static {
         /* Entities */

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/sounds/Effect.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/sounds/Effect.java
@@ -22,7 +22,7 @@ import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
 public class Effect {
 
-    private static final Int2IntMap EFFECTS = new Int2IntOpenHashMap(19, 1F);
+    private static final Int2IntMap EFFECTS = new Int2IntOpenHashMap(19, .99F);
 
     static {
         addRewrite(1005, 1010); //Play music disc

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
@@ -18,7 +18,6 @@
 package com.viaversion.viaversion.protocols.protocol1_9to1_8.storage;
 
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.Sets;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.legacy.bossbar.BossBar;
@@ -40,20 +39,22 @@ import com.viaversion.viaversion.protocols.protocol1_9to1_8.chat.GameMode;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.metadata.MetadataRewriter1_9To1_8;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.BossBarProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.EntityIdProvider;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import space.vectrix.flare.fastutil.Int2ObjectSyncMap;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 public class EntityTracker1_9 extends EntityTrackerBase {
     public static final String WITHER_TRANSLATABLE = "{\"translate\":\"entity.WitherBoss.name\"}";
     public static final String DRAGON_TRANSLATABLE = "{\"translate\":\"entity.EnderDragon.name\"}";
-    private final Map<Integer, UUID> uuidMap = new ConcurrentHashMap<>();
-    private final Map<Integer, List<Metadata>> metadataBuffer = new ConcurrentHashMap<>();
-    private final Map<Integer, Integer> vehicleMap = new ConcurrentHashMap<>();
-    private final Map<Integer, BossBar> bossBarMap = new ConcurrentHashMap<>();
-    private final Set<Integer> validBlocking = Sets.newConcurrentHashSet();
-    private final Set<Integer> knownHolograms = Sets.newConcurrentHashSet();
+    private final Int2ObjectMap<UUID> uuidMap = Int2ObjectSyncMap.hashmap();
+    private final Int2ObjectMap<List<Metadata>> metadataBuffer = Int2ObjectSyncMap.hashmap();
+    private final Int2ObjectMap<Integer> vehicleMap = Int2ObjectSyncMap.hashmap();
+    private final Int2ObjectMap<BossBar> bossBarMap = Int2ObjectSyncMap.hashmap();
+    private final IntSet validBlocking = Int2ObjectSyncMap.hashset();
+    private final Set<Integer> knownHolograms = Int2ObjectSyncMap.hashset();
     private final Set<Position> blockInteractions = Collections.newSetFromMap(CacheBuilder.newBuilder()
             .maximumSize(1000)
             .expireAfterAccess(250, TimeUnit.MILLISECONDS)

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -196,7 +196,7 @@ public abstract class EntityRewriter<T extends Protocol> extends RewriterBase<T>
      */
     public <E extends Enum<E> & EntityType> void mapTypes(EntityType[] oldTypes, Class<E> newTypeClass) {
         if (typeMappings == null) {
-            typeMappings = new Int2IntOpenHashMap(oldTypes.length, 1F);
+            typeMappings = new Int2IntOpenHashMap(oldTypes.length, .99F);
             typeMappings.defaultReturnValue(-1);
         }
         for (EntityType oldType : oldTypes) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,8 @@ metadata.format.version = "1.1"
 
 adventure = "4.9.1"
 gson = "2.8.8"
-fastutil = "8.3.1"
+fastutil = "8.5.6"
+flare = "1.0.0"
 openNBT = "2.0-SNAPSHOT"
 javassist = "3.28.0-GA"
 
@@ -34,6 +35,8 @@ adventureTextSerializerLegacy = { group = "net.kyori", name = "adventure-text-se
 
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 fastutil = { group = "it.unimi.dsi", name = "fastutil", version.ref = "fastutil" }
+flare = { group = "space.vectrix.flare", name = "flare", version.ref = "flare" }
+flareFastutil = { group = "space.vectrix.flare", name = "flare-fastutil", version.ref = "flare" }
 openNBT = { group = "com.viaversion", name = "opennbt", version.ref = "openNBT" }
 javassist = { group = "org.javassist", name = "javassist", version.ref = "javassist" }
 


### PR DESCRIPTION
With these collections having a frequent reads/writes, this makes some optimizations to the entity tracker & block storage collections by using a new collection (https://github.com/vectrix-space/flare) that is able to better handle the higher lock contention. It also wraps fastutil collections saving some time on autoboxing. This needed to update fastutil for compatibility, requiring fastutil collections to have a load factor of less than 1 which I have changed to .99.

I also removed some unnecessary contains checks when adding/removing hologram entity ids.