### PR TITLE
Patch armor swapping on 1.19.3 servers

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19_4To1_19_3/ArmorToggleListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19_4To1_19_3/ArmorToggleListener.java
@@ -40,7 +40,10 @@ public final class ArmorToggleListener extends ViaBukkitListener {
     public void itemUse(final PlayerInteractEvent event) {
         final Player player = event.getPlayer();
         final ItemStack item = event.getItem();
-        if (item == null || event.getHand() == null || event.getAction() != Action.RIGHT_CLICK_AIR || !isOnPipe(player)) {
+        if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        if (item == null || event.getHand() == null || !isOnPipe(player)) {
             return;
         }
 
@@ -50,8 +53,8 @@ public final class ArmorToggleListener extends ViaBukkitListener {
             final ItemStack armor = inventory.getItem(armorItemSlot);
             // If two pieces of armor are equal, the client will do nothing.
             if (armor != null && armor.getType() != Material.AIR && !armor.equals(item)) {
-                inventory.setItem(event.getHand(), armor);
-                inventory.setItem(armorItemSlot, item);
+                inventory.setItem(event.getHand(), item);
+                inventory.setItem(armorItemSlot, armor);
             }
         }
     }

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19_4To1_19_3/ArmorToggleListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19_4To1_19_3/ArmorToggleListener.java
@@ -24,6 +24,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -39,7 +40,7 @@ public final class ArmorToggleListener extends ViaBukkitListener {
     public void itemUse(final PlayerInteractEvent event) {
         final Player player = event.getPlayer();
         final ItemStack item = event.getItem();
-        if (item == null || event.getHand() == null || !isOnPipe(player)) {
+        if (item == null || event.getHand() == null || event.getAction() != Action.RIGHT_CLICK_AIR || !isOnPipe(player)) {
             return;
         }
 
@@ -49,8 +50,8 @@ public final class ArmorToggleListener extends ViaBukkitListener {
             final ItemStack armor = inventory.getItem(armorItemSlot);
             // If two pieces of armor are equal, the client will do nothing.
             if (armor != null && armor.getType() != Material.AIR && !armor.equals(item)) {
-                inventory.setItem(event.getHand(), inventory.getItem(event.getHand()));
-                inventory.setItem(armorItemSlot, armor);
+                inventory.setItem(event.getHand(), armor);
+                inventory.setItem(armorItemSlot, item);
             }
         }
     }


### PR DESCRIPTION
Updates the armor toggle listener to swap armor rather than update to original inventory, but only when action is `RIGHT_CLICK_AIR` to prevent double toggle when `LEFT_CLICK_AIR` event also fires