### PR TITLE
Optimize block connections on neighbour chunk calculation

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/ConnectionData.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/ConnectionData.java
@@ -629,7 +629,7 @@ public final class ConnectionData {
             this.userBlockData = blockConnectionProvider.forUser(user);
         }
 
-        public void updateChunkSectionNeighbours(int chunkX, int chunkZ, int chunkSectionY) {
+        public void updateChunkSectionNeighbours(int chunkX, int chunkZ, int chunkSectionY) throws Exception {
             int chunkMinY = chunkSectionY << 4;
             List<BlockChangeRecord1_8> updates = new ArrayList<>();
             for (int chunkDeltaX = -1; chunkDeltaX <= 1; chunkDeltaX++) {
@@ -683,11 +683,7 @@ public final class ConnectionData {
                         wrapper.write(Type.INT, chunkX + chunkDeltaX);
                         wrapper.write(Type.INT, chunkZ + chunkDeltaZ);
                         wrapper.write(Type.BLOCK_CHANGE_RECORD_ARRAY, updates.toArray(EMPTY_RECORDS));
-                        try {
-                            wrapper.send(Protocol1_13To1_12_2.class);
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
+                        wrapper.send(Protocol1_13To1_12_2.class);
                         updates.clear();
                     }
                 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/providers/BlockConnectionProvider.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/providers/BlockConnectionProvider.java
@@ -55,4 +55,9 @@ public class BlockConnectionProvider implements Provider {
     public boolean storesBlocks() {
         return false;
     }
+
+    public UserBlockData forUser(UserConnection connection) {
+        return (x, y, z) -> getBlockData(connection, x, y, z);
+    }
+
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/providers/PacketBlockConnectionProvider.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/providers/PacketBlockConnectionProvider.java
@@ -56,4 +56,9 @@ public class PacketBlockConnectionProvider extends BlockConnectionProvider {
     public boolean storesBlocks() {
         return true;
     }
+
+    @Override
+    public UserBlockData forUser(UserConnection connection) {
+        return connection.get(BlockConnectionStorage.class)::get;
+    }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/providers/UserBlockData.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/blockconnections/providers/UserBlockData.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2023 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.protocol1_13to1_12_2.blockconnections.providers;
+
+public interface UserBlockData {
+
+    int getBlockData(int x, int y, int z);
+
+}

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -448,10 +448,11 @@ public class WorldPackets {
                 // Workaround for packet order issue
                 wrapper.send(Protocol1_13To1_12_2.class);
                 wrapper.cancel();
+                ConnectionData.NeighbourUpdater updater = new ConnectionData.NeighbourUpdater(wrapper.user());
                 for (int i = 0; i < chunk.getSections().length; i++) {
                     ChunkSection section = chunk.getSections()[i];
                     if (section == null) continue;
-                    ConnectionData.updateChunkSectionNeighbours(wrapper.user(), chunk.getX(), chunk.getZ(), i);
+                    updater.updateChunkSectionNeighbours(chunk.getX(), chunk.getZ(), i);
                 }
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockConnectionStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockConnectionStorage.java
@@ -36,7 +36,7 @@ public class BlockConnectionStorage implements StorableObject {
     private final Map<Long, SectionData> blockStorage = createLongObjectMap();
 
     // Cache to retrieve section quicker
-    private long lastIndex;
+    private Long lastIndex;
     private SectionData lastSection;
 
     static {
@@ -114,6 +114,7 @@ public class BlockConnectionStorage implements StorableObject {
     public void clear() {
         blockStorage.clear();
         lastSection = null;
+        lastIndex = null;
     }
 
     public void unloadChunk(int x, int z) {
@@ -141,7 +142,7 @@ public class BlockConnectionStorage implements StorableObject {
     }
 
     private SectionData getSection(long index) {
-        if (lastSection != null && lastIndex == index) {
+        if (lastIndex != null && lastIndex == index) {
             return lastSection;
         }
         lastIndex = index;
@@ -150,7 +151,8 @@ public class BlockConnectionStorage implements StorableObject {
 
     private void removeSection(long index) {
         blockStorage.remove(index);
-        if (index == lastIndex) {
+        if (lastIndex != null && lastIndex == index) {
+            lastIndex = null;
             lastSection = null;
         }
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockConnectionStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockConnectionStorage.java
@@ -108,7 +108,7 @@ public class BlockConnectionStorage implements StorableObject {
         for (short entry : map.blockIds()) {
             if (entry != 0) return;
         }
-        blockStorage.remove(pair);
+        removeSection(pair);
     }
 
     public void clear() {
@@ -123,11 +123,7 @@ public class BlockConnectionStorage implements StorableObject {
     }
 
     public void unloadSection(int x, int y, int z) {
-        long index = getChunkSectionIndex(x << 4, y << 4, z << 4);
-        blockStorage.remove(index);
-        if (index == lastIndex) {
-            lastSection = null;
-        }
+        removeSection(getChunkSectionIndex(x << 4, y << 4, z << 4));
     }
 
     private SectionData getChunkSection(long index, boolean requireNibbleArray) {
@@ -135,6 +131,8 @@ public class BlockConnectionStorage implements StorableObject {
         if (map == null) {
             map = new SectionData(new byte[4096]);
             blockStorage.put(index, map);
+            lastSection = map;
+            lastIndex = index;
         }
         if (map.nibbleArray() == null && requireNibbleArray) {
             map.setNibbleArray(new NibbleArray(4096));
@@ -148,6 +146,13 @@ public class BlockConnectionStorage implements StorableObject {
         }
         lastIndex = index;
         return lastSection = blockStorage.get(index);
+    }
+
+    private void removeSection(long index) {
+        blockStorage.remove(index);
+        if (index == lastIndex) {
+            lastSection = null;
+        }
     }
 
     private long getChunkSectionIndex(int x, int y, int z) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockConnectionStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockConnectionStorage.java
@@ -35,6 +35,10 @@ public class BlockConnectionStorage implements StorableObject {
 
     private final Map<Long, SectionData> blockStorage = createLongObjectMap();
 
+    // Cache to retrieve section quicker
+    private long lastIndex;
+    private SectionData lastSection;
+
     static {
         try {
             //noinspection StringBufferReplaceableByString - prevent relocation
@@ -73,7 +77,7 @@ public class BlockConnectionStorage implements StorableObject {
 
     public int get(int x, int y, int z) {
         long pair = getChunkSectionIndex(x, y, z);
-        SectionData map = blockStorage.get(pair);
+        SectionData map = getSection(pair);
         if (map == null) return 0;
         short blockPosition = encodeBlockPos(x, y, z);
         NibbleArray nibbleArray = map.nibbleArray();
@@ -85,7 +89,7 @@ public class BlockConnectionStorage implements StorableObject {
 
     public void remove(int x, int y, int z) {
         long pair = getChunkSectionIndex(x, y, z);
-        SectionData map = blockStorage.get(pair);
+        SectionData map = getSection(pair);
         if (map == null) return;
         int blockIndex = encodeBlockPos(x, y, z);
         NibbleArray nibbleArray = map.nibbleArray();
@@ -109,6 +113,7 @@ public class BlockConnectionStorage implements StorableObject {
 
     public void clear() {
         blockStorage.clear();
+        lastSection = null;
     }
 
     public void unloadChunk(int x, int z) {
@@ -118,11 +123,15 @@ public class BlockConnectionStorage implements StorableObject {
     }
 
     public void unloadSection(int x, int y, int z) {
-        blockStorage.remove(getChunkSectionIndex(x << 4, y << 4, z << 4));
+        long index = getChunkSectionIndex(x << 4, y << 4, z << 4);
+        blockStorage.remove(index);
+        if (index == lastIndex) {
+            lastSection = null;
+        }
     }
 
     private SectionData getChunkSection(long index, boolean requireNibbleArray) {
-        SectionData map = blockStorage.get(index);
+        SectionData map = getSection(index);
         if (map == null) {
             map = new SectionData(new byte[4096]);
             blockStorage.put(index, map);
@@ -131,6 +140,14 @@ public class BlockConnectionStorage implements StorableObject {
             map.setNibbleArray(new NibbleArray(4096));
         }
         return map;
+    }
+
+    private SectionData getSection(long index) {
+        if (lastSection != null && lastIndex == index) {
+            return lastSection;
+        }
+        lastIndex = index;
+        return lastSection = blockStorage.get(index);
     }
 
     private long getChunkSectionIndex(int x, int y, int z) {


### PR DESCRIPTION
Optimizes the following bottleneck:
![image](https://user-images.githubusercontent.com/11789291/222933530-fc52db6f-3706-41cd-9910-02d8311c5b3c.png)


This is a profile from the netty event thread, for a few seconds during which a ton of players (about 60) are teleported between worlds. Updating block connections for neighboring chunks was a pretty significant part of the time, causing some lag on the network thread and causing players to run behind the server for a bit.

The PR mainly caches `connection.get(BlockConnectionStorage.class)` and `blockStorage.get(index)`, both of which are taking significantly long and don't need to be ran *for every single block* when the value returned can be cached temporarily.

Note: I have not yet ran/tested these changes, but i'm still opening the PR as a draft to be able to get feedback/reviews. Will update with results once i've tested, deployed, and validated the results.