### PR TITLE
Reference command permission to filter root suggestions (/via<tab>)

### DIFF
--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -8,5 +8,6 @@ loadbefore: [ProtocolLib, ProxyPipe, SpigotLib, SkinRestorer]
 softdepend: [ProtocolSupport, PacketListenerApi]
 commands:
   viaversion:
+    permission: viaversion.admin # The permission is also referenced here to filter root suggestions (/via<tab>)
     description: Shows ViaVersion Version and more.
     aliases: [viaver, vvbukkit]

--- a/bungee/src/main/java/com/viaversion/viaversion/bungee/commands/BungeeCommand.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/bungee/commands/BungeeCommand.java
@@ -25,7 +25,7 @@ public class BungeeCommand extends Command implements TabExecutor {
     private final BungeeCommandHandler handler;
 
     public BungeeCommand(BungeeCommandHandler handler) {
-        super("viaversion", "", "viaver", "vvbungee"); // The CommandHandler will handle the permission
+        super("viaversion", "viaversion.admin", "viaver", "vvbungee"); // The permission is also referenced here to filter root suggestions (/via<tab>)
         this.handler = handler;
     }
 

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/command/VelocityCommandHandler.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/command/VelocityCommandHandler.java
@@ -41,4 +41,9 @@ public class VelocityCommandHandler extends ViaCommandHandler implements SimpleC
     public List<String> suggest(Invocation invocation) {
         return onTabComplete(new VelocityCommandSender(invocation.source()), invocation.arguments());
     }
+
+    @Override
+    public boolean hasPermission(Invocation invocation) {
+        return invocation.source().hasPermission("viaversion.admin"); // The permission is also referenced here to filter root suggestions (/via<tab>)
+    }
 }


### PR DESCRIPTION
The implementation of the command suggestions themself are properly handled by the "ViaCommandHandler", but the suggestion of the command on the root node is not handled properly, so typing /via suggest /viaversion even when the user is not granted the "viaversion.admin" permission.

I also considered splitting the perm to something like "viaversion.command.use" and "viaversion.admin" to differentiate the permission of the main command from all the sub commands, but they currently all use the same permission so i think it might be good enough for now.