### PR TITLE
Preparation for remapping the 1.19.0 signatures in ViaFabric

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_1to1_19/provider/OldSignatureProvider.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_1to1_19/provider/OldSignatureProvider.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2022 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.protocol1_19_1to1_19.provider;
+
+import com.viaversion.viaversion.api.platform.providers.Provider;
+
+public class OldSignatureProvider implements Provider {
+
+    public boolean platformSpecificHandling() {
+        return false;
+    }
+}


### PR DESCRIPTION
This pull request is a preparation for fixing the signatures of the 1.19.2 -> 1.19.0 protocol, it removes the old code from ViaVersion and just lets the input from the original client pass through, so that you can later implement the signatures of 1.19.0 in ViaFabric so that you can join. If this PR is merged, I will make a second one in ViaFabric that uses the provider.