### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Resources
 --------
 
 - **[Via Mappings Generator](https://github.com/ViaVersion/Mappings)**
-- **[Mojang mappings](https://minecraft.fandom.com/wiki/Obfuscation_map)** (Thank you, Mojang, very cool)
+- **[Mojang mappings](https://minecraft.wiki/w/Obfuscation_map)** (Thank you, Mojang, very cool)
 - **[wiki.vg](https://wiki.vg)** (Used for historic information regarding packet structure, we also contribute back)
 - **[Burger](https://github.com/Pokechu22/Burger)** (See [PAaaS](https://github.com/Matsv/Paaas))
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: <https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom>.