### PR TITLE
Change suggested Maven version from deprecated LATEST

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can find official dev builds here:
 <dependency>
     <groupId>com.viaversion</groupId>
     <artifactId>viaversion-api</artifactId>
-    <version>LATEST</version>
+    <version>[4.0.0,5.0.0)</version>
     <scope>provided</scope>
 </dependency>
 ```


### PR DESCRIPTION
The README suggests to use LATEST as the version for importing the Via API as a Maven dependency. LATEST is now deprecated by Maven 3 for better reproducible builds. This pull request changes it to [4.0.0-5.0.0), which should use the latest 4.x.x release, and should work as long as they don’t decide to deprecate that. This should be updated each major version.