### PR TITLE
Use default painting mapping of 0 instead of -1

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/EntityPackets.java
@@ -151,7 +151,7 @@ public final class EntityPackets extends EntityRewriter<Protocol1_19To1_18_2> {
                     final PacketWrapper metaPacket = wrapper.create(ClientboundPackets1_19.ENTITY_METADATA);
                     metaPacket.write(Type.VAR_INT, wrapper.get(Type.VAR_INT, 0)); // Entity id
                     final List<Metadata> metadata = new ArrayList<>();
-                    metadata.add(new Metadata(8, Types1_19.META_TYPES.paintingVariantType, protocol.getMappingData().getPaintingMappings().getNewId(motive)));
+                    metadata.add(new Metadata(8, Types1_19.META_TYPES.paintingVariantType, protocol.getMappingData().getPaintingMappings().getNewIdOrDefault(motive, 0)));
                     metaPacket.write(Types1_19.METADATA_LIST, metadata);
                     metaPacket.send(Protocol1_19To1_18_2.class);
                 });


### PR DESCRIPTION
Currently, a painting mapping from 1.19.1 server -> 1.18 client works fine, but 1.19.1 -> 1.19 will map some paintings to -1, causing a client crash. This commit ensures an unknown painting ID is safely mapped to 0.

Here is a client crash caused by this issue:
```
java.lang.NullPointerException: Cannot invoke "net.minecraft.core.Holder.value()" because the return value of "net.minecraft.world.entity.decoration.Painting.getVariant()" is null
	at Genesis//net.minecraft.client.renderer.entity.PaintingRenderer.render(SourceFile:33)
	at Genesis//net.minecraft.client.renderer.entity.PaintingRenderer.render(SourceFile:23)
	at Genesis//net.minecraft.client.renderer.entity.EntityRenderDispatcher.render(EntityRenderDispatcher.java:184)
	at Genesis//net.minecraft.client.renderer.LevelRenderer.renderEntity(LevelRenderer.java:2261)
	at Genesis//net.minecraft.client.renderer.LevelRenderer.renderLevel(LevelRenderer.java:1858)
	at Genesis//net.minecraft.client.renderer.GameRenderer.renderLevel(GameRenderer.java:1573)
	at Genesis//net.minecraft.client.renderer.GameRenderer.render(GameRenderer.java:1187)
	at Genesis//net.minecraft.client.Minecraft.runTick(SourceFile:1143)
	at Genesis//net.minecraft.client.Minecraft.run(SourceFile:734)
	at Genesis//net.minecraft.client.main.Main.main(SourceFile:237)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at com.moonsworth.lunar.genesis.Genesis.main(Unknown Source)
```
