### PR TITLE
Fix skin layers breaking for >= 1.20.2 clients on < 1.20.2 velocity proxies

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/rewriter/EntityPacketRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/rewriter/EntityPacketRewriter1_20_2.java
@@ -103,7 +103,9 @@ public final class EntityPacketRewriter1_20_2 extends EntityRewriter<Clientbound
                         // No change, so no need to re-enter the configuration state - just let this one through
                         final PacketWrapper clientInformationPacket = configurationBridge.clientInformationPacket(wrapper.user());
                         if (clientInformationPacket != null) {
-                            clientInformationPacket.sendToServer(Protocol1_20_2To1_20.class);
+                            // Schedule the sending to ensure it arrives later, this fixes an issue where on
+                            // servers running < 1.20.2 a client changing servers on a proxy lost skin layers
+                            clientInformationPacket.scheduleSendToServer(Protocol1_20_2To1_20.class);
                         }
                         return;
                     }


### PR DESCRIPTION
This fixes an issue MCC Island (and likely other servers) are having where skin layers go missing when players switch servers. We run ViaVersion only on the proxy. Without this fix skin layers break every server switch, seems completely fixed after.

I don't know enough about Via's workings to fully understand why this fixes it but my guess is that there's some issue with the packet arriving in the wrong phase when the client doesn't go into the configuration phase first? Maybe this needs a better fix.

Found this fix because were running a very specific developer build that had 1.20.2 support but without this issue, and I reverted the one commit that made any changes and this was the only part of that commit that has any effects.