### PR TITLE
Emulates Armor HUD for 1.9+ players on 1.8 servers

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -396,6 +396,13 @@ public interface ViaVersionConfig {
     boolean isLeftHandedHandling();
 
     /**
+     * Emulates the armor hud on 1.8 servers for 1.9+ clients
+     *
+     * @return true if enabled
+     */
+    boolean isArmorHud1_8();
+
+    /**
      * Fixes velocity bugs due to different hitbox for 1.9-1.13 clients on 1.8 servers.
      *
      * @return true if enabled

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -82,6 +82,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private int tabCompleteDelay;
     private boolean truncate1_14Books;
     private boolean leftHandedHandling;
+    private boolean armorHud1_8;
     private boolean fullBlockLightFix;
     private boolean healthNaNFix;
     private boolean instantRespawn;
@@ -148,6 +149,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         tabCompleteDelay = getInt("1_13-tab-complete-delay", 0);
         truncate1_14Books = getBoolean("truncate-1_14-books", false);
         leftHandedHandling = getBoolean("left-handed-handling", true);
+        armorHud1_8 = getBoolean("armor-hud-1_8", true);
         fullBlockLightFix = getBoolean("fix-non-full-blocklight", false);
         healthNaNFix = getBoolean("fix-1_14-health-nan", true);
         instantRespawn = getBoolean("use-1_15-instant-respawn", false);
@@ -477,6 +479,11 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public boolean isLeftHandedHandling() {
         return leftHandedHandling;
+    }
+
+    @Override
+    public boolean isArmorHud1_8() {
+        return armorHud1_8;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
@@ -145,6 +145,8 @@ public class Protocol1_9To1_8 extends AbstractProtocol<ClientboundPackets1_8, Cl
         userConnection.put(new InventoryTracker());
         // CommandBlock storage
         userConnection.put(new CommandBlockStorage());
+        // Armor Tracker
+        userConnection.put(new ArmorTracker());
 
         if (!userConnection.has(ClientWorld.class)) {
             userConnection.put(new ClientWorld(userConnection));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/EntityPackets.java
@@ -178,9 +178,14 @@ public class EntityPackets {
                         Item stack = wrapper.get(Type.ITEM, 0);
                         ItemRewriter.toClient(stack);
 
-                        int slotID = wrapper.get(Type.VAR_INT, 0);
-                        ArmorTracker armorTracker = wrapper.user().get(ArmorTracker.class);
-                        armorTracker.onSetSlot((short) slotID, stack == null ? 0 : stack.identifier(), wrapper.user());
+                        EntityTracker1_9 entityTracker = wrapper.user().getEntityTracker(Protocol1_9To1_8.class);
+                        int entityId = wrapper.get(Type.VAR_INT, 0);
+
+                        if (entityId == entityTracker.getProvidedEntityId()) {
+                            int slotID = wrapper.get(Type.VAR_INT, 1);
+                            ArmorTracker armorTracker = wrapper.user().get(ArmorTracker.class);
+                            armorTracker.onSetSlot((short) slotID, stack == null ? 0 : stack.identifier(), wrapper.user());
+                        }
                     }
                 });
                 // Blocking

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/EntityPackets.java
@@ -34,6 +34,7 @@ import com.viaversion.viaversion.protocols.protocol1_9to1_8.ItemRewriter;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.Protocol1_9To1_8;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.ServerboundPackets1_9;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.metadata.MetadataRewriter1_9To1_8;
+import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.ArmorTracker;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.EntityTracker1_9;
 import com.viaversion.viaversion.util.Pair;
 import com.viaversion.viaversion.util.Triple;
@@ -176,6 +177,10 @@ public class EntityPackets {
                     public void handle(PacketWrapper wrapper) throws Exception {
                         Item stack = wrapper.get(Type.ITEM, 0);
                         ItemRewriter.toClient(stack);
+
+                        int slotID = wrapper.get(Type.VAR_INT, 0);
+                        ArmorTracker armorTracker = wrapper.user().get(ArmorTracker.class);
+                        armorTracker.onSetSlot((short) slotID, stack == null ? 0 : stack.identifier(), wrapper.user());
                     }
                 });
                 // Blocking

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
@@ -194,6 +194,9 @@ public class InventoryPackets {
                             }
 
                             ItemRewriter.toClient(stack);
+
+                            ArmorTracker armorTracker = wrapper.user().get(ArmorTracker.class);
+                            armorTracker.onSetSlot(i, stack == null ? 0 : stack.identifier(), wrapper.user());
                         }
 
                         // Sync shield item in offhand with main hand

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
@@ -181,6 +181,7 @@ public class InventoryPackets {
 
                         InventoryTracker inventoryTracker = wrapper.user().get(InventoryTracker.class);
                         EntityTracker1_9 entityTracker = wrapper.user().getEntityTracker(Protocol1_9To1_8.class);
+                        ArmorTracker armorTracker = wrapper.user().get(ArmorTracker.class);
 
                         boolean showShieldWhenSwordInHand = Via.getConfig().isShowShieldWhenSwordInHand()
                                 && Via.getConfig().isShieldBlocking();
@@ -195,7 +196,6 @@ public class InventoryPackets {
 
                             ItemRewriter.toClient(stack);
 
-                            ArmorTracker armorTracker = wrapper.user().get(ArmorTracker.class);
                             armorTracker.onSetSlot(i, stack == null ? 0 : stack.identifier(), wrapper.user());
                         }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
@@ -29,6 +29,7 @@ import com.viaversion.viaversion.protocols.protocol1_9to1_8.ClientboundPackets1_
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.ItemRewriter;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.Protocol1_9To1_8;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.ServerboundPackets1_9;
+import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.ArmorTracker;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.EntityTracker1_9;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.InventoryTracker;
 
@@ -110,6 +111,17 @@ public class InventoryPackets {
                 map(Type.UNSIGNED_BYTE); // 0 - Window ID
                 map(Type.SHORT); // 1 - Slot ID
                 map(Type.ITEM); // 2 - Slot Value
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        Item stack = wrapper.get(Type.ITEM, 0);
+                        ItemRewriter.toClient(stack);
+                        short slotID = wrapper.get(Type.SHORT, 0);
+
+                        ArmorTracker armorTracker = wrapper.user().get(ArmorTracker.class);
+                        armorTracker.onSetSlot(slotID, stack == null ? 0 : stack.identifier(), wrapper.user());
+                    }
+                });
                 handler(new PacketHandler() {
                     @Override
                     public void handle(PacketWrapper wrapper) throws Exception {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/storage/ArmorTracker.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/storage/ArmorTracker.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_9to1_8.storage;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.StorableObject;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
@@ -35,6 +36,8 @@ public class ArmorTracker implements StorableObject {
     private double armorPoints;
 
     public void onSetSlot(final short slotId, final int itemId, final UserConnection userConnection) {
+        if (!Via.getConfig().isArmorHud1_8()) return;
+
         if (slotId >= 5 && slotId <= 8) { // Armor slots
             if (!armorSlotsTracker.containsKey(slotId) && itemId != 0) {
                 armorSlotsTracker.put(slotId, itemId);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/storage/ArmorTracker.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/storage/ArmorTracker.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2022 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.protocol1_9to1_8.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
+import com.viaversion.viaversion.api.type.Type;
+import com.viaversion.viaversion.protocols.protocol1_9to1_8.ArmorType;
+import com.viaversion.viaversion.protocols.protocol1_9to1_8.ClientboundPackets1_9;
+import com.viaversion.viaversion.protocols.protocol1_9to1_8.Protocol1_9To1_8;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ArmorTracker implements StorableObject {
+
+    public final Map<Short, Integer> armorSlotsTracker = new HashMap<>();
+    private double armorPoints;
+
+    public void onSetSlot(final short slotId, final int itemId, final UserConnection userConnection) {
+        if (slotId >= 5 && slotId <= 8) { // Armor slots
+            if (!armorSlotsTracker.containsKey(slotId) && itemId != 0) {
+                armorSlotsTracker.put(slotId, itemId);
+                armorPoints += ArmorType.findById(itemId).getArmorPoints();
+            } else {
+                final int lastItem = armorSlotsTracker.get(slotId);
+                armorSlotsTracker.remove(slotId);
+                armorPoints -= ArmorType.findById(lastItem).getArmorPoints();
+            }
+
+            EntityTracker1_9 tracker = userConnection.getEntityTracker(Protocol1_9To1_8.class);
+            final PacketWrapper propertiesPacket = PacketWrapper.create(ClientboundPackets1_9.ENTITY_PROPERTIES, userConnection);
+
+            propertiesPacket.write(Type.VAR_INT, tracker.getProvidedEntityId());
+            propertiesPacket.write(Type.INT, 1);
+            propertiesPacket.write(Type.STRING, "generic.armor");
+            propertiesPacket.write(Type.DOUBLE, 0.0);
+            propertiesPacket.write(Type.VAR_INT, 1);
+            propertiesPacket.write(Type.UUID, UUID.fromString("2AD3F246-FEE1-4E67-B886-69FD380BB150"));
+            propertiesPacket.write(Type.DOUBLE, armorPoints);
+            propertiesPacket.write(Type.BYTE, (byte) 0);
+
+            try {
+                propertiesPacket.scheduleSend(Protocol1_9To1_8.class);
+            } catch (Exception ignored) {
+            }
+        }
+    }
+}

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -221,6 +221,8 @@ force-json-transform: false
 minimize-cooldown: true
 # Allows 1.9+ left-handedness (main hand) on 1.8 servers
 left-handed-handling: true
+# Emulates the armor hud on 1.8 servers for 1.9+ clients
+armor-hud-1_8: true
 # Get the world names which should be returned for each vanilla dimension
 map-1_16-world-names:
   overworld: "minecraft:overworld"


### PR DESCRIPTION
This pull request emulates the Armor of each 1.9+ player and sends back the correct Entity Properties packet, so that the Armor HUD of Minecraft for 1.9+ players works again on 1.8 servers.