### PR TITLE
Depend on newer fabric loader, Recommend newer ViaFabric

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -20,10 +20,10 @@
     "Matsv"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0"
+    "fabricloader": ">=0.14.0"
   },
   "recommends": {
-    "viafabric": ">=0.3.99"
+    "viafabric": ">=0.4.10"
   },
   "custom": {
     "modmenu:api": true,


### PR DESCRIPTION
The reason why this is done is because fabric loader 0.4.0 is very ancient and very likely will no longer work properly with the current viafabric builds, The viafabric recommendation is also bumped to a much newer version for a better experience.

*(Should this be merged; Please sync this to ViaBackwards and ViaRewind)*