### PR TITLE
Some minor performance improvements and cleanups

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/version/ChunkSectionType1_8.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/version/ChunkSectionType1_8.java
@@ -24,6 +24,8 @@ package com.viaversion.viaversion.api.type.types.version;
 
 import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
 import com.viaversion.viaversion.api.minecraft.chunks.ChunkSectionImpl;
+import com.viaversion.viaversion.api.minecraft.chunks.DataPalette;
+import com.viaversion.viaversion.api.minecraft.chunks.PaletteType;
 import com.viaversion.viaversion.api.type.Type;
 import io.netty.buffer.ByteBuf;
 
@@ -38,16 +40,14 @@ public class ChunkSectionType1_8 extends Type<ChunkSection> {
     @Override
     public ChunkSection read(ByteBuf buffer) throws Exception {
         ChunkSection chunkSection = new ChunkSectionImpl(true);
+        DataPalette blocks = chunkSection.palette(PaletteType.BLOCKS);
+        assert blocks != null;
         // 0 index needs to be air in 1.9
-        chunkSection.addPaletteEntry(0);
+        blocks.addId(0);
 
         ByteBuf littleEndianView = buffer.order(ByteOrder.LITTLE_ENDIAN);
-
-        for (int i = 0; i < ChunkSection.SIZE; i++) {
-            int mask = littleEndianView.readShort();
-            int type = mask >> 4;
-            int data = mask & 0xF;
-            chunkSection.setBlockWithData(i, type, data);
+        for (int idx = 0; idx < ChunkSection.SIZE; idx++) {
+            blocks.setIdAt(idx, littleEndianView.readShort());
         }
 
         return chunkSection;
@@ -55,15 +55,12 @@ public class ChunkSectionType1_8 extends Type<ChunkSection> {
 
     @Override
     public void write(ByteBuf buffer, ChunkSection chunkSection) throws Exception {
-        for (int y = 0; y < 16; y++) {
-            for (int z = 0; z < 16; z++) {
-                for (int x = 0; x < 16; x++) {
-                    int block = chunkSection.getFlatBlock(x, y, z);
-                    buffer.writeByte(block);
-                    buffer.writeByte(block >> 8);
-                }
-            }
+        DataPalette blocks = chunkSection.palette(PaletteType.BLOCKS);
+        assert blocks != null;
+
+        ByteBuf littleEndianView = buffer.order(ByteOrder.LITTLE_ENDIAN);
+        for (int idx = 0; idx < ChunkSection.SIZE; idx++) {
+            littleEndianView.writeShort(blocks.idAt(idx));
         }
     }
-
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -27,6 +27,8 @@ import com.viaversion.viaversion.api.minecraft.BlockChangeRecord;
 import com.viaversion.viaversion.api.minecraft.Position;
 import com.viaversion.viaversion.api.minecraft.chunks.Chunk;
 import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
+import com.viaversion.viaversion.api.minecraft.chunks.DataPalette;
+import com.viaversion.viaversion.api.minecraft.chunks.PaletteType;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketRemapper;
@@ -334,77 +336,63 @@ public class WorldPackets {
                     Chunk chunk = wrapper.read(type);
                     wrapper.write(type1_13, chunk);
 
-                    for (int i = 0; i < chunk.getSections().length; i++) {
-                        ChunkSection section = chunk.getSections()[i];
-                        if (section == null)
-                            continue;
+                    for (int s = 0; s < chunk.getSections().length; s++) {
+                        ChunkSection section = chunk.getSections()[s];
+                        if (section == null) continue;
+                        DataPalette blocks = section.palette(PaletteType.BLOCKS);
+                        assert blocks != null;
 
-                        for (int p = 0; p < section.getPaletteSize(); p++) {
-                            int old = section.getPaletteEntry(p);
+                        for (int p = 0; p < blocks.size(); p++) {
+                            int old = blocks.idByIndex(p);
                             int newId = toNewId(old);
-                            section.setPaletteEntry(p, newId);
+                            blocks.setIdByIndex(p, newId);
                         }
 
                         storage:
                         {
                             if (chunk.isFullChunk()) {
                                 boolean willSave = false;
-                                for (int j = 0; j < section.getPaletteSize(); j++) {
-                                    if (storage.isWelcome(section.getPaletteEntry(j))) {
+                                for (int p = 0; p < blocks.size(); p++) {
+                                    if (storage.isWelcome(blocks.idByIndex(p))) {
                                         willSave = true;
                                         break;
                                     }
                                 }
                                 if (!willSave) break storage;
                             }
-                            for (int y = 0; y < 16; y++) {
-                                for (int z = 0; z < 16; z++) {
-                                    for (int x = 0; x < 16; x++) {
-                                        int block = section.getFlatBlock(x, y, z);
-                                        Position pos = new Position(
-                                                (x + (chunk.getX() << 4)),
-                                                (y + (i << 4)),
-                                                (z + (chunk.getZ() << 4))
-                                        );
-                                        if (storage.isWelcome(block)) {
-                                            storage.store(pos, block);
-                                        } else if (!chunk.isFullChunk()) { // Update
-                                            storage.remove(pos);
-                                        }
-                                    }
+                            for (int idx = 0; idx < ChunkSection.SIZE; idx++) {
+                                int id = blocks.idAt(idx);
+                                if (storage.isWelcome(id)) {
+                                    storage.store(new Position((idx & 0xF) + (chunk.getX() << 4), (idx >> 8 & 0xF) + (s << 4), (idx >> 4 & 0xF) + (chunk.getZ() << 4)), id);
+                                } else if (!chunk.isFullChunk()) { // Update
+                                    storage.remove(new Position((idx & 0xF) + (chunk.getX() << 4), (idx >> 8 & 0xF) + (s << 4), (idx >> 4 & 0xF) + (chunk.getZ() << 4)));
                                 }
                             }
                         }
 
                         save_connections:
                         {
-                            if (!Via.getConfig().isServersideBlockConnections()
-                                    || !ConnectionData.needStoreBlocks()) break save_connections;
+                            if (!Via.getConfig().isServersideBlockConnections() || !ConnectionData.needStoreBlocks()) break save_connections;
 
                             if (!chunk.isFullChunk()) { // Update
-                                ConnectionData.blockConnectionProvider.unloadChunkSection(wrapper.user(), chunk.getX(), i, chunk.getZ());
+                                ConnectionData.blockConnectionProvider.unloadChunkSection(wrapper.user(), chunk.getX(), s, chunk.getZ());
                             }
                             boolean willSave = false;
-                            for (int j = 0; j < section.getPaletteSize(); j++) {
-                                if (ConnectionData.isWelcome(section.getPaletteEntry(j))) {
+                            for (int p = 0; p < blocks.size(); p++) {
+                                if (ConnectionData.isWelcome(blocks.idByIndex(p))) {
                                     willSave = true;
                                     break;
                                 }
                             }
                             if (!willSave) break save_connections;
 
-                            for (int y = 0; y < 16; y++) {
-                                for (int z = 0; z < 16; z++) {
-                                    for (int x = 0; x < 16; x++) {
-                                        int block = section.getFlatBlock(x, y, z);
-                                        if (ConnectionData.isWelcome(block)) {
-                                            int globalX = x + (chunk.getX() << 4);
-                                            int globalY = y + (i << 4);
-                                            int globalZ = z + (chunk.getZ() << 4);
-                                            ConnectionData.blockConnectionProvider.storeBlock(wrapper.user(), globalX,
-                                                    globalY, globalZ, block);
-                                        }
-                                    }
+                            for (int idx = 0; idx < ChunkSection.SIZE; idx++) {
+                                int id = blocks.idAt(idx);
+                                if (ConnectionData.isWelcome(id)) {
+                                    int globalX = (idx & 0xF) + (chunk.getX() << 4);
+                                    int globalY = (idx >> 8 & 0xF) + (s << 4);
+                                    int globalZ = (idx >> 4 & 0xF) + (chunk.getZ() << 4);
+                                    ConnectionData.blockConnectionProvider.storeBlock(wrapper.user(), globalX, globalY, globalZ, id);
                                 }
                             }
                         }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/Protocol1_9_3To1_9_1_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/Protocol1_9_3To1_9_1_2.java
@@ -25,6 +25,8 @@ import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.Position;
 import com.viaversion.viaversion.api.minecraft.chunks.Chunk;
 import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
+import com.viaversion.viaversion.api.minecraft.chunks.DataPalette;
+import com.viaversion.viaversion.api.minecraft.chunks.PaletteType;
 import com.viaversion.viaversion.api.protocol.AbstractProtocol;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
@@ -107,15 +109,13 @@ public class Protocol1_9_3To1_9_1_2 extends AbstractProtocol<ClientboundPackets1
                         for (int i = 0; i < chunk.getSections().length; i++) {
                             ChunkSection section = chunk.getSections()[i];
                             if (section == null) continue;
+                            DataPalette blocks = section.palette(PaletteType.BLOCKS);
+                            assert blocks != null;
 
-                            for (int y = 0; y < 16; y++) {
-                                for (int z = 0; z < 16; z++) {
-                                    for (int x = 0; x < 16; x++) {
-                                        int block = section.getBlockWithoutData(x, y, z);
-                                        if (FakeTileEntity.isTileEntity(block)) {
-                                            tags.add(FakeTileEntity.createTileEntity(x + (chunk.getX() << 4), y + (i << 4), z + (chunk.getZ() << 4), block));
-                                        }
-                                    }
+                            for (int idx = 0; idx < ChunkSection.SIZE; idx++) {
+                                int id = blocks.idAt(idx) >> 4;
+                                if (FakeTileEntity.isTileEntity(id)) {
+                                    tags.add(FakeTileEntity.createTileEntity((idx & 0xF) + (chunk.getX() << 4), (idx >> 8 & 0xF) + (i << 4), (idx >> 4 & 0xF) + (chunk.getZ() << 4), id));
                                 }
                             }
                         }


### PR DESCRIPTION
Replaced some x,y,z for loops with index loops to reduce xyz/index packing/unpacking. Also replaced calls to methods that access the palette via ChunkSection with direct calls to the palette. And some other minor changes to reduce object allocation.
Did some quick testing with a 1.19.2 client on a 1.8.9 server, but further testing might be needed.