### PR TITLE
Handle invalid chunk data properly

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/chunk/ChunkType1_8.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/chunk/ChunkType1_8.java
@@ -22,15 +22,19 @@
  */
 package com.viaversion.viaversion.api.type.types.chunk;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.minecraft.Environment;
 import com.viaversion.viaversion.api.minecraft.chunks.BaseChunk;
 import com.viaversion.viaversion.api.minecraft.chunks.Chunk;
 import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.version.Types1_8;
+import com.viaversion.viaversion.util.ChunkUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+
 import java.util.ArrayList;
+import java.util.logging.Level;
 
 public class ChunkType1_8 extends Type<Chunk> {
 
@@ -62,7 +66,12 @@ public class ChunkType1_8 extends Type<Chunk> {
             return new BaseChunk(chunkX, chunkZ, true, false, 0, new ChunkSection[16], null, new ArrayList<>());
         }
 
-        return deserialize(chunkX, chunkZ, fullChunk, hasSkyLight, bitmask, data);
+        try {
+            return deserialize(chunkX, chunkZ, fullChunk, hasSkyLight, bitmask, data);
+        } catch (Throwable e) {
+            Via.getPlatform().getLogger().log(Level.WARNING, "The server sent an invalid chunk data packet, returning an empty chunk instead", e);
+            return ChunkUtil.createEmptyChunk(chunkX, chunkZ);
+        }
     }
 
     @Override

--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/chunk/ChunkType1_9_3.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/chunk/ChunkType1_9_3.java
@@ -30,10 +30,13 @@ import com.viaversion.viaversion.api.minecraft.chunks.Chunk;
 import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.version.Types1_9;
+import com.viaversion.viaversion.util.ChunkUtil;
 import io.netty.buffer.ByteBuf;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
 
 public class ChunkType1_9_3 extends Type<Chunk> {
 
@@ -59,24 +62,29 @@ public class ChunkType1_9_3 extends Type<Chunk> {
         int primaryBitmask = Type.VAR_INT.readPrimitive(input);
         ByteBuf data = input.readSlice(Type.VAR_INT.readPrimitive(input));
 
-        // Read sections
         ChunkSection[] sections = new ChunkSection[16];
-        for (int i = 0; i < 16; i++) {
-            if ((primaryBitmask & (1 << i)) == 0) continue; // Section not set
-
-            ChunkSection section = Types1_9.CHUNK_SECTION.read(data);
-            sections[i] = section;
-            section.getLight().readBlockLight(data);
-            if (hasSkyLight) {
-                section.getLight().readSkyLight(data);
-            }
-        }
-
         int[] biomeData = fullChunk ? new int[256] : null;
-        if (fullChunk) {
-            for (int i = 0; i < 256; i++) {
-                biomeData[i] = data.readByte() & 0xFF;
+        try {
+            // Read sections
+            for (int i = 0; i < 16; i++) {
+                if ((primaryBitmask & (1 << i)) == 0) continue; // Section not set
+
+                ChunkSection section = Types1_9.CHUNK_SECTION.read(data);
+                sections[i] = section;
+                section.getLight().readBlockLight(data);
+                if (hasSkyLight) {
+                    section.getLight().readSkyLight(data);
+                }
             }
+
+            if (fullChunk) {
+                for (int i = 0; i < 256; i++) {
+                    biomeData[i] = data.readByte() & 0xFF;
+                }
+            }
+        } catch (Throwable e) {
+            Via.getPlatform().getLogger().log(Level.WARNING, "The server sent an invalid chunk data packet, returning an empty chunk instead", e);
+            return ChunkUtil.createEmptyChunk(chunkX, chunkZ);
         }
 
         List<CompoundTag> nbtData = new ArrayList<>(Arrays.asList(Type.NAMED_COMPOUND_TAG_ARRAY.read(input)));

--- a/api/src/main/java/com/viaversion/viaversion/util/ChunkUtil.java
+++ b/api/src/main/java/com/viaversion/viaversion/util/ChunkUtil.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2023 ViaVersion and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.viaversion.viaversion.util;
+
+import com.viaversion.viaversion.api.minecraft.chunks.*;
+
+import java.util.ArrayList;
+
+public class ChunkUtil {
+
+    public static Chunk createEmptyChunk(final int chunkX, final int chunkZ) {
+        final ChunkSection[] airSections = new ChunkSection[16];
+        for (int i = 0; i < airSections.length; i++) {
+            airSections[i] = new ChunkSectionImpl(true);
+            airSections[i].palette(PaletteType.BLOCKS).addId(0);
+        }
+        return new BaseChunk(chunkX, chunkZ, true, false, 0xFFFF, airSections, new int[256], new ArrayList<>());
+    }
+
+}


### PR DESCRIPTION
This fixes handling of invalid chunk data packets in <= 1.12.2. In those versions the actual chunk data was read in the main thread of the game (in a task) which didn't cause a disconnect if it failed, but instead ignores the exception. This causes invalid chunks to be handled as "air chunks" because the game prepares the chunk at the location for block data, but fails at filling the block data, so the chunk will stay empty. Some servers use this to load empty chunks by just sending a couple of bytes (chunk data header) and not write any of the block/biome data at all.

Here is the observed behaviour on how different client version handle this:
1.8 - 1.12.2: load empty
1.13 - 1.13.2: crash
1.14 - latest: cancel

This PR only implements 1.8 - 1.12.2, as the other behaviour isn't easily fixable without larger changes to the chunk data translation (And its not that important since I only ever saw invalid chunk data being used in 1.8 antibot bungeecord forks)