### PR TITLE
Fix reflection field search on 1.20.2

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/JoinListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/JoinListener.java
@@ -63,8 +63,8 @@ public class JoinListener implements Listener {
     }
 
     // Loosely search a field with any name, as long as it matches a type name.
-    private static Field findField(boolean all, Class<?> clazz, String... types) throws NoSuchFieldException {
-        for (Field field : all ? clazz.getFields() : clazz.getDeclaredFields()) {
+    private static Field findField(boolean checkSuperClass, Class<?> clazz, String... types) throws NoSuchFieldException {
+        for (Field field : clazz.getDeclaredFields()) {
             String fieldTypeName = field.getType().getSimpleName();
             for (String type : types) {
                 if (!fieldTypeName.equals(type)) {
@@ -77,6 +77,11 @@ public class JoinListener implements Listener {
                 return field;
             }
         }
+
+        if (checkSuperClass && clazz != Object.class && clazz.getSuperclass() != null) {
+            return findField(true, clazz.getSuperclass(), types);
+        }
+
         throw new NoSuchFieldException(types[0]);
     }
 


### PR DESCRIPTION
On 1.20.2 the `NetworkManager` field is located in the super class of `PlayerConnection`.

<details><summary>Error before this patch</summary>

```text
[ViaVersion] Couldn't find reflection methods/fields to access Channel from player.
Login race condition fixer will be disabled.
 Some plugins that use ViaAPI on join event may work incorrectly.
java.lang.NoSuchFieldException: NetworkManager
	at com.viaversion.viaversion.bukkit.listeners.JoinListener.findField(JoinListener.java:80) ~[?:?]
	at com.viaversion.viaversion.bukkit.listeners.JoinListener.<clinit>(JoinListener.java:50) ~[?:?]
	at com.viaversion.viaversion.ViaVersionPlugin.onEnable(ViaVersionPlugin.java:109) ~[?:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:266) ~[spigot-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:342) ~[spigot-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:480) ~[spigot-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_20_R2.CraftServer.enablePlugin(CraftServer.java:548) ~[spigot-1.20.2-R0.1-SNAPSHOT.jar:3922-Spigot-dba3cdc-75502b6]
	at org.bukkit.craftbukkit.v1_20_R2.CraftServer.enablePlugins(CraftServer.java:462) ~[spigot-1.20.2-R0.1-SNAPSHOT.jar:3922-Spigot-dba3cdc-75502b6]
	at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:577) ~[spigot-1.20.2-R0.1-SNAPSHOT.jar:3922-Spigot-dba3cdc-75502b6]
	at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:400) ~[spigot-1.20.2-R0.1-SNAPSHOT.jar:3922-Spigot-dba3cdc-75502b6]
	at net.minecraft.server.dedicated.DedicatedServer.e(DedicatedServer.java:250) ~[spigot-1.20.2-R0.1-SNAPSHOT.jar:3922-Spigot-dba3cdc-75502b6]
	at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:954) ~[spigot-1.20.2-R0.1-SNAPSHOT.jar:3922-Spigot-dba3cdc-75502b6]
	at net.minecraft.server.MinecraftServer.lambda$0(MinecraftServer.java:298) ~[spigot-1.20.2-R0.1-SNAPSHOT.jar:3922-Spigot-dba3cdc-75502b6]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

</details>