### PR TITLE
Return air instead of stone for unknown block ids

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -582,8 +582,8 @@ public class WorldPackets {
         if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
             Via.getPlatform().getLogger().warning("Missing block completely " + oldId);
         }
-        // Default stone
-        return 1;
+        // Default air
+        return 0;
     }
 
     private static int checkStorage(UserConnection user, Position position, int newId) {


### PR DESCRIPTION
This PR corrects the handling of invalid block ids in 1.13 -> 1.12.2. A vanilla client loads an air block instead of stone for any unknown blocks. ViaVersion should do the same as all vanilla blocks have mappings anyways, so it shouldn't be needed to return stone