### PR TITLE
Match current command input for sub argument tab completions

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/commands/ViaCommandHandler.java
+++ b/common/src/main/java/com/viaversion/viaversion/commands/ViaCommandHandler.java
@@ -125,7 +125,15 @@ public abstract class ViaCommandHandler implements ViaVersionCommand {
 
                 List<String> tab = sub.onTabComplete(sender, subArgs);
                 Collections.sort(tab);
-                return tab;
+                if (!tab.isEmpty()) {
+                    final String currArg = subArgs[subArgs.length - 1];
+                    for (String s : tab) {
+                        if (s.toLowerCase(Locale.ROOT).startsWith(currArg.toLowerCase(Locale.ROOT))) {
+                            output.add(s);
+                        }
+                    }
+                }
+                return output;
             }
         }
         return output;

--- a/common/src/main/java/com/viaversion/viaversion/commands/defaultsubs/DebugSubCmd.java
+++ b/common/src/main/java/com/viaversion/viaversion/commands/defaultsubs/DebugSubCmd.java
@@ -71,7 +71,6 @@ public class DebugSubCmd extends ViaSubCommand {
     @Override
     public List<String> onTabComplete(final ViaCommandSender sender, final String[] args) {
         if (args.length == 1) {
-            //TODO match current input
             return Arrays.asList("clear", "logposttransform", "add", "remove");
         }
         return Collections.emptyList();


### PR DESCRIPTION
Fixed for example the bug that when you type **/viaversion debug a** it suggests all debug modes when it should only suggest **add**.