### PR TITLE
Add armor toggle patch for Bukkit

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -458,4 +458,6 @@ public interface ViaVersionConfig {
     boolean cache1_17Light();
 
     @Nullable String chatTypeFormat(String translationKey);
+
+    boolean isArmorToggleFix();
 }

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19_4To1_19_3/ArmorToggleListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19_4To1_19_3/ArmorToggleListener.java
@@ -23,6 +23,7 @@ import com.viaversion.viaversion.protocols.protocol1_19_4to1_19_3.Protocol1_19_4
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -33,7 +34,7 @@ public final class ArmorToggleListener extends ViaBukkitListener {
         super(plugin, Protocol1_19_4To1_19_3.class);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void itemUse(final PlayerInteractEvent event) {
         final Player player = event.getPlayer();
         if (!isOnPipe(player)) return;

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19_4To1_19_3/ArmorToggleListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19_4To1_19_3/ArmorToggleListener.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2023 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.bukkit.listeners.protocol1_19_4To1_19_3;
+
+import com.viaversion.viaversion.ViaVersionPlugin;
+import com.viaversion.viaversion.bukkit.listeners.ViaBukkitListener;
+import com.viaversion.viaversion.protocols.protocol1_19_4to1_19_3.Protocol1_19_4To1_19_3;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+public final class ArmorToggleListener extends ViaBukkitListener {
+
+    public ArmorToggleListener(ViaVersionPlugin plugin) {
+        super(plugin, Protocol1_19_4To1_19_3.class);
+    }
+
+    @EventHandler
+    public void itemUse(final PlayerInteractEvent event) {
+        final Player player = event.getPlayer();
+        if (!isOnPipe(player)) return;
+
+        final ItemStack item = event.getItem();
+        if (item == null) {
+            return;
+        }
+        final EquipmentSlot equipmentSlot = item.getType().getEquipmentSlot();
+        // Name comparison for OFF_HAND so 1.8 doesn't complain
+        if (equipmentSlot != EquipmentSlot.HAND && !equipmentSlot.name().equals("OFF_HAND")) {
+            final ItemStack armor = player.getInventory().getItem(equipmentSlot);
+            // If two pieces of armor are equal, the client will do nothing.
+            if (armor != null && armor.getType() != Material.AIR && !armor.equals(item)) {
+                player.updateInventory();
+            }
+        }
+    }
+}

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaConfig.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaConfig.java
@@ -33,6 +33,7 @@ public class BukkitViaConfig extends AbstractViaConfig {
     private boolean hitboxFix1_9;
     private boolean hitboxFix1_14;
     private String blockConnectionMethod;
+    private boolean armorToggleFix;
 
     public BukkitViaConfig() {
         super(new File(((Plugin) Via.getPlatform()).getDataFolder(), "config.yml"));
@@ -47,6 +48,7 @@ public class BukkitViaConfig extends AbstractViaConfig {
         hitboxFix1_9 = getBoolean("change-1_9-hitbox", false);
         hitboxFix1_14 = getBoolean("change-1_14-hitbox", false);
         blockConnectionMethod = getString("blockconnection-method", "packet");
+        armorToggleFix = getBoolean("armor-toggle-fix", true);
     }
 
     @Override
@@ -76,6 +78,11 @@ public class BukkitViaConfig extends AbstractViaConfig {
     @Override
     public String getBlockConnectionMethod() {
         return blockConnectionMethod;
+    }
+
+    @Override
+    public boolean isArmorToggleFix() {
+        return armorToggleFix;
     }
 
     @Override

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
@@ -28,6 +28,7 @@ import com.viaversion.viaversion.bukkit.listeners.JoinListener;
 import com.viaversion.viaversion.bukkit.listeners.UpdateListener;
 import com.viaversion.viaversion.bukkit.listeners.multiversion.PlayerSneakListener;
 import com.viaversion.viaversion.bukkit.listeners.protocol1_15to1_14_4.EntityToggleGlideListener;
+import com.viaversion.viaversion.bukkit.listeners.protocol1_19_4To1_19_3.ArmorToggleListener;
 import com.viaversion.viaversion.bukkit.listeners.protocol1_19to1_18_2.BlockBreakListener;
 import com.viaversion.viaversion.bukkit.listeners.protocol1_9to1_8.ArmorListener;
 import com.viaversion.viaversion.bukkit.listeners.protocol1_9to1_8.BlockListener;
@@ -140,6 +141,10 @@ public class BukkitViaLoader implements ViaPlatformLoader {
             if (paper) {
                 storeListener(new PaperPatch(plugin)).register();
             }
+        }
+
+        if (serverProtocolVersion < ProtocolVersion.v1_19_4.getVersion() && plugin.getConf().isArmorToggleFix()) {
+            storeListener(new ArmorToggleListener(plugin)).register();
         }
 
         /* Providers */

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -533,4 +533,9 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     public @Nullable String chatTypeFormat(final String translationKey) {
         return chatTypeFormats.get(translationKey);
     }
+
+    @Override
+    public boolean isArmorToggleFix() {
+        return false;
+    }
 }

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -172,6 +172,9 @@ chat-types-1_19:
   chat.type.team.text: "%s <%s> %s"
   chat.type.emote: "* %s %s"
 #
+# Force-update 1.19.4+ player's inventory when they try to swap armor in a pre-occupied slot.
+armor-toggle-fix: true
+#
 #----------------------------------------------------------#
 #             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #
 #----------------------------------------------------------#


### PR DESCRIPTION
1.19.4 will allow players to swap armor as long as the armor slot isn't identical to the hand slot. This PR patches that using the Bukkit API.