### PR TITLE
Fixed 1.19 -> 1.18.2 title translation: Empty text edge case

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -120,7 +120,8 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
 
         final PacketHandler titleHandler = wrapper -> {
             final JsonElement component = wrapper.read(Type.COMPONENT);
-            if (!component.isJsonNull()) {
+            final boolean isEmpty = component.isJsonNull() || (component.isJsonArray() && component.getAsJsonArray().size() == 0);
+            if (!isEmpty) {
                 wrapper.write(Type.COMPONENT, component);
             } else {
                 wrapper.write(Type.COMPONENT, GsonComponentSerializer.gson().serializeToTree(Component.empty()));


### PR DESCRIPTION
Fixes the client (1.19+) being kicked from servers if the server sends an empty json array as title text.