### PR TITLE
Safely handle bad configuration of 'block-protocols' and 'block-versions'

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.IntPredicate;
 
@@ -160,10 +161,12 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     }
 
     private BlockedProtocolVersions loadBlockedProtocolVersions() {
-        IntSet blockedProtocols = new IntOpenHashSet(getIntegerList("block-protocols"));
+        List<Integer> blockProtocols = getListSafe("block-protocols", Integer.class, "Invalid blocked version protocol found in config: '%s'");
+        List<String> blockVersions = getListSafe("block-versions", String.class, "Invalid blocked version found in config: '%s'");
+        IntSet blockedProtocols = new IntOpenHashSet(blockProtocols);
         int lowerBound = -1;
         int upperBound = -1;
-        for (String s : getStringList("block-versions")) {
+        for (String s : blockVersions) {
             if (s.isEmpty()) {
                 continue;
             }

--- a/common/src/main/java/com/viaversion/viaversion/util/Config.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/Config.java
@@ -18,6 +18,7 @@
 package com.viaversion.viaversion.util;
 
 import com.google.gson.JsonElement;
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.configuration.ConfigurationProvider;
 import com.viaversion.viaversion.libs.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import com.viaversion.viaversion.libs.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -26,11 +27,7 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.representer.Representer;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -212,6 +209,23 @@ public abstract class Config implements ConfigurationProvider {
     public List<String> getStringList(String key) {
         Object o = this.config.get(key);
         return o != null ? (List<String>) o : new ArrayList<>();
+    }
+
+    public <T> List<T> getListSafe(String key, Class<T> type, String invalidValueMessage) {
+        Object o = this.config.get(key);
+        if (o instanceof List) {
+            List<?> list = (List<?>) o;
+            List<T> filteredValues = new ArrayList<>();
+            for (Object o1 : list) {
+                if (type.isInstance(o1)) {
+                    filteredValues.add(type.cast(o1));
+                } else if (invalidValueMessage != null) {
+                    Via.getPlatform().getLogger().warning(String.format(invalidValueMessage, o1));
+                }
+            }
+            return filteredValues;
+        }
+        return new ArrayList<>();
     }
 
     public @Nullable JsonElement getSerializedComponent(String key) {


### PR DESCRIPTION
Is this good enough or should I handle this with more details ?

I also thought about handling both list the same way to make them interchangeable but maybe not a good idea.