### PR TITLE
Fixed wrong data type in JOIN_GAME handlers

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16_2to1_16_1/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16_2to1_16_1/packets/EntityPackets.java
@@ -44,9 +44,7 @@ public class EntityPackets {
                 handler(wrapper -> {
                     short gamemode = wrapper.read(Type.UNSIGNED_BYTE);
                     wrapper.write(Type.BOOLEAN, (gamemode & 0x08) != 0); // Hardcore
-
-                    gamemode &= ~0x08;
-                    wrapper.write(Type.UNSIGNED_BYTE, gamemode);
+                    wrapper.write(Type.BYTE, (byte) (gamemode & ~0x08)); // Gamemode
                 });
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/EntityPackets.java
@@ -206,7 +206,7 @@ public class EntityPackets {
             @Override
             public void register() {
                 map(Type.INT); // Entity ID
-                map(Type.UNSIGNED_BYTE); //  Gamemode
+                map(Type.BYTE); //  Gamemode
                 handler(wrapper -> {
                     wrapper.write(Type.BYTE, (byte) -1); // Previous gamemode, set to none
                     wrapper.write(Type.STRING_ARRAY, Arrays.copyOf(WORLD_NAMES, WORLD_NAMES.length)); // World list - only used for command completion

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/EntityPackets.java
@@ -22,9 +22,9 @@ import com.github.steveice10.opennbt.tag.builtin.IntTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.Tag;
 import com.viaversion.viaversion.api.data.entity.EntityTracker;
+import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_16_2;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_17;
-import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
@@ -70,7 +70,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_16_2
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Registry

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18_2to1_18/Protocol1_18_2To1_18.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18_2to1_18/Protocol1_18_2To1_18.java
@@ -62,7 +62,7 @@ public final class Protocol1_18_2To1_18 extends AbstractProtocol<ClientboundPack
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Registry

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/EntityPackets.java
@@ -18,11 +18,11 @@
 package com.viaversion.viaversion.protocols.protocol1_18to1_17_1.packets;
 
 import com.viaversion.viaversion.api.data.entity.EntityTracker;
-import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_17;
+import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_17;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
-import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.type.types.version.Types1_17;
 import com.viaversion.viaversion.api.type.types.version.Types1_18;
 import com.viaversion.viaversion.protocols.protocol1_17_1to1_17.ClientboundPackets1_17_1;
@@ -45,7 +45,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_17_1
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Registry

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_1to1_19/Protocol1_19_1To1_19.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_1to1_19/Protocol1_19_1To1_19.java
@@ -210,7 +210,7 @@ public final class Protocol1_19_1To1_19 extends AbstractProtocol<ClientboundPack
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 handler(wrapper -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_3to1_19_1/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_3to1_19_1/packets/EntityPackets.java
@@ -18,8 +18,8 @@
 package com.viaversion.viaversion.protocols.protocol1_19_3to1_19_1.packets;
 
 import com.google.gson.JsonElement;
-import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_3;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_3;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
@@ -29,6 +29,7 @@ import com.viaversion.viaversion.protocols.protocol1_19_1to1_19.ClientboundPacke
 import com.viaversion.viaversion.protocols.protocol1_19_3to1_19_1.ClientboundPackets1_19_3;
 import com.viaversion.viaversion.protocols.protocol1_19_3to1_19_1.Protocol1_19_3To1_19_1;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
+
 import java.util.BitSet;
 import java.util.UUID;
 
@@ -49,7 +50,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_19_1
             public void register() {
                 map(Type.INT); // Entity id
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_4to1_19_3/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_4to1_19_3/packets/EntityPackets.java
@@ -17,13 +17,9 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_19_4to1_19_3.packets;
 
-import com.github.steveice10.opennbt.tag.builtin.ByteTag;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
-import com.github.steveice10.opennbt.tag.builtin.ListTag;
-import com.github.steveice10.opennbt.tag.builtin.StringTag;
-import com.github.steveice10.opennbt.tag.builtin.Tag;
-import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
+import com.github.steveice10.opennbt.tag.builtin.*;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
@@ -48,7 +44,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_19_3
             public void register() {
                 map(Type.INT); // Entity id
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/EntityPackets.java
@@ -27,15 +27,15 @@ import com.google.gson.JsonElement;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.data.ParticleMappings;
 import com.viaversion.viaversion.api.data.entity.DimensionData;
+import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.minecraft.Position;
-import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19;
 import com.viaversion.viaversion.api.minecraft.metadata.MetaType;
 import com.viaversion.viaversion.api.minecraft.metadata.Metadata;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
-import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.type.types.version.Types1_18;
 import com.viaversion.viaversion.api.type.types.version.Types1_19;
 import com.viaversion.viaversion.data.entity.DimensionDataImpl;
@@ -46,11 +46,8 @@ import com.viaversion.viaversion.protocols.protocol1_19to1_18_2.storage.Dimensio
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.util.Key;
 import com.viaversion.viaversion.util.Pair;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 
 public final class EntityPackets extends EntityRewriter<ClientboundPackets1_18, Protocol1_19To1_18_2> {
 
@@ -199,7 +196,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_18, 
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Registry

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/rewriter/EntityPacketRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/rewriter/EntityPacketRewriter1_20_2.java
@@ -18,8 +18,8 @@
 package com.viaversion.viaversion.protocols.protocol1_20_2to1_20.rewriter;
 
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
-import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
@@ -71,7 +71,7 @@ public final class EntityPacketRewriter1_20_2 extends EntityRewriter<Clientbound
                     wrapper.passthrough(Type.INT); // Entity id
                     wrapper.passthrough(Type.BOOLEAN); // Hardcore
 
-                    final byte gamemode = wrapper.read(Type.UNSIGNED_BYTE).byteValue();
+                    final byte gamemode = wrapper.read(Type.BYTE);
                     final byte previousGamemode = wrapper.read(Type.BYTE);
 
                     wrapper.passthrough(Type.STRING_ARRAY); // World List

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20to1_19_4/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20to1_19_4/packets/EntityPackets.java
@@ -17,15 +17,10 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_20to1_19_4.packets;
 
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
-import com.github.steveice10.opennbt.tag.builtin.FloatTag;
-import com.github.steveice10.opennbt.tag.builtin.IntTag;
-import com.github.steveice10.opennbt.tag.builtin.ListTag;
-import com.github.steveice10.opennbt.tag.builtin.StringTag;
-import com.github.steveice10.opennbt.tag.builtin.Tag;
+import com.github.steveice10.opennbt.tag.builtin.*;
 import com.viaversion.viaversion.api.minecraft.Quaternion;
-import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
 import com.viaversion.viaversion.api.minecraft.metadata.Metadata;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
@@ -54,7 +49,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_19_4
             public void register() {
                 map(Type.INT); // Entity id
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry


### PR DESCRIPTION
This PR uses the correct data type for reading the gamemode in the JOIN_GAME handlers.
Vanilla client code:
![image](https://github.com/ViaVersion/ViaVersion/assets/50594595/75d3aa3a-801f-4db6-b05c-f886f3550eac)
