### PR TITLE
Fixed 1.9.2 -> 1.9.3 block entity translation

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/Protocol1_11To1_10.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/Protocol1_11To1_10.java
@@ -234,11 +234,7 @@ public class Protocol1_11To1_10 extends AbstractProtocol<ClientboundPackets1_9_3
                     public void handle(PacketWrapper wrapper) throws Exception {
                         ClientWorld clientWorld = wrapper.user().get(ClientWorld.class);
 
-                        Chunk1_9_3_4Type type = new Chunk1_9_3_4Type(clientWorld);
-                        Chunk chunk = wrapper.passthrough(type);
-
-                        // Clear any other bytes (This is a workaround for a issue with 1.9.2 encoder adding nbt list)
-                        wrapper.clearInputBuffer();
+                        Chunk chunk = wrapper.passthrough(new Chunk1_9_3_4Type(clientWorld));
 
                         if (chunk.getBlockEntities() == null) return;
                         for (CompoundTag tag : chunk.getBlockEntities()) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/WorldPackets.java
@@ -24,12 +24,7 @@ import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.data.entity.EntityTracker;
 import com.viaversion.viaversion.api.minecraft.blockentity.BlockEntity;
 import com.viaversion.viaversion.api.minecraft.blockentity.BlockEntityImpl;
-import com.viaversion.viaversion.api.minecraft.chunks.Chunk;
-import com.viaversion.viaversion.api.minecraft.chunks.Chunk1_18;
-import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
-import com.viaversion.viaversion.api.minecraft.chunks.ChunkSectionImpl;
-import com.viaversion.viaversion.api.minecraft.chunks.DataPaletteImpl;
-import com.viaversion.viaversion.api.minecraft.chunks.PaletteType;
+import com.viaversion.viaversion.api.minecraft.chunks.*;
 import com.viaversion.viaversion.api.protocol.remapper.PacketRemapper;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.protocols.protocol1_17_1to1_17.ClientboundPackets1_17_1;
@@ -118,24 +113,11 @@ public final class WorldPackets {
                         final NumberTag yTag = tag.get("y");
                         final NumberTag zTag = tag.get("z");
                         final StringTag idTag = tag.get("id");
-                        if (xTag == null || yTag == null || zTag == null) {
+                        if (xTag == null || yTag == null || zTag == null || idTag == null) {
                             continue;
                         }
 
-                        final String id;
-                        if (idTag == null) {
-                            // Thank you 1.8, very cool (might have to be moved somewhere else)
-                            if (tag.get("Chest") instanceof StringTag) {
-                                id = "minecraft:chest";
-                            } else if (tag.get("EnderChest") instanceof StringTag) {
-                                id = "minecraft:ender_chest";
-                            } else {
-                                continue;
-                            }
-                        } else {
-                            id = idTag.getValue();
-                        }
-
+                        final String id = idTag.getValue();
                         final int typeId = protocol.getMappingData().blockEntityIds().getInt(id.replace("minecraft:", ""));
                         if (typeId == -1) {
                             Via.getPlatform().getLogger().warning("Unknown block entity: " + id);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/Protocol1_9_3To1_9_1_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/Protocol1_9_3To1_9_1_2.java
@@ -100,23 +100,20 @@ public class Protocol1_9_3To1_9_1_2 extends AbstractProtocol<ClientboundPackets1
                     public void handle(PacketWrapper wrapper) throws Exception {
                         ClientWorld clientWorld = wrapper.user().get(ClientWorld.class);
 
-                        Chunk1_9_1_2Type oldType = new Chunk1_9_1_2Type(clientWorld);
-                        Chunk1_9_3_4Type newType = new Chunk1_9_3_4Type(clientWorld);
-                        Chunk chunk = wrapper.read(oldType);
-                        wrapper.write(newType, chunk);
+                        Chunk chunk = wrapper.read(new Chunk1_9_1_2Type(clientWorld));
+                        wrapper.write(new Chunk1_9_3_4Type(clientWorld), chunk);
 
                         List<CompoundTag> tags = chunk.getBlockEntities();
                         for (int i = 0; i < chunk.getSections().length; i++) {
                             ChunkSection section = chunk.getSections()[i];
-                            if (section == null)
-                                continue;
+                            if (section == null) continue;
 
                             for (int y = 0; y < 16; y++) {
                                 for (int z = 0; z < 16; z++) {
                                     for (int x = 0; x < 16; x++) {
                                         int block = section.getBlockWithoutData(x, y, z);
-                                        if (FakeTileEntity.hasBlock(block)) {
-                                            tags.add(FakeTileEntity.getFromBlock(x + (chunk.getX() << 4), y + (i << 4), z + (chunk.getZ() << 4), block));
+                                        if (FakeTileEntity.isTileEntity(block)) {
+                                            tags.add(FakeTileEntity.createTileEntity(x + (chunk.getX() << 4), y + (i << 4), z + (chunk.getZ() << 4), block));
                                         }
                                     }
                                 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/chunks/FakeTileEntity.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/chunks/FakeTileEntity.java
@@ -23,58 +23,51 @@ import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
- * Mojang changed the way how tile entities inside chunk packets work in 1.10.1
+ * Mojang changed the way how tile entities inside chunk packets work in 1.9.3/4
  * It requires now to have all tile entity data included in the chunk packet, otherwise it'll crash.
  */
 public class FakeTileEntity {
     private static final Int2ObjectMap<CompoundTag> tileEntities = new Int2ObjectOpenHashMap<>();
 
     static {
-        register(Arrays.asList(61, 62), "Furnace");
-        register(Arrays.asList(54, 146), "Chest");
-        register(130, "EnderChest");
-        register(84, "RecordPlayer");
-        register(23, "Trap"); // Dispenser
-        register(158, "Dropper");
-        register(Arrays.asList(63, 68), "Sign");
-        register(52, "MobSpawner");
-        register(25, "Music"); // Note Block
-        register(Arrays.asList(33, 34, 29, 36), "Piston");
-        register(117, "Cauldron"); // Brewing stand
-        register(116, "EnchantTable");
-        register(Arrays.asList(119, 120), "Airportal"); // End portal
-        register(138, "Beacon");
-        register(144, "Skull");
-        register(Arrays.asList(178, 151), "DLDetector");
-        register(154, "Hopper");
-        register(Arrays.asList(149, 150), "Comparator");
-        register(140, "FlowerPot");
-        register(Arrays.asList(176, 177), "Banner");
-        register(209, "EndGateway");
-        register(137, "Control");
+        register("Furnace", 61, 62);
+        register("Chest", 54, 146);
+        register("EnderChest", 130);
+        register("RecordPlayer", 84);
+        register("Trap", 23); // Dispenser
+        register("Dropper", 158);
+        register("Sign", 63, 68);
+        register("MobSpawner", 52);
+        register("Music", 25); // Note Block
+        register("Piston", 33, 34, 29, 36);
+        register("Cauldron", 117); // Brewing stand
+        register("EnchantTable", 116);
+        register("Airportal", 119, 120); // End portal
+        register("Beacon", 138);
+        register("Skull", 144);
+        register("DLDetector", 178, 151);
+        register("Hopper", 154);
+        register("Comparator", 149, 150);
+        register("FlowerPot", 140);
+        register("Banner", 176, 177);
+        register("EndGateway", 209);
+        register("Control", 137);
     }
 
-    private static void register(int material, String name) {
-        CompoundTag comp = new CompoundTag();
-        comp.put(name, new StringTag());
-        tileEntities.put(material, comp);
-    }
-
-    private static void register(List<Integer> materials, String name) {
-        for (int id : materials) {
-            register(id, name);
+    private static void register(String name, int... ids) {
+        for (int id : ids) {
+            CompoundTag comp = new CompoundTag();
+            comp.put("id", new StringTag(name));
+            tileEntities.put(id, comp);
         }
     }
 
-    public static boolean hasBlock(int block) {
+    public static boolean isTileEntity(int block) {
         return tileEntities.containsKey(block);
     }
 
-    public static CompoundTag getFromBlock(int x, int y, int z, int block) {
+    public static CompoundTag createTileEntity(int x, int y, int z, int block) {
         CompoundTag originalTag = tileEntities.get(block);
         if (originalTag != null) {
             CompoundTag tag = originalTag.clone();


### PR DESCRIPTION
Correctly fixes #2744 and potentially other block entities like furnaces which weren't fixed before