### PR TITLE
Fix missing zombie_pigman (1.15.2) => zombified_piglin (1.16) translation in mob_spawner tile entity

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/WorldPackets.java
@@ -141,6 +141,17 @@ public class WorldPackets {
                     compoundTag.put("Text" + i, new StringTag(text.toString()));
                 }
             }
+        } else if (id.equals("minecraft:mob_spawner")) {
+            Tag spawnDataTag = compoundTag.get("SpawnData");
+            if (spawnDataTag instanceof CompoundTag) {
+                Tag spawnDataIdTag = ((CompoundTag) spawnDataTag).get("id");
+                if (spawnDataIdTag instanceof StringTag) {
+                    StringTag spawnDataIdStringTag = ((StringTag) spawnDataIdTag);
+                    if (spawnDataIdStringTag.getValue().equals("minecraft:zombie_pigman")) {
+                        spawnDataIdStringTag.setValue("minecraft:zombified_piglin");
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
Between version 1.15.2 and 1.16, the entity zombie_pigman was renamed to zombified_piglin, but mob_spawners didn't had any translation, which causes the client to spam the log with errors "Skipping Entity with id minecraft:zombie_pigman" and no entity is shown in the mob spawner.

# Testing
Can be tested with a server which has version 1.8.9 until 1.15.2 and a client with version 1.16 until 1.19.2 by creating a mob spawner, and setting it with a zombified piglin spawnegg.