### PR TITLE
Use friendly names in CI tasks, Update shadow and blossom.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,3 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
 name: Java CI with Gradle
 
 on: [push, pull_request]
@@ -13,8 +10,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: gradle/wrapper-validation-action@v1
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+    - name: Validate Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
@@ -22,7 +21,8 @@ jobs:
         java-version: 11
     - name: Build with Gradle
       run: ./gradlew build
-    - uses: actions/upload-artifact@v3
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
       with:
         name: artifact
         path: build/libs

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,8 +17,8 @@ dependencyResolutionManagement {
 pluginManagement {
     // default plugin versions
     plugins {
-        id("net.kyori.blossom") version "1.2.0"
-        id("com.github.johnrengelman.shadow") version "8.1.0"
+        id("net.kyori.blossom") version "1.3.0"
+        id("com.github.johnrengelman.shadow") version "8.1.1"
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ dependencyResolutionManagement {
 pluginManagement {
     // default plugin versions
     plugins {
-        id("net.kyori.blossom") version "1.3.0"
+        id("net.kyori.blossom") version "1.3.1"
         id("com.github.johnrengelman.shadow") version "8.1.1"
     }
 }


### PR DESCRIPTION
Makes the GitHub CI script morely complete by introducing rest of friendly names into the jobs as current one only has two friendly name strings included which is the setup JDK and build contexts,

For dependencies, The following is updated:

Kyori's blossom: 1.2.0 -> 1.3.1,
johnrengelman's shadow: 8.1.0 -> 8.1.1.

*(Syncable to viabackwards' repository if this PR works out properly)*