### PR TITLE
fix 1.20.3 chat component parsing

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_3to1_20_2/Protocol1_20_3To1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_3to1_20_2/Protocol1_20_3To1_20_2.java
@@ -35,6 +35,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.internal.LazilyParsedNumber;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.MappingData;
@@ -418,8 +419,10 @@ public final class Protocol1_20_3To1_20_2 extends AbstractProtocol<ClientboundPa
                 return new DoubleTag(number.doubleValue());
             } else if (number instanceof Float) {
                 return new FloatTag(number.floatValue());
+            } else if (number instanceof LazilyParsedNumber) {
+                return new IntTag(number.intValue());
             }
-            return new StringTag(primitive.getAsString()); // ???
+            return new IntTag(number.intValue()); // ???
         }
         throw new IllegalArgumentException("Unhandled json type " + element.getClass().getSimpleName() + " with value " + element.getAsString());
     }


### PR DESCRIPTION
Fixes #3546 

Problem is: The count of the item in the chat component is parsed as string, as the json element could not detect the actual type (int). I've just added another case for the `LazilyParsedNumber` to act as int, as well as changed the default "idk what this is" case to an int. This may not be an ideal solution, but I think this whole section, may be replaced with another solution like adventure?
This just fixes the issue (on my machine)