### PR TITLE
Fixed 1.9 -> 1.8 potion metadata packet order

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/SpawnPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/SpawnPackets.java
@@ -114,7 +114,7 @@ public class SpawnPackets {
                         int typeID = wrapper.get(Type.BYTE, 0);
                         if (Entity1_10Types.getTypeFromId(typeID, true) == Entity1_10Types.EntityType.SPLASH_POTION) {
                             // Convert this to meta data, woo!
-                            PacketWrapper metaPacket = wrapper.create(0x39, new PacketHandler() {
+                            PacketWrapper metaPacket = wrapper.create(ClientboundPackets1_9.ENTITY_METADATA, new PacketHandler() {
                                 @Override
                                 public void handle(PacketWrapper wrapper) throws Exception {
                                     wrapper.write(Type.VAR_INT, entityID);
@@ -127,7 +127,10 @@ public class SpawnPackets {
                                     wrapper.write(Types1_9.METADATA_LIST, meta);
                                 }
                             });
-                            metaPacket.scheduleSend(Protocol1_9To1_8.class);
+                            // Fix packet order
+                            wrapper.send(Protocol1_9To1_8.class);
+                            metaPacket.send(Protocol1_9To1_8.class);
+                            wrapper.cancel();
                         }
                     }
                 });


### PR DESCRIPTION
Fixes those client errors being spammed into the console everytime a potion is thrown
![MultiMC_vwBxXBN2uu](https://user-images.githubusercontent.com/50594595/145203343-37af94d2-d3b7-4743-b170-42e5f6881d75.png)
![MultiMC_NjGujhtQzV](https://user-images.githubusercontent.com/50594595/145203359-cc90f8a4-f365-4c77-98dc-1f5936a50da6.png)

