### PR TITLE
Fix `SpongeViaInjector#getServerProtocolVersion()` for Sponge API-10+

### DIFF
--- a/sponge/src/main/java/com/viaversion/viaversion/sponge/platform/SpongeViaInjector.java
+++ b/sponge/src/main/java/com/viaversion/viaversion/sponge/platform/SpongeViaInjector.java
@@ -32,7 +32,13 @@ public class SpongeViaInjector extends LegacyViaInjector {
     @Override
     public int getServerProtocolVersion() throws ReflectiveOperationException {
         MinecraftVersion version = Sponge.platform().minecraftVersion();
-        return (int) version.getClass().getDeclaredMethod("getProtocol").invoke(version);
+
+        // 'protocolVersion' method was exposed to the API in a 1.19.4 build and 'getProtocol' no longer exists in the impl.
+        try {
+            return (int) version.getClass().getDeclaredMethod("getProtocol").invoke(version);
+        } catch (NoSuchMethodException e) {
+            return (int) version.getClass().getDeclaredMethod("protocolVersion").invoke(version);
+        }
     }
 
     @Override


### PR DESCRIPTION
The [`protocolVersion`](https://jd.spongepowered.org/spongeapi/10.0.0-SNAPSHOT/org/spongepowered/api/MinecraftVersion.html#protocolVersion()) method was exposed to the API in a 1.19.4 build and 'getProtocol' no longer exists in the impl. This PR fixes the issue while maintaining compatibility with API-8.