### PR TITLE
Generate a random seed to simulate random sounds

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -54,6 +54,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.concurrent.ThreadLocalRandom;
 
 public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPackets1_18, ClientboundPackets1_19, ServerboundPackets1_17, ServerboundPackets1_19> {
 
@@ -97,7 +98,7 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
                 map(Type.INT); // Z
                 map(Type.FLOAT); // Volume
                 map(Type.FLOAT); // Pitch
-                create(Type.LONG, 0L); // Seed
+                create(Type.LONG, randomLong()); // Seed
                 handler(soundRewriter.getSoundHandler());
             }
         });
@@ -109,7 +110,7 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
                 map(Type.VAR_INT); // Entity id
                 map(Type.FLOAT); // Volume
                 map(Type.FLOAT); // Pitch
-                create(Type.LONG, 0L); // Seed
+                create(Type.LONG, randomLong()); // Seed
                 handler(soundRewriter.getSoundHandler());
             }
         });
@@ -123,7 +124,7 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
                 map(Type.INT); // Z
                 map(Type.FLOAT); // Volume
                 map(Type.FLOAT); // Pitch
-                create(Type.LONG, 0L); // Seed
+                create(Type.LONG, randomLong()); // Seed
             }
         });
 
@@ -293,6 +294,10 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
                 });
             }
         });
+    }
+
+    private static long randomLong() {
+        return ThreadLocalRandom.current().nextLong();
     }
 
     @Override


### PR DESCRIPTION
Prevents sounds from being the same on 1.19 clients, simulate randomness by sending a random seed.