### PR TITLE
Read 1.8 chunk block ids as unsigned

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/chunk/ChunkSectionType1_8.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/chunk/ChunkSectionType1_8.java
@@ -46,7 +46,7 @@ public class ChunkSectionType1_8 extends Type<ChunkSection> {
 
         ByteBuf littleEndianView = buffer.order(ByteOrder.LITTLE_ENDIAN);
         for (int idx = 0; idx < ChunkSection.SIZE; idx++) {
-            blocks.setIdAt(idx, littleEndianView.readShort());
+            blocks.setIdAt(idx, littleEndianView.readUnsignedShort());
         }
 
         return chunkSection;


### PR DESCRIPTION
In 1.8, block ids in chunks are read as unsigned. This only fixes mods with custom blocks, translating through a modified version with custom mappings.