### PR TITLE
Fix support for 1.20.2+ clients to older servers on bungeecord

### DIFF
--- a/bungee/src/main/java/com/viaversion/viaversion/bungee/handlers/BungeeEncodeHandler.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/bungee/handlers/BungeeEncodeHandler.java
@@ -37,6 +37,10 @@ public class BungeeEncodeHandler extends MessageToMessageEncoder<ByteBuf> {
         this.info = info;
     }
 
+    public UserConnection getInfo() {
+        return info;
+    }
+
     @Override
     protected void encode(final ChannelHandlerContext ctx, ByteBuf bytebuf, List<Object> out) throws Exception {
         if (!ctx.channel().isActive()) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
@@ -121,6 +121,10 @@ public class BaseProtocol1_7 extends AbstractProtocol {
             ProtocolInfo info = wrapper.user().getProtocolInfo();
             if (info.getProtocolVersion() < ProtocolVersion.v1_20_2.getVersion()) { // On 1.20.2+, wait for the login ack
                 info.setState(State.PLAY);
+            } else {
+                // FIXME: Hack to not break on the UUID type when we send it
+                // manually.
+                return;
             }
 
             UUID uuid = passthroughLoginUUID(wrapper);


### PR DESCRIPTION
This should work around the way BungeeCord handles the first connection on 1.20.2+. Bungeecord keeps the player in the 'login' state, so that the first backend the player connects to can complete the handshake. However, without this patch that does prevent ViaVersion from working properly, as it relies on the login state being completed to initialize its user object, and changes the version of the connection without adjusting the game state or sending out a packet to complete the login.

**NOTE**: This will need some (minor?) adjustments before this can be merged, that go beyond my experience with ViaVersion (which was none before this patch). Sending out the 'GAME_PROFILE' packet also (incorrectly) invokes the base protocol handler, which expects a string UUID, instead of the two longs. To be able to test this, an early return was added to the base protocol, but this will probably break non-bungeecord versions.

This was locally tested with bungeecord and two (custom) 1.12.2 backends, and is currently running in a more conventional bungeecord production setup with several (modified) paper backends. No testing was done on anything non-bungeecord.

Any feedback or help with that remaining issue would be appreciated.

Fixes ViaVersion/ViaBungee#2
