### PR TITLE
Optimize memory allocation for data palette

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/DataPaletteImpl.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/DataPaletteImpl.java
@@ -41,7 +41,7 @@ public final class DataPaletteImpl implements DataPalette {
     }
 
     public DataPaletteImpl(final int valuesLength, final int initialSize) {
-        values = new ByteChunkData(valuesLength);
+        values = new EmptyChunkData(valuesLength);
         sizeBits = Integer.numberOfTrailingZeros(valuesLength) / 3;
         // Pre-size the palette array/map
         palette = new IntArrayList(initialSize);
@@ -138,6 +138,28 @@ public final class DataPaletteImpl implements DataPalette {
     interface ChunkData {
         int get(int idx);
         void set(int idx, int val);
+    }
+
+    private class EmptyChunkData implements ChunkData {
+
+        private final int size;
+
+        public EmptyChunkData(int size) {
+            this.size = size;
+        }
+
+        @Override
+        public int get(int idx) {
+            return 0;
+        }
+
+        @Override
+        public void set(int idx, int val) {
+            if (val != 0) {
+                values = new ByteChunkData(size);
+                values.set(idx, val);
+            }
+        }
     }
 
     private class ByteChunkData implements ChunkData {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/DataPaletteImpl.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/DataPaletteImpl.java
@@ -29,21 +29,24 @@ import it.unimi.dsi.fastutil.ints.IntList;
 
 public final class DataPaletteImpl implements DataPalette {
 
+    private static final int DEFAULT_INITIAL_SIZE = 16;
+
     private final IntList palette;
     private final Int2IntMap inversePalette;
-    private final int[] values;
     private final int sizeBits;
+    private ChunkData values;
 
     public DataPaletteImpl(final int valuesLength) {
-        this(valuesLength, 8);
+        this(valuesLength, DEFAULT_INITIAL_SIZE);
     }
 
-    public DataPaletteImpl(final int valuesLength, final int expectedPaletteLength) {
-        this.values = new int[valuesLength];
+    public DataPaletteImpl(final int valuesLength, final int initialSize) {
+        values = new ByteChunkData(valuesLength);
         sizeBits = Integer.numberOfTrailingZeros(valuesLength) / 3;
         // Pre-size the palette array/map
-        palette = new IntArrayList(expectedPaletteLength);
-        inversePalette = new Int2IntOpenHashMap(expectedPaletteLength);
+        palette = new IntArrayList(initialSize);
+        // To get an initial table size of initialSize, need to scale it down by load factor.
+        inversePalette = new Int2IntOpenHashMap((int) (initialSize * Int2IntOpenHashMap.DEFAULT_LOAD_FACTOR));
         inversePalette.defaultReturnValue(-1);
     }
 
@@ -54,7 +57,7 @@ public final class DataPaletteImpl implements DataPalette {
 
     @Override
     public int idAt(final int sectionCoordinate) {
-        final int index = values[sectionCoordinate];
+        final int index = values.get(sectionCoordinate);
         return palette.getInt(index);
     }
 
@@ -67,17 +70,17 @@ public final class DataPaletteImpl implements DataPalette {
             inversePalette.put(id, index);
         }
 
-        values[sectionCoordinate] = index;
+        values.set(sectionCoordinate, index);
     }
 
     @Override
     public int paletteIndexAt(final int packedCoordinate) {
-        return values[packedCoordinate];
+        return values.get(packedCoordinate);
     }
 
     @Override
     public void setPaletteIndexAt(final int sectionCoordinate, final int index) {
-        values[sectionCoordinate] = index;
+        values.set(sectionCoordinate, index);
     }
 
     @Override
@@ -131,4 +134,55 @@ public final class DataPaletteImpl implements DataPalette {
         palette.clear();
         inversePalette.clear();
     }
+
+    interface ChunkData {
+        int get(int idx);
+        void set(int idx, int val);
+    }
+
+    private class ByteChunkData implements ChunkData {
+        private final byte[] data;
+
+        public ByteChunkData(int size) {
+            this.data = new byte[size];
+        }
+
+        @Override
+        public int get(int idx) {
+            return data[idx] & 0xFF;
+        }
+
+        @Override
+        public void set(int idx, int val) {
+            // Overflowed size of byte (over 256 different materials), go up to short
+            if (val > 0xFF) {
+                values = new ShortChunkData(data);
+                values.set(idx, val);
+                return;
+            }
+            data[idx] = (byte) val;
+        }
+    }
+
+    private static class ShortChunkData implements ChunkData {
+        private final short[] data;
+
+        public ShortChunkData(byte[] data) {
+            this.data = new short[data.length];
+            for (int i = 0; i < data.length; i++) {
+                this.data[i] = (short) (data[i] & 0xFF);
+            }
+        }
+
+        @Override
+        public int get(int idx) {
+            return data[idx];
+        }
+
+        @Override
+        public void set(int idx, int val) {
+            data[idx] = (short) val;
+        }
+    }
+
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockConnectionStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/storage/BlockConnectionStorage.java
@@ -38,7 +38,7 @@ public class BlockConnectionStorage implements StorableObject {
     private final Queue<Position> modified = EvictingQueue.create(5);
 
     // Cache to retrieve section quicker
-    private Long lastIndex;
+    private long lastIndex = -1;
     private SectionData lastSection;
 
     static {
@@ -114,7 +114,7 @@ public class BlockConnectionStorage implements StorableObject {
     public void clear() {
         blockStorage.clear();
         lastSection = null;
-        lastIndex = null;
+        lastIndex = -1;
         modified.clear();
     }
 
@@ -129,7 +129,7 @@ public class BlockConnectionStorage implements StorableObject {
     }
 
     private @Nullable SectionData getSection(long index) {
-        if (lastIndex != null && lastIndex == index) {
+        if (lastIndex == index) {
             return lastSection;
         }
         lastIndex = index;
@@ -138,8 +138,8 @@ public class BlockConnectionStorage implements StorableObject {
 
     private void removeSection(long index) {
         blockStorage.remove(index);
-        if (lastIndex != null && lastIndex == index) {
-            lastIndex = null;
+        if (lastIndex == index) {
+            lastIndex = -1;
             lastSection = null;
         }
     }


### PR DESCRIPTION
Improves memory allocation time when lots of players are being moved between worlds. The test setup is 80 players in 1.20, connected to a 1.8 server, being teleported at once from a world to another.

Current viaversion is using upwards of 20GB worth of memory allocations solely on DataPaletteImpl, with the applied optimizations it lowers to ~6GB~ 2.1GB (world with some empty regions) or even 800MB (world with mostly void).

Before: 
![image](https://github.com/ViaVersion/ViaVersion/assets/11789291/8fd4f408-b496-4824-a373-95dd03592d66)
![image](https://github.com/ViaVersion/ViaVersion/assets/11789291/e7b2b9a0-29ac-4f8b-9e57-9cf9b31502b5)

After:
![image](https://github.com/ViaVersion/ViaVersion/assets/11789291/f6ac12d0-385a-4b7a-8f50-ef13cff0c044)
![image](https://github.com/ViaVersion/ViaVersion/assets/11789291/2f4ac143-b6d3-42ad-9805-194a11cf0bc9)


The main  gains are:
 - byte[] instead of int[] for the chunk data, and nothing at all for empty chunks
   - Works as long as there's up to 256 different types of blocks
   - If there's over 256 block types, it'll migrate over to a short[] instead
   - Turns ~9.31GB of allocations into ~2.92GB, with some empty chunks 1.35GB, with mostly void 5MB
 - Initializing the palette to 16 instead of 8.
   - very few chunks use less than 8, so they almost always had to resize
   - Turns ~7.34GB of allocations into 1.58GB
   - Tried alternative parameters (32, 64, 128) but they didn't improve. Allocating more is a trade-off, some will enjoy it being available, but the baseline increases. 

initial | resizes (MB) | init (MB) | total (MB)
-- | -- | -- | --
8 | 7280 | 62 | 7342
16 | 1970 | 94 | 2064
32 | 1850 | 199 | 2049
64 | 1770 | 402 | 2172
128 | 2070 | 624 | 2694

- The inverse palette had behavior where bumping up the size caused an increase of initial (as expected) but the resizes were barely accounting for anything.

initial | resizes (MB) | init (MB) | total (MB)
-- | -- | -- | --
8 | 54 | 244 | 298
16 | 78 | 392 | 470
32 | 56 | 838 | 894

I'm unsure as to what causes this behavior, but i've left it in a way that the initial size is kept as it was (table size of 16, which is the same as it was with expected size of 8). The theory may be that most chunks have enough with 12 blocks.
