### PR TITLE
Fix wrong chunk loading in 1.9+ from #2669

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/types/ChunkBulk1_8Type.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/types/ChunkBulk1_8Type.java
@@ -65,12 +65,11 @@ public class ChunkBulk1_8Type extends PartialType<Chunk[], ClientWorld> {
     @Override
     public void write(ByteBuf output, ClientWorld world, Chunk[] chunks) throws Exception {
         boolean skyLight = false;
-        for (Chunk c : chunks) {
+        loop1: for (Chunk c : chunks) {
             for (ChunkSection section : c.getSections()) {
-                if (section != null) {
-                    if (section.getLight().hasSkyLight()) {
-                        skyLight = true;
-                    }
+                if (section != null && section.getLight().hasSkyLight()) {
+                    skyLight = true;
+                    break loop1;
                 }
             }
         }


### PR DESCRIPTION
This was causing random empty chunks and "slow loading" of chunks from client pov.

This PR restore some behavior that #2669 accidentally removed.
https://github.com/ViaVersion/ViaVersion/blob/257eea5b044bdd0af71c198eb53832927374d963/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java#L94

There is also some minor optimizations.