### PR TITLE
Handle more null TextComponent for 1.19 to 1.18.2

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -138,7 +138,6 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
             if (action == 0 || action == 2) {
                 wrapper.write(Type.COMPONENT, mapTextComponentIfNull(wrapper.read(Type.COMPONENT))); // Display Name
             }
-            wrapper.passthroughAll();
         });
         registerClientbound(ClientboundPackets1_18.TEAMS, wrapper -> {
             wrapper.passthrough(Type.STRING); // Team Name
@@ -152,7 +151,6 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
                 wrapper.write(Type.COMPONENT, mapTextComponentIfNull(wrapper.read(Type.COMPONENT))); // Prefix
                 wrapper.write(Type.COMPONENT, mapTextComponentIfNull(wrapper.read(Type.COMPONENT))); // Suffix
             }
-            wrapper.passthroughAll();
         });
 
         final CommandRewriter<ClientboundPackets1_18> commandRewriter = new CommandRewriter<>(this);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -131,6 +131,14 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
         };
         registerClientbound(ClientboundPackets1_18.TITLE_TEXT, titleHandler);
         registerClientbound(ClientboundPackets1_18.TITLE_SUBTITLE, titleHandler);
+        registerClientbound(ClientboundPackets1_18.SCOREBOARD_OBJECTIVE, wrapper -> {
+            wrapper.passthrough(Type.STRING); // Objective Name
+            byte action = wrapper.passthrough(Type.BYTE); // Mode
+            if (action == 0 || action == 2) {
+                wrapper.write(Type.COMPONENT, mapTextComponentIfNull(wrapper.read(Type.COMPONENT))); // Display Name
+            }
+            wrapper.passthroughAll();
+        });
         registerClientbound(ClientboundPackets1_18.TEAMS, wrapper -> {
             wrapper.passthrough(Type.STRING); // Team Name
             byte action = wrapper.passthrough(Type.BYTE); // Mode

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -64,7 +64,7 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
         return element == null || element.isJsonNull() || (element.isJsonArray() && element.getAsJsonArray().size() == 0);
     }
 
-    public JsonElement void mapTextComponentIfNull(JsonElement component) {
+    public static JsonElement mapTextComponentIfNull(JsonElement component) {
         if (!isTextComponentNull(component)) {
             return component;
         } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -63,12 +63,13 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
     public static boolean isTextComponentNull(final JsonElement element) {
         return element == null || element.isJsonNull() || (element.isJsonArray() && element.getAsJsonArray().size() == 0);
     }
+
     public static void mapTextComponentIfNull(JsonElement component) {
-            if (!isTextComponentNull(component)) {
-                return component;
-            } else {
-                return ChatRewriter.emptyComponent();
-            }
+        if (!isTextComponentNull(component)) {
+            return component;
+        } else {
+            return ChatRewriter.emptyComponent();
+        }
     }
 
     @Override
@@ -134,7 +135,7 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
             wrapper.passthrough(Type.STRING); // Team Name
             byte action = wrapper.passthrough(Type.BYTE); // Mode
             if (action == 0 || action == 2) {
-                wrapper.write(Type.COMPONENT, mapTextComponentIfNull(wrapper.read(Type.COMPONENT)));; // Display Name
+                wrapper.write(Type.COMPONENT, mapTextComponentIfNull(wrapper.read(Type.COMPONENT))); // Display Name
                 wrapper.passthrough(Type.BYTE); // Flags
                 wrapper.passthrough(Type.STRING); // Name Tag Visibility
                 wrapper.passthrough(Type.STRING); // Collision rule

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -64,7 +64,7 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
         return element == null || element.isJsonNull() || (element.isJsonArray() && element.getAsJsonArray().size() == 0);
     }
 
-    public static void mapTextComponentIfNull(JsonElement component) {
+    public JsonElement void mapTextComponentIfNull(JsonElement component) {
         if (!isTextComponentNull(component)) {
             return component;
         } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -126,11 +126,12 @@ public final class Protocol1_19To1_18_2 extends AbstractProtocol<ClientboundPack
 
         new StatisticsRewriter<>(this).register(ClientboundPackets1_18.STATISTICS);
 
-        final PacketHandler titleHandler = wrapper -> {
+        final PacketHandler singleNullTextComponentMapper = wrapper -> {
             wrapper.write(Type.COMPONENT, mapTextComponentIfNull(wrapper.read(Type.COMPONENT)));
         };
-        registerClientbound(ClientboundPackets1_18.TITLE_TEXT, titleHandler);
-        registerClientbound(ClientboundPackets1_18.TITLE_SUBTITLE, titleHandler);
+        registerClientbound(ClientboundPackets1_18.TITLE_TEXT, singleNullTextComponentMapper);
+        registerClientbound(ClientboundPackets1_18.TITLE_SUBTITLE, singleNullTextComponentMapper);
+        registerClientbound(ClientboundPackets1_18.ACTIONBAR, singleNullTextComponentMapper);
         registerClientbound(ClientboundPackets1_18.SCOREBOARD_OBJECTIVE, wrapper -> {
             wrapper.passthrough(Type.STRING); // Objective Name
             byte action = wrapper.passthrough(Type.BYTE); // Mode


### PR DESCRIPTION
Through in the previous issue (#2923), the fix handle the component on title packet, but null component could also appear on action bar, teams and scoreboard objective packet and result in the same "Received unexpected null component" error, this PR handle those packets above and map it into empty component like the fix commit (https://github.com/ViaVersion/ViaVersion/commit/66b21431f22a62cc1f3d0a5cdd28bd9ea1e36944).