### PR TITLE
Replaced hardcoded chunk section out of bounds check

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
@@ -382,7 +382,7 @@ public class WorldPackets {
                         neighbourY = 15;
                     }
 
-                    if (ySection == 16 || ySection == -1) continue;
+                    if (ySection == chunk.getSections().length || ySection == -1) continue;
 
                     ChunkSection newSection = chunk.getSections()[ySection];
                     if (newSection == null) continue;


### PR DESCRIPTION
Fixes a rare error when chunk sections passed through the protocol are larger than 16 sections. Does not break anything else.