### PR TITLE
Added VersionInfo#getVersion to bypass Java inlining

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/util/VersionInfo.java
+++ b/api/src/main/java/com/viaversion/viaversion/util/VersionInfo.java
@@ -32,4 +32,8 @@ public final class VersionInfo {
      * @see ViaPlatform#getPluginVersion()
      */
     public static final String VERSION = "$VERSION";
+
+    public static String getVersion() {
+        return VERSION;
+    }
 }


### PR DESCRIPTION
ViaLoader needs this getter, because otherwise when compiling ViaLoader the plugin version string is inlined, and when someone then creates a ViaProxy / ViaFabricPlus dump, the plugin version is displayed, with which ViaLoader was compiled, and not the one that is currently loaded.