### PR TITLE
Fix late registration of join listener

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/ViaVersionPlugin.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/ViaVersionPlugin.java
@@ -103,6 +103,12 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaPlatform<Player> 
             manager.init();
         }
 
+        if (Via.getConfig().shouldRegisterUserConnectionOnJoin()) {
+            // When event priority ties, registration order is used.
+            // Must register without delay to ensure other plugins on lowest get the fix applied.
+            getServer().getPluginManager().registerEvents(new JoinListener(), this);
+        }
+
         if (FOLIA) {
             // Use Folia's RegionizedServerInitEvent to run code after the server has loaded
             final Class<? extends Event> serverInitEventClass;

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
@@ -79,10 +79,6 @@ public class BukkitViaLoader implements ViaPlatformLoader {
     public void load() {
         registerListener(new UpdateListener());
 
-        if (Via.getConfig().shouldRegisterUserConnectionOnJoin()) {
-            registerListener(new JoinListener());
-        }
-
         /* Base Protocol */
         final ViaVersionPlugin plugin = (ViaVersionPlugin) Bukkit.getPluginManager().getPlugin("ViaVersion");
 


### PR DESCRIPTION
Related to the original issue fixed in #2849. The original fix helped any plugin which tries to use a low-or-later priority on the event, but will, on current code, not work if registered as LOWEST.

The reason for this is that viaversion can delay the registration of the events to the next tick, causing it to be (consistently) the last registered listener. There is no need for this listener in particular to be registered later, it can be done earlier to ensure anything with a depend or soft-depend on viaversion will work correctly, as bukkit will load viaversion prior to the others.

A real-world implication is [adventure for bukkit](https://github.com/KyoriPowered/adventure-platform/blob/master/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiencesImpl.java#L105) which registers in priority LOWEST, *will* use the protocol to determine how to address players, leading to bossbars on 1.9+ clients using withers (as if they were in 1.8) due to the race condition originally explained in #2835 .

With the fix, viaversion loads its listener first, so when adventure gets to ask the version the player is in, it will get the correct one regardless of the race-condition.