### PR TITLE
Fixed 1.19 -> 1.18.2 player info display name translation: Empty text edge case

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -64,6 +64,10 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
         super(ClientboundPackets1_18.class, ClientboundPackets1_19.class, ServerboundPackets1_17.class, ServerboundPackets1_19.class);
     }
 
+    public static boolean isTextComponentNull(final JsonElement element) {
+        return element == null || element.isJsonNull() || (element.isJsonArray() && element.getAsJsonArray().size() == 0);
+    }
+
     @Override
     protected void registerPackets() {
         final TagRewriter tagRewriter = new TagRewriter(this);
@@ -120,8 +124,7 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
 
         final PacketHandler titleHandler = wrapper -> {
             final JsonElement component = wrapper.read(Type.COMPONENT);
-            final boolean isEmpty = component.isJsonNull() || (component.isJsonArray() && component.getAsJsonArray().size() == 0);
-            if (!isEmpty) {
+            if (!isTextComponentNull(component)) {
                 wrapper.write(Type.COMPONENT, component);
             } else {
                 wrapper.write(Type.COMPONENT, GsonComponentSerializer.gson().serializeToTree(Component.empty()));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/EntityPackets.java
@@ -22,6 +22,7 @@ import com.github.steveice10.opennbt.tag.builtin.IntTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.Tag;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonElement;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.data.entity.DimensionData;
 import com.viaversion.viaversion.api.minecraft.Position;
@@ -280,19 +281,29 @@ public final class EntityPackets extends EntityRewriter<Protocol1_19To1_18_2> {
                             for (int j = 0; j < properties; j++) {
                                 wrapper.passthrough(Type.STRING); // Name
                                 wrapper.passthrough(Type.STRING); // Value
-                                    wrapper.passthrough(Type.OPTIONAL_STRING); // Signature
+                                wrapper.passthrough(Type.OPTIONAL_STRING); // Signature
                             }
 
                             wrapper.passthrough(Type.VAR_INT); // Gamemode
                             wrapper.passthrough(Type.VAR_INT); // Ping
-                            wrapper.passthrough(Type.OPTIONAL_COMPONENT); // Display name
+                            final JsonElement displayName = wrapper.read(Type.OPTIONAL_COMPONENT); // Display name
+                            if (!Protocol1_19To1_18_2.isTextComponentNull(displayName)) {
+                                wrapper.write(Type.OPTIONAL_COMPONENT, displayName);
+                            } else {
+                                wrapper.write(Type.OPTIONAL_COMPONENT, null);
+                            }
 
                             // No public profile signature
                             wrapper.write(Type.OPTIONAL_PROFILE_KEY, null);
                         } else if (action == 1 || action == 2) { // Update gamemode/update latency
                             wrapper.passthrough(Type.VAR_INT);
                         } else if (action == 3) { // Update display name
-                                wrapper.passthrough(Type.OPTIONAL_COMPONENT);
+                            final JsonElement displayName = wrapper.read(Type.OPTIONAL_COMPONENT); // Display name
+                            if (!Protocol1_19To1_18_2.isTextComponentNull(displayName)) {
+                                wrapper.write(Type.OPTIONAL_COMPONENT, displayName);
+                            } else {
+                                wrapper.write(Type.OPTIONAL_COMPONENT, null);
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
Fixes the client (1.19+) being kicked from servers if the server sends an empty json array as display name for player info entries.
Basically the same fix as #3115 but for player list entries.