### PR TITLE
Rotate item displays by 180 degrees around the y-axis

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20to1_19_4/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20to1_19_4/packets/EntityPackets.java
@@ -23,6 +23,7 @@ import com.github.steveice10.opennbt.tag.builtin.IntTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import com.github.steveice10.opennbt.tag.builtin.Tag;
+import com.viaversion.viaversion.api.data.entity.TrackedEntity;
 import com.viaversion.viaversion.api.minecraft.entities.Entity1_19_4Types;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
@@ -41,9 +42,84 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_19_4
 
     @Override
     public void registerPackets() {
-        registerTrackerWithData1_19(ClientboundPackets1_19_4.SPAWN_ENTITY, Entity1_19_4Types.FALLING_BLOCK);
+        registerTrackerWithData1_20(ClientboundPackets1_19_4.SPAWN_ENTITY, Entity1_19_4Types.FALLING_BLOCK, Entity1_19_4Types.ITEM_DISPLAY);
         registerMetadataRewriter(ClientboundPackets1_19_4.ENTITY_METADATA, Types1_19_4.METADATA_LIST, Types1_20.METADATA_LIST);
         registerRemoveEntities(ClientboundPackets1_19_4.REMOVE_ENTITIES);
+
+        protocol.registerClientbound(ClientboundPackets1_19_4.ENTITY_POSITION_AND_ROTATION, new PacketHandlers() {
+            @Override
+            protected void register() {
+                map(Type.VAR_INT); // Entity id
+                map(Type.SHORT);   // Delta X
+                map(Type.SHORT);   // Delta Y
+                map(Type.SHORT);   // Delta Z
+                map(Type.BYTE);    // Yaw
+                map(Type.BYTE);    // Pitch
+                map(Type.BOOLEAN); // On Ground
+
+                handler(wrapper -> {
+                    TrackedEntity trackedEntity = tracker(wrapper.user()).entity(wrapper.get(Type.VAR_INT, 0));
+                    if (trackedEntity == null) return;
+                    if (trackedEntity.entityType() != Entity1_19_4Types.ITEM_DISPLAY) return;
+                    wrapper.set(Type.BYTE, 0, (byte) (wrapper.get(Type.BYTE, 0) - 128));
+                    wrapper.set(Type.BYTE, 1, (byte)-wrapper.get(Type.BYTE, 1));
+                });
+            }
+        });
+
+        protocol.registerClientbound(ClientboundPackets1_19_4.ENTITY_ROTATION, new PacketHandlers() {
+            @Override
+            protected void register() {
+                map(Type.VAR_INT); // Entity id
+                map(Type.BYTE);    // Yaw
+                map(Type.BYTE);    // Pitch
+                map(Type.BOOLEAN); // On Ground
+
+                handler(wrapper -> {
+                    TrackedEntity trackedEntity = tracker(wrapper.user()).entity(wrapper.get(Type.VAR_INT, 0));
+                    if (trackedEntity == null) return;
+                    if (trackedEntity.entityType() != Entity1_19_4Types.ITEM_DISPLAY) return;
+                    wrapper.set(Type.BYTE, 0, (byte) (wrapper.get(Type.BYTE, 0) - 128));
+                    wrapper.set(Type.BYTE, 1, (byte)-wrapper.get(Type.BYTE, 1));
+                });
+            }
+        });
+
+        protocol.registerClientbound(ClientboundPackets1_19_4.ENTITY_HEAD_LOOK, new PacketHandlers() {
+            @Override
+            protected void register() {
+                map(Type.VAR_INT); // Entity id
+                map(Type.BYTE);    // Head Yaw
+
+                handler(wrapper -> {
+                    TrackedEntity trackedEntity = tracker(wrapper.user()).entity(wrapper.get(Type.VAR_INT, 0));
+                    if (trackedEntity == null) return;
+                    if (trackedEntity.entityType() != Entity1_19_4Types.ITEM_DISPLAY) return;
+                    wrapper.set(Type.BYTE, 0, (byte) (wrapper.get(Type.BYTE, 0) - 128));
+                });
+            }
+        });
+
+        protocol.registerClientbound(ClientboundPackets1_19_4.ENTITY_TELEPORT, new PacketHandlers() {
+            @Override
+            protected void register() {
+                map(Type.VAR_INT); // Entity id
+                map(Type.DOUBLE);  // X
+                map(Type.DOUBLE);  // Y
+                map(Type.DOUBLE);  // Z
+                map(Type.BYTE);    // Yaw
+                map(Type.BYTE);    // Pitch
+                map(Type.BOOLEAN); // On Ground
+
+                handler(wrapper -> {
+                    TrackedEntity trackedEntity = tracker(wrapper.user()).entity(wrapper.get(Type.VAR_INT, 0));
+                    if (trackedEntity == null) return;
+                    if (trackedEntity.entityType() != Entity1_19_4Types.ITEM_DISPLAY) return;
+                    wrapper.set(Type.BYTE, 0, (byte) (wrapper.get(Type.BYTE, 0) - 128));
+                    wrapper.set(Type.BYTE, 1, (byte)-wrapper.get(Type.BYTE, 1));
+                });
+            }
+        });
 
         protocol.registerClientbound(ClientboundPackets1_19_4.JOIN_GAME, new PacketHandlers() {
             @Override

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -321,6 +321,40 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
         });
     }
 
+    public void registerTrackerWithData1_20(C packetType, EntityType fallingBlockType, EntityType itemDisplayType) {
+        protocol.registerClientbound(packetType, new PacketHandlers() {
+            @Override
+            public void register() {
+                map(Type.VAR_INT); // Entity id
+                map(Type.UUID); // Entity UUID
+                map(Type.VAR_INT); // Entity type
+                map(Type.DOUBLE); // X
+                map(Type.DOUBLE); // Y
+                map(Type.DOUBLE); // Z
+                map(Type.BYTE); // Pitch
+                map(Type.BYTE); // Yaw
+                map(Type.BYTE); // Head yaw
+                map(Type.VAR_INT); // Data
+                handler(trackerHandler());
+                handler(wrapper -> {
+                    int entityId = wrapper.get(Type.VAR_INT, 0);
+                    EntityType entityType = tracker(wrapper.user()).entityType(entityId);
+                    if (entityType == fallingBlockType) {
+                        wrapper.set(Type.VAR_INT, 2, protocol.getMappingData().getNewBlockStateId(wrapper.get(Type.VAR_INT, 2)));
+                    }
+                });
+                handler(wrapper -> {
+                    int entityId = wrapper.get(Type.VAR_INT, 0);
+                    EntityType entityType = tracker(wrapper.user()).entityType(entityId);
+                    if (entityType == itemDisplayType) {
+                        wrapper.set(Type.BYTE, 0, (byte)-wrapper.get(Type.BYTE, 0));
+                        wrapper.set(Type.BYTE, 1, (byte) (wrapper.get(Type.BYTE, 1) - 128));
+                    }
+                });
+            }
+        });
+    }
+
     /**
      * Registers an entity tracker for the extra spawn packets like player, painting, or xp orb spawns.
      *


### PR DESCRIPTION
Items in item display entities got rotated in 1.20. This PR reverses this behaviour for 1.20 players to keep the rotation consistent for all players.

> `item_display` items have been rotated 180 degrees around the Y axis to better match the transformation that is applied when rendering items on an Armor Stand head and in Item Frames

Not sure if I added the handlers correctly, because I needed to re-map all packets containing the entity rotation to add the handlers manipulating the yaw and pitch of the entities, maybe there is another way to do so without re-mapping them.