### PR TITLE
Fill in creeper igniter tag for 1.19.3

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_3to1_19_1/Protocol1_19_3To1_19_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_3to1_19_1/Protocol1_19_3To1_19_1.java
@@ -69,6 +69,10 @@ public final class Protocol1_19_3To1_19_1 extends AbstractProtocol<ClientboundPa
     @Override
     protected void registerPackets() {
         final TagRewriter tagRewriter = new TagRewriter(this);
+
+        // Flint and steel was hardcoded before 1.19.3 to ignite a creeper; has been moved to a tag - adding this ensures offhand doesn't trigger as well
+        tagRewriter.addTagRaw(RegistryType.ITEM, "minecraft:creeper_igniters", 733); // 733 = flint_and_steel 1.19.3
+
         tagRewriter.addEmptyTags(RegistryType.ITEM, "minecraft:bookshelf_books", "minecraft:hanging_signs", "minecraft:stripped_logs");
         tagRewriter.addEmptyTags(RegistryType.BLOCK, "minecraft:all_hanging_signs", "minecraft:ceiling_hanging_signs", "minecraft:invalid_spawn_inside",
                 "minecraft:stripped_logs", "minecraft:wall_hanging_signs");


### PR DESCRIPTION
1.19.3 added the CREEPER_IGNITERS tag to control what items can ignite a creeper. If not filled in, the client will assume the action did nothing and will allow items in the offhand to test on the item (I.E. a name tag on the offhand will succeed in naming the soon-to-be-blown-up creeper). 
This PR fills in that tag with the only item that was an igniter in 1.19.2, flint and steel.