### PR TITLE
fixed Particle Rendering in 1.13.0 -> 1.12.2

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
@@ -159,7 +159,7 @@ public class EntityPackets {
                     byte flags = packetWrapper.read(Type.BYTE); // Input Flags
 
                     if (Via.getConfig().isNewEffectIndicator())
-                        flags += 2; // Since Minecraft 1.14.4, Minecraft has 2 Flags for rendering the particles, one for the Player Inventory, and one for the InGame HUD
+                        flags += 2;
 
                     packetWrapper.write(Type.BYTE, flags);
                 });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
@@ -159,7 +159,7 @@ public class EntityPackets {
                     byte flags = packetWrapper.read(Type.BYTE); // Input Flags
 
                     if (Via.getConfig().isNewEffectIndicator())
-                        flags += 2;
+                        flags |= 0x04;
 
                     packetWrapper.write(Type.BYTE, flags);
                 });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_13to1_12_2.packets;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.minecraft.entities.Entity1_13Types;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
@@ -143,6 +144,25 @@ public class EntityPackets {
                 });
                 handler(metadataRewriter.playerTrackerHandler());
                 handler(Protocol1_13To1_12_2.SEND_DECLARE_COMMANDS_AND_TAGS);
+            }
+        });
+
+        protocol.registerClientbound(ClientboundPackets1_12_1.ENTITY_EFFECT, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // Entity id
+                map(Type.BYTE); // Effect id
+                map(Type.BYTE); // Amplifier
+                map(Type.VAR_INT); // Duration
+
+                handler(packetWrapper -> {
+                    byte flags = packetWrapper.read(Type.BYTE); // Input Flags
+
+                    if (Via.getConfig().isNewEffectIndicator())
+                        flags += 2; // Since Minecraft 1.14.4, Minecraft has 2 Flags for rendering the particles, one for the Player Inventory, and one for the InGame HUD
+
+                    packetWrapper.write(Type.BYTE, flags);
+                });
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14_4to1_14_3/Protocol1_14_4To1_14_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14_4to1_14_3/Protocol1_14_4To1_14_3.java
@@ -17,7 +17,6 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_14_4to1_14_3;
 
-import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.protocol.AbstractProtocol;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14_4to1_14_3/Protocol1_14_4To1_14_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14_4to1_14_3/Protocol1_14_4To1_14_3.java
@@ -60,24 +60,5 @@ public class Protocol1_14_4To1_14_3 extends AbstractProtocol<ClientboundPackets1
                 });
             }
         });
-
-        this.registerClientbound(ClientboundPackets1_14.ENTITY_EFFECT, new PacketRemapper() {
-            @Override
-            public void registerMap() {
-                map(Type.VAR_INT); // Entity id
-                map(Type.BYTE); // Effect id
-                map(Type.BYTE); // Amplifier
-                map(Type.VAR_INT); // Duration
-
-                handler(packetWrapper -> {
-                    byte flags = packetWrapper.read(Type.BYTE); // Input Flags
-
-                    if (Via.getConfig().isNewEffectIndicator())
-                        flags += 2; // Since Minecraft 1.14.4, Minecraft has 2 Flags for rendering the particles, one for the Player Inventory, and one for the InGame HUD
-
-                    packetWrapper.write(Type.BYTE, flags);
-                });
-            }
-        });
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14_4to1_14_3/Protocol1_14_4To1_14_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14_4to1_14_3/Protocol1_14_4To1_14_3.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_14_4to1_14_3;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.protocol.AbstractProtocol;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
@@ -56,6 +57,25 @@ public class Protocol1_14_4To1_14_3 extends AbstractProtocol<ClientboundPackets1
                             wrapper.write(Type.INT, 0); // demand value added in pre5
                         }
                     }
+                });
+            }
+        });
+
+        this.registerClientbound(ClientboundPackets1_14.ENTITY_EFFECT, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // Entity id
+                map(Type.BYTE); // Effect id
+                map(Type.BYTE); // Amplifier
+                map(Type.VAR_INT); // Duration
+
+                handler(packetWrapper -> {
+                    byte flags = packetWrapper.read(Type.BYTE); // Input Flags
+
+                    if (Via.getConfig().isNewEffectIndicator())
+                        flags += 2; // Since Minecraft 1.14.4, Minecraft has 2 Flags for rendering the particles, one for the Player Inventory, and one for the InGame HUD
+
+                    packetWrapper.write(Type.BYTE, flags);
                 });
             }
         });


### PR DESCRIPTION
As of Minecraft 1.13, a new flag has been added to the Status Effect Packet that specifically says whether a Status Effect should be displayed in-game at the top right, this PR always sets it to true if enabled in ViaConfig. So that 1.14.4+ clients on older servers have the HUD correctly.