### PR TITLE
Fix itemArrayType of ItemRewriter on dev branch

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
@@ -35,7 +35,7 @@ public abstract class ItemRewriter<C extends ClientboundPacketType, S extends Se
     private final Type<Item[]> itemArrayType;
 
     protected ItemRewriter(T protocol) {
-        this(protocol, Type.FLAT_VAR_INT_ITEM, Type.FLAT_VAR_INT_ITEM_ARRAY);
+        this(protocol, Type.FLAT_VAR_INT_ITEM, Type.FLAT_VAR_INT_ITEM_ARRAY_VAR_INT);
     }
 
     public ItemRewriter(T protocol, Type<Item> itemType, Type<Item[]> itemArrayType) {


### PR DESCRIPTION
This fixes IndexOutOfBoundsException with 23w31a client on 1.19.4 (and older?) server

<details>
  <summary>Stacktrace</summary>

```
[01:42:02 WARN]: [ViaVersion] ERROR IN Protocol1_20To1_19_4 IN REMAP OF WINDOW_ITEMS (0x12)
[01:42:02 WARN]: io.netty.handler.codec.EncoderException: com.viaversion.viaversion.exception.InformativeException: Please report this on the Via support Discord or open an issue on the relevant GitHub repository
[01:42:02 WARN]: Packet Type: WINDOW_ITEMS, Type: Flat Item Array, Index: 3, Data: [{Unsigned Byte: 0}, {VarInt: 1}], Source 0: com.viaversion.viaversion.rewriter.ItemRewriter$2 (Anonymous), Packet ID: 18
[01:42:02 WARN]:        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:107)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[01:42:02 WARN]:        at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:113)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[01:42:02 WARN]:        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:984)
[01:42:02 WARN]:        at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1025)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:306)
[01:42:02 WARN]:        at net.minecraft.network.NetworkManager.doSendPacket(NetworkManager.java:469)
[01:42:02 WARN]:        at net.minecraft.network.NetworkManager.lambda$sendPacket$11(NetworkManager.java:443)
[01:42:02 WARN]:        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
[01:42:02 WARN]:        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
[01:42:02 WARN]:        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
[01:42:02 WARN]:        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
[01:42:02 WARN]:        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
[01:42:02 WARN]:        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
[01:42:02 WARN]:        at java.base/java.lang.Thread.run(Thread.java:833)
[01:42:02 WARN]: Caused by: com.viaversion.viaversion.exception.InformativeException: Please report this on the Via support Discord or open an issue on the relevant GitHub repository
[01:42:02 WARN]: Packet Type: WINDOW_ITEMS, Type: Flat Item Array, Index: 3, Data: [{Unsigned Byte: 0}, {VarInt: 1}], Source 0: com.viaversion.viaversion.rewriter.ItemRewriter$2 (Anonymous), Packet ID: 18
[01:42:02 WARN]: Caused by: java.lang.IndexOutOfBoundsException: readerIndex(51) + length(1) exceeds writerIndex(51): PooledUnsafeDirectByteBuf(ridx: 51, widx: 51, cap: 256)
[01:42:02 WARN]:        at io.netty.buffer.AbstractByteBuf.checkReadableBytes0(AbstractByteBuf.java:1442)
[01:42:02 WARN]:        at io.netty.buffer.AbstractByteBuf.readByte(AbstractByteBuf.java:730)
[01:42:02 WARN]:        at io.netty.buffer.AbstractByteBuf.readBoolean(AbstractByteBuf.java:739)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.api.type.types.minecraft.FlatVarIntItemType.read(FlatVarIntItemType.java:37)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.api.type.types.minecraft.FlatVarIntItemType.read(FlatVarIntItemType.java:30)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.api.type.types.minecraft.FlatVarIntItemArrayType.read(FlatVarIntItemArrayType.java:39)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.api.type.types.minecraft.FlatVarIntItemArrayType.read(FlatVarIntItemArrayType.java:28)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.read(PacketWrapperImpl.java:145)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.passthrough(PacketWrapperImpl.java:191)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.rewriter.ItemRewriter$2.lambda$register$0(ItemRewriter.java:85)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.api.protocol.remapper.PacketHandlers.handle(PacketHandlers.java:158)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.api.protocol.AbstractProtocol.transform(AbstractProtocol.java:366)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.apply(PacketWrapperImpl.java:407)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.apply(PacketWrapperImpl.java:395)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.apply(PacketWrapperImpl.java:45)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.protocol.ProtocolPipelineImpl.transform(ProtocolPipelineImpl.java:122)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.connection.UserConnectionImpl.transform(UserConnectionImpl.java:312)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.connection.UserConnectionImpl.transformClientbound(UserConnectionImpl.java:291)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.bukkit.handlers.BukkitEncodeHandler.encode(BukkitEncodeHandler.java:57)
[01:42:02 WARN]:        at ViaVersion-4.8.0-23w31a-SNAPSHOT.jar//com.viaversion.viaversion.bukkit.handlers.BukkitEncodeHandler.encode(BukkitEncodeHandler.java:35)
[01:42:02 WARN]:        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:90)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[01:42:02 WARN]:        at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:113)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[01:42:02 WARN]:        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:984)
[01:42:02 WARN]:        at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1025)
[01:42:02 WARN]:        at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:306)
[01:42:02 WARN]:        at net.minecraft.network.NetworkManager.doSendPacket(NetworkManager.java:469)
[01:42:02 WARN]:        at net.minecraft.network.NetworkManager.lambda$sendPacket$11(NetworkManager.java:443)
[01:42:02 WARN]:        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
[01:42:02 WARN]:        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
[01:42:02 WARN]:        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
[01:42:02 WARN]:        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
[01:42:02 WARN]:        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
[01:42:02 WARN]:        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
[01:42:02 WARN]:        at java.base/java.lang.Thread.run(Thread.java:833)
```
</details>

See https://github.com/ViaVersion/ViaVersion/commit/62c0ef360fc9240aca7ce9854a0fbbfa9f230309#diff-bd72a58719d5c4d8bfebbfa756254904e91f06ee2fadfe290215e50ed75e00af