### PR TITLE
Don't cancel chunks with missing light data

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/WorldPackets.java
@@ -165,8 +165,7 @@ public final class WorldPackets {
 
                     final ChunkLightStorage lightStorage = wrapper.user().get(ChunkLightStorage.class);
                     // Mark chunk as loaded
-                    boolean alreadyLoaded = lightStorage.isLoaded(chunk.getX(), chunk.getZ());
-                    lightStorage.addLoadedChunk(chunk.getX(), chunk.getZ());
+                    boolean alreadyLoaded = !lightStorage.addLoadedChunk(chunk.getX(), chunk.getZ());
 
                     // Get and remove light stored, there's only full chunk packets //TODO Only get, not remove if we find out people re-send full chunk packets without re-sending light
                     // Append light data to chunk packet

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/storage/ChunkLightStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/storage/ChunkLightStorage.java
@@ -38,8 +38,8 @@ public final class ChunkLightStorage implements StorableObject {
         return lightPackets.remove(getChunkSectionIndex(x, z));
     }
 
-    public void addLoadedChunk(final int x, final int z) {
-        loadedChunks.add(getChunkSectionIndex(x, z));
+    public boolean addLoadedChunk(final int x, final int z) {
+        return loadedChunks.add(getChunkSectionIndex(x, z));
     }
 
     public boolean isLoaded(final int x, final int z) {


### PR DESCRIPTION
In case somebody wrote block and light data to their replays in the wrong order since 1.14 (totally not me).
There's still a warning to catch possible issues like client lag.
Tested with some mcpr files with disordered block/light data (provided by a friend of mine obviously).