### PR TITLE
Fix user connection race condition (PoC)

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/handlers/BukkitEncodeHandler.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/handlers/BukkitEncodeHandler.java
@@ -100,4 +100,8 @@ public class BukkitEncodeHandler extends MessageToByteEncoder implements ViaCode
             cause.printStackTrace(); // Print if CB doesn't already do it
         }
     }
+
+    public UserConnection getInfo() {
+        return info;
+    }
 }

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/JoinListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/JoinListener.java
@@ -27,21 +27,21 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.logging.Level;
 
-public class LoginListener implements Listener {
+public class JoinListener implements Listener {
 
     private final Method getHandle;
     private final Field connection;
     private final Field networkManager;
     private final Field channel;
 
-    public LoginListener() {
+    public JoinListener() {
         try {
             getHandle = NMSUtil.obc("entity.CraftPlayer").getDeclaredMethod("getHandle");
         } catch (NoSuchMethodException | ClassNotFoundException e) {
@@ -65,7 +65,7 @@ public class LoginListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    public void onLogin(PlayerLoginEvent e) {
+    public void onJoin(PlayerJoinEvent e) {
         Player player = e.getPlayer();
 
         UserConnection user = getUserConnection(player);

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/LoginListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/LoginListener.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2022 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.bukkit.listeners;
+
+import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.connection.ProtocolInfo;
+import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.bukkit.handlers.BukkitEncodeHandler;
+import com.viaversion.viaversion.bukkit.util.NMSUtil;
+import io.netty.channel.Channel;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerLoginEvent;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+
+public class LoginListener implements Listener {
+
+    private final Method getHandle;
+    private final Field connection;
+    private final Field networkManager;
+    private final Field channel;
+
+    public LoginListener() {
+        try {
+            getHandle = NMSUtil.obc("entity.CraftPlayer").getDeclaredMethod("getHandle");
+        } catch (NoSuchMethodException | ClassNotFoundException e) {
+            throw new RuntimeException("Couldn't find CraftPlayer", e);
+        }
+        try {
+            connection = NMSUtil.nms("EntityPlayer").getDeclaredField("playerConnection");
+        } catch (NoSuchFieldException | ClassNotFoundException e) {
+            throw new RuntimeException("Couldn't find Player Connection", e);
+        }
+        try {
+            networkManager = NMSUtil.nms("PlayerConnection").getDeclaredField("networkManager");
+        } catch (NoSuchFieldException | ClassNotFoundException e) {
+            throw new RuntimeException("Couldn't find Network Manager", e);
+        }
+        try {
+            channel = NMSUtil.nms("NetworkManager").getDeclaredField("channel");
+        } catch (NoSuchFieldException | ClassNotFoundException e) {
+            throw new RuntimeException("Couldn't find Channel", e);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onLogin(PlayerLoginEvent e) {
+        Player player = e.getPlayer();
+
+        UserConnection user = getUserConnection(player);
+        if (user == null) {
+            Via.getPlatform().getLogger().log(Level.WARNING,
+                    "Could not find UserConnection for logging-in player {0}",
+                    player.getUniqueId());
+            return;
+        }
+
+        ProtocolInfo info = user.getProtocolInfo();
+        info.setUuid(player.getUniqueId());
+        info.setUsername(player.getName());
+        Via.getManager().getConnectionManager().onLoginSuccess(user);
+    }
+
+    private UserConnection getUserConnection(Player player) {
+        Channel channel = getChannel(player);
+        if (channel == null) return null;
+        BukkitEncodeHandler encoder = channel.pipeline().get(BukkitEncodeHandler.class);
+        return encoder != null ? encoder.getInfo() : null;
+    }
+
+    private Channel getChannel(Player player) {
+        try {
+            Object entityPlayer = getHandle.invoke(player);
+            Object pc = connection.get(entityPlayer);
+            Object nm = networkManager.get(pc);
+            return (Channel) channel.get(nm);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+}

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
@@ -24,7 +24,7 @@ import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.bukkit.classgenerator.ClassGenerator;
-import com.viaversion.viaversion.bukkit.listeners.LoginListener;
+import com.viaversion.viaversion.bukkit.listeners.JoinListener;
 import com.viaversion.viaversion.bukkit.listeners.UpdateListener;
 import com.viaversion.viaversion.bukkit.listeners.multiversion.PlayerSneakListener;
 import com.viaversion.viaversion.bukkit.listeners.protocol1_15to1_14_4.EntityToggleGlideListener;
@@ -82,7 +82,7 @@ public class BukkitViaLoader implements ViaPlatformLoader {
         registerListener(new UpdateListener());
 
         // Login listener
-        registerListener(new LoginListener());
+        registerListener(new JoinListener());
 
         /* Base Protocol */
         final ViaVersionPlugin plugin = (ViaVersionPlugin) Bukkit.getPluginManager().getPlugin("ViaVersion");

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
@@ -24,6 +24,7 @@ import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.bukkit.classgenerator.ClassGenerator;
+import com.viaversion.viaversion.bukkit.listeners.LoginListener;
 import com.viaversion.viaversion.bukkit.listeners.UpdateListener;
 import com.viaversion.viaversion.bukkit.listeners.multiversion.PlayerSneakListener;
 import com.viaversion.viaversion.bukkit.listeners.protocol1_15to1_14_4.EntityToggleGlideListener;
@@ -79,6 +80,9 @@ public class BukkitViaLoader implements ViaPlatformLoader {
     public void load() {
         // Update Listener
         registerListener(new UpdateListener());
+
+        // Login listener
+        registerListener(new LoginListener());
 
         /* Base Protocol */
         final ViaVersionPlugin plugin = (ViaVersionPlugin) Bukkit.getPluginManager().getPlugin("ViaVersion");

--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionManagerImpl.java
@@ -37,16 +37,17 @@ public class ConnectionManagerImpl implements ConnectionManager {
     @Override
     public void onLoginSuccess(UserConnection connection) {
         Objects.requireNonNull(connection, "connection is null!");
-        connections.add(connection);
+        boolean newlyAdded = connections.add(connection);
 
         if (isFrontEnd(connection)) {
             UUID id = connection.getProtocolInfo().getUuid();
-            if (clients.put(id, connection) != null) {
+            UserConnection previous = clients.put(id, connection);
+            if (previous != null && previous != connection) {
                 Via.getPlatform().getLogger().warning("Duplicate UUID on frontend connection! (" + id + ")");
             }
         }
 
-        if (connection.getChannel() != null) {
+        if (newlyAdded && connection.getChannel() != null) {
             connection.getChannel().closeFuture().addListener((ChannelFutureListener) future -> onDisconnect(connection));
         }
     }

--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionManagerImpl.java
@@ -53,7 +53,7 @@ public class ConnectionManagerImpl implements ConnectionManager {
     }
 
     @Override
-    public void onDisconnect(UserConnection connection) {
+    public synchronized void onDisconnect(UserConnection connection) {
         Objects.requireNonNull(connection, "connection is null!");
         connections.remove(connection);
 

--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionManagerImpl.java
@@ -35,7 +35,7 @@ public class ConnectionManagerImpl implements ConnectionManager {
     protected final Set<UserConnection> connections = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     @Override
-    public void onLoginSuccess(UserConnection connection) {
+    public synchronized void onLoginSuccess(UserConnection connection) {
         Objects.requireNonNull(connection, "connection is null!");
         boolean newlyAdded = connections.add(connection);
 


### PR DESCRIPTION
This is a PoC implementation of a fix for #2835

The idea is that on join event (on the main thread) we set the UserConnection in the ConnectionManager, this means any other plugin requesting player info (like the user's protocol) in PlayerJoinEvent (anything above lowest priority) will get correct info. For more info on the issue refer to #2835 .

This change makes onLoginSuccess be indepotent (assumed to be called twice for each player, once on login event from main thread, and once from network thread), and adds a listener for PlayerLoginEvent on lowest priority that finds the UserConnection from the Player -> EntityPlayer -> PlayerConnection -> NetworkManager -> Channel -> Viaversion encoder -> UserConnection

Edit: 
I have tested and validated that this works as intended on sportpaper 1.8.8 (fork of paper 1.8), i'd assume it should work on any 1.8 bukkit-based platform, if higher mc versions made changes it may not work on them, i did not test them.
 
Initially the PR had the logic on Login event, had to move it to Join event because bukkit does not create (and set) the PlayerConnection until after login event

Edit 2:
Upgraded reflection to be more robust, works in spigot 1.8.8, paper 1.8.8, sportpaper 1.8.8, paper 1.12.2, paper 1.14.4, paper 1.17.1 and paper 1.18.1, in all of the cases connecting with a 1.18.1 client