### PR TITLE
Update checkout to v4, Check for latest JDK 11 build.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
     - name: Set up JDK 11
@@ -19,5 +19,6 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 11
+        check-latest: true
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
@@ -19,6 +19,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
+          check-latest: true
       - name: Publish
         env:
           HANGAR_TOKEN: ${{ secrets.HANGAR_TOKEN }}


### PR DESCRIPTION
1. Updates the checkout step to version 4, *(Changelogs can be [found here](https://github.com/actions/checkout/releases/tag/v4.0.0))*
2. GitHub Actions will now automatically check for any new builds of the JDK 11 distribution instead of having to relay on the provided Ubuntu image itself.

This PR has been tested and can be safely included into dev branch.