### PR TITLE
add flamecord warning message

### DIFF
--- a/bungee/src/main/java/com/viaversion/viaversion/BungeePlugin.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/BungeePlugin.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.ViaAPI;
@@ -24,6 +25,7 @@ import com.viaversion.viaversion.api.command.ViaCommandSender;
 import com.viaversion.viaversion.api.configuration.ConfigurationProvider;
 import com.viaversion.viaversion.api.data.MappingDataLoader;
 import com.viaversion.viaversion.api.platform.PlatformTask;
+import com.viaversion.viaversion.api.platform.UnsupportedSoftware;
 import com.viaversion.viaversion.api.platform.ViaPlatform;
 import com.viaversion.viaversion.bungee.commands.BungeeCommand;
 import com.viaversion.viaversion.bungee.commands.BungeeCommandHandler;
@@ -35,6 +37,7 @@ import com.viaversion.viaversion.bungee.platform.BungeeViaInjector;
 import com.viaversion.viaversion.bungee.platform.BungeeViaLoader;
 import com.viaversion.viaversion.bungee.service.ProtocolDetectorService;
 import com.viaversion.viaversion.dump.PluginInfo;
+import com.viaversion.viaversion.unsupported.UnsupportedServerSoftware;
 import com.viaversion.viaversion.util.GsonUtil;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -56,7 +59,7 @@ public class BungeePlugin extends Plugin implements ViaPlatform<ProxiedPlayer>, 
     @Override
     public void onLoad() {
         try {
-            ProtocolConstants.class.getField("MINECRAFT_1_19");
+            ProtocolConstants.class.getField("MINECRAFT_1_19_1");
         } catch (NoSuchFieldException e) {
             getLogger().warning("      / \\");
             getLogger().warning("     /   \\");
@@ -204,6 +207,17 @@ public class BungeePlugin extends Plugin implements ViaPlatform<ProxiedPlayer>, 
     @Override
     public boolean isOldClientsAllowed() {
         return true;
+    }
+
+    @Override
+    public Collection<UnsupportedSoftware> getUnsupportedSoftwareClasses() {
+        final Collection<UnsupportedSoftware> list = new ArrayList<>(ViaPlatform.super.getUnsupportedSoftwareClasses());
+        list.add(new UnsupportedServerSoftware.Builder()
+                .name("FlameCord")
+                .addClassName("dev._2lstudios.flamecord.FlameCord")
+                .reason(UnsupportedServerSoftware.Reason.BREAKING_PROXY_SOFTWARE)
+                .build());
+        return ImmutableList.copyOf(list);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/unsupported/UnsupportedServerSoftware.java
+++ b/common/src/main/java/com/viaversion/viaversion/unsupported/UnsupportedServerSoftware.java
@@ -110,5 +110,6 @@ public final class UnsupportedServerSoftware implements UnsupportedSoftware {
     public static final class Reason {
 
         public static final String DANGEROUS_SERVER_SOFTWARE = "You are using server software that - outside of possibly breaking ViaVersion - can also cause severe damage to your server's integrity as a whole.";
+        public static final String BREAKING_PROXY_SOFTWARE = "You are using proxy software that intentionally breaks ViaVersion. Please use another proxy software or move ViaVersion to each backend server instead of the proxy.";
     }
 }


### PR DESCRIPTION
Since Flamecord doesn't work with ViaVersion, I think it could be great to add it as an unsupported software to log something users can understand without getting to Discord for support.

I also updated the protocol version constant check for bungeecord outdated check.