### PR TITLE
Allow "No light data found" message to be suppressed

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/WorldPackets.java
@@ -168,7 +168,9 @@ public final class WorldPackets {
                     final ChunkLightStorage.ChunkLight light = Via.getConfig().cache1_17Light() ?
                             lightStorage.getLight(chunk.getX(), chunk.getZ()) : lightStorage.removeLight(chunk.getX(), chunk.getZ());
                     if (light == null) {
-                        Via.getPlatform().getLogger().warning("No light data found for chunk at " + chunk.getX() + ", " + chunk.getZ() + ". Chunk was already loaded: " + alreadyLoaded);
+                        if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
+                            Via.getPlatform().getLogger().warning("No light data found for chunk at " + chunk.getX() + ", " + chunk.getZ() + ". Chunk was already loaded: " + alreadyLoaded);
+                        }
 
                         final BitSet emptyLightMask = new BitSet();
                         emptyLightMask.set(0, tracker.currentWorldSectionHeight() + 2);


### PR DESCRIPTION
This uses the existing suppress-conversion-warnings config entry to suppress the
"No light data found for chunk at... Chunk was already loaded..." warning.
This message can occur if a plugin does asynchronous chunk processing and a
chunk is unloaded before the plugin's processing is completed. The warning
occurs frequently when a 1.17.1 server is used with a 1.18.1 client.

Fixes #2791 