### PR TITLE
Map smoke directions from 1.13 to 1.13.1

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/Protocol1_13_1To1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/Protocol1_13_1To1_13.java
@@ -144,6 +144,41 @@ public class Protocol1_13_1To1_13 extends AbstractProtocol<ClientboundPackets1_1
             }
         });
 
+        registerClientbound(ClientboundPackets1_13.EFFECT, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.INT); // Effect Id
+                map(Type.POSITION); // Location
+                map(Type.INT); // Data
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int id = wrapper.get(Type.INT, 0);
+                        int data = wrapper.get(Type.INT, 1);
+                        if (id == 2000) { // Smoke
+                            switch (data) {
+                                case 1: // North
+                                    wrapper.set(Type.INT, 1, 2);
+                                    break;
+                                case 3: // West
+                                    wrapper.set(Type.INT, 1, 4);
+                                    break;
+                                case 5: // East
+                                    //No-op - Data is the same
+                                    break;
+                                case 7: // South
+                                    wrapper.set(Type.INT, 1, 3);
+                                    break;
+                                default: // Everything else is unsupported, falls back to Down
+                                    wrapper.set(Type.INT, 1, 0);
+                                    break;
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
         new TagRewriter(this).register(ClientboundPackets1_13.TAGS, RegistryType.ITEM);
         new StatisticsRewriter(this).register(ClientboundPackets1_13.STATISTICS);
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/Protocol1_13_1To1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/Protocol1_13_1To1_13.java
@@ -158,19 +158,23 @@ public class Protocol1_13_1To1_13 extends AbstractProtocol<ClientboundPackets1_1
                             int data = wrapper.get(Type.INT, 1);
                             switch (data) {
                                 case 1: // North
-                                    wrapper.set(Type.INT, 1, 2);
+                                    wrapper.set(Type.INT, 1, 2); // North
                                     break;
+                                case 0: // North-West
                                 case 3: // West
-                                    wrapper.set(Type.INT, 1, 4);
+                                case 6: // South-West
+                                    wrapper.set(Type.INT, 1, 4); // West
                                     break;
+                                case 2: // North-East
                                 case 5: // East
-                                    //No-op - Data is the same
+                                case 8: // South-East
+                                    wrapper.set(Type.INT, 1, 5); // East
                                     break;
                                 case 7: // South
-                                    wrapper.set(Type.INT, 1, 3);
+                                    wrapper.set(Type.INT, 1, 3); // South
                                     break;
-                                default: // Everything else is unsupported, falls back to Down
-                                    wrapper.set(Type.INT, 1, 0);
+                                default: // Self and other directions
+                                    wrapper.set(Type.INT, 1, 0); // Down
                                     break;
                             }
                         }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/Protocol1_13_1To1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/Protocol1_13_1To1_13.java
@@ -154,8 +154,8 @@ public class Protocol1_13_1To1_13 extends AbstractProtocol<ClientboundPackets1_1
                     @Override
                     public void handle(PacketWrapper wrapper) throws Exception {
                         int id = wrapper.get(Type.INT, 0);
-                        int data = wrapper.get(Type.INT, 1);
                         if (id == 2000) { // Smoke
+                            int data = wrapper.get(Type.INT, 1);
                             switch (data) {
                                 case 1: // North
                                     wrapper.set(Type.INT, 1, 2);


### PR DESCRIPTION
There has been a change in directions of the smoke effect back in 1.13.1 that has gone relatively unnoticed. Below is a comparison from before and after (including the data of each direction):
![image](https://user-images.githubusercontent.com/6293922/144335221-5c98a41b-d9b1-4126-9723-22d5cd0f475e.png)

Some of the old directions are no longer reproducible as of 1.13.1, but North, South, East and West are, and this PR maps them to their new data values. For the old unsupported ones, I added a fallback to 0 (Down), or should it be something else?