### PR TITLE
Allow skylight to be set to null

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/ChunkSectionLightImpl.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/ChunkSectionLightImpl.java
@@ -47,6 +47,11 @@ public class ChunkSectionLightImpl implements ChunkSectionLight {
 
     @Override
     public void setSkyLight(byte[] data) {
+        if (data == null) {
+            this.skyLight = null;
+            return;
+        }
+
         if (data.length != LIGHT_LENGTH) throw new IllegalArgumentException("Data length != " + LIGHT_LENGTH);
         if (this.skyLight == null) {
             this.skyLight = new NibbleArray(data);


### PR DESCRIPTION
Allows rewriters/packet handlers to remove skylight from an already read chunk