### PR TITLE
Fix recipe book not being empty when using a multi-server configuration, with servers which are pre-1.12.

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/Protocol1_12To1_11_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/Protocol1_12To1_11_1.java
@@ -33,6 +33,7 @@ import com.viaversion.viaversion.api.protocol.AbstractProtocol;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
 import com.viaversion.viaversion.api.protocol.remapper.PacketRemapper;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.rewriter.ItemRewriter;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.version.Types1_12;
@@ -40,6 +41,8 @@ import com.viaversion.viaversion.data.entity.EntityTrackerBase;
 import com.viaversion.viaversion.protocols.protocol1_12to1_11_1.metadata.MetadataRewriter1_12To1_11_1;
 import com.viaversion.viaversion.protocols.protocol1_12to1_11_1.packets.InventoryPackets;
 import com.viaversion.viaversion.protocols.protocol1_12to1_11_1.providers.InventoryQuickMoveProvider;
+import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.ClientboundPackets1_13;
+import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;
 import com.viaversion.viaversion.protocols.protocol1_9_1_2to1_9_3_4.types.Chunk1_9_3_4Type;
 import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.ClientboundPackets1_9_3;
 import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.ServerboundPackets1_9_3;
@@ -164,9 +167,16 @@ public class Protocol1_12To1_11_1 extends AbstractProtocol<ClientboundPackets1_9
                 map(Type.UNSIGNED_BYTE);
                 map(Type.INT);
                 handler(wrapper -> {
-                    ClientWorld clientChunks = wrapper.user().get(ClientWorld.class);
+                    UserConnection user = wrapper.user();
+                    ClientWorld clientChunks = user.get(ClientWorld.class);
                     int dimensionId = wrapper.get(Type.INT, 1);
                     clientChunks.setEnvironment(dimensionId);
+
+                    // Reset recipes
+                    if (user.getProtocolInfo().getProtocolVersion() >= ProtocolVersion.v1_13.getVersion()) {
+                        wrapper.create(ClientboundPackets1_13.DECLARE_RECIPES, packetWrapper -> packetWrapper.write(Type.VAR_INT, 0))
+                                .scheduleSend(Protocol1_13To1_12_2.class);
+                    }
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_13to1_12_2.packets;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.minecraft.entities.Entity1_13Types;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
@@ -143,6 +144,25 @@ public class EntityPackets {
                 });
                 handler(metadataRewriter.playerTrackerHandler());
                 handler(Protocol1_13To1_12_2.SEND_DECLARE_COMMANDS_AND_TAGS);
+            }
+        });
+
+        protocol.registerClientbound(ClientboundPackets1_12_1.ENTITY_EFFECT, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // Entity id
+                map(Type.BYTE); // Effect id
+                map(Type.BYTE); // Amplifier
+                map(Type.VAR_INT); // Duration
+
+                handler(packetWrapper -> {
+                    byte flags = packetWrapper.read(Type.BYTE); // Input Flags
+
+                    if (Via.getConfig().isNewEffectIndicator())
+                        flags |= 0x04;
+
+                    packetWrapper.write(Type.BYTE, flags);
+                });
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/WorldPackets.java
@@ -141,6 +141,17 @@ public class WorldPackets {
                     compoundTag.put("Text" + i, new StringTag(text.toString()));
                 }
             }
+        } else if (id.equals("minecraft:mob_spawner")) {
+            Tag spawnDataTag = compoundTag.get("SpawnData");
+            if (spawnDataTag instanceof CompoundTag) {
+                Tag spawnDataIdTag = ((CompoundTag) spawnDataTag).get("id");
+                if (spawnDataIdTag instanceof StringTag) {
+                    StringTag spawnDataIdStringTag = ((StringTag) spawnDataIdTag);
+                    if (spawnDataIdStringTag.getValue().equals("minecraft:zombie_pigman")) {
+                        spawnDataIdStringTag.setValue("minecraft:zombified_piglin");
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
When using a multi-server configuration, with servers which are pre-1.12, switching from 1.12 to pre-1.12 causes the recipe book to not clear.

# Testing
Can be tested with a BungeeCord and two servers, one is pre-1.12 and the other one 1.12 or later. When switching from 1.12 to 1.11, the recipe book is still shown, even when unusable and containing invalid recipes.