### PR TITLE
Clear input buffer instead of reading remaining bytes

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/Protocol1_20_2To1_20.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/Protocol1_20_2To1_20.java
@@ -49,8 +49,9 @@ import com.viaversion.viaversion.protocols.protocol1_20_2to1_20.storage.Configur
 import com.viaversion.viaversion.protocols.protocol1_20_2to1_20.storage.ConfigurationState.BridgePhase;
 import com.viaversion.viaversion.protocols.protocol1_20_2to1_20.storage.LastResourcePack;
 import com.viaversion.viaversion.rewriter.SoundRewriter;
-import java.util.UUID;
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.UUID;
 
 public final class Protocol1_20_2To1_20 extends AbstractProtocol<ClientboundPackets1_19_4, ClientboundPackets1_20_2, ServerboundPackets1_19_4, ServerboundPackets1_20_2> {
 
@@ -75,14 +76,14 @@ public final class Protocol1_20_2To1_20 extends AbstractProtocol<ClientboundPack
             final String channel = wrapper.passthrough(Type.STRING);
             if (channel.equals("minecraft:brand")) {
                 wrapper.passthrough(Type.STRING);
-                wrapper.read(Type.REMAINING_BYTES);
+                wrapper.clearInputBuffer();
             }
         });
         registerServerbound(ServerboundPackets1_20_2.PLUGIN_MESSAGE, wrapper -> {
             final String channel = wrapper.passthrough(Type.STRING);
             if (channel.equals("minecraft:brand")) {
                 wrapper.passthrough(Type.STRING);
-                wrapper.read(Type.REMAINING_BYTES);
+                wrapper.clearInputBuffer();
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
@@ -268,10 +268,9 @@ public class PlayerPackets {
                 handler(wrapper -> {
                     String name = wrapper.get(Type.STRING, 0);
                     if (name.equalsIgnoreCase("MC|BOpen")) {
-                        wrapper.read(Type.REMAINING_BYTES); // Not used anymore
+                        wrapper.clearInputBuffer();
                         wrapper.write(Type.VAR_INT, 0);
-                    }
-                    if (name.equalsIgnoreCase("MC|TrList")) {
+                    } else if (name.equalsIgnoreCase("MC|TrList")) {
                         wrapper.passthrough(Type.INT); // ID
 
                         Short size = wrapper.passthrough(Type.UNSIGNED_BYTE);


### PR DESCRIPTION
Clears the packet properly instead of reading remaining bytes. Fixes issues where the code throws an exception if the packet is not originating from a ByteBuf, but was constructed via PacketWrapper.create