### PR TITLE
Fixed wrong packet in MovementTransmitter

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitViaMovementTransmitter.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitViaMovementTransmitter.java
@@ -84,14 +84,14 @@ public class BukkitViaMovementTransmitter extends MovementTransmitterProvider {
     public Object getFlyingPacket() {
         if (idlePacket == null)
             throw new NullPointerException("Could not locate flying packet");
-        return idlePacket2;
+        return idlePacket;
     }
 
     @Override
     public Object getGroundPacket() {
         if (idlePacket == null)
             throw new NullPointerException("Could not locate flying packet");
-        return idlePacket;
+        return idlePacket2;
     }
 
     @Override


### PR DESCRIPTION
Fixed packet getters in BukkitMovementTransmitter leading to sending the opposite packet (sending the ground one when flying, and the flying one when on ground) when not using the nms player ticking config option