### PR TITLE
Support config loading from input stream as fallback if URL cannot be acquired

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/util/InputStreamSupplier.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/InputStreamSupplier.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@FunctionalInterface
+public interface InputStreamSupplier {
+
+    InputStream get() throws IOException;
+}


### PR DESCRIPTION
The URL for the default config could be null, depending on the ClassLoader. However, getting the resource as stream is possible in more cases due to multiple datasources.

These changes allow subclasses of `com.viaversion.viaversion.util.Config` to support loading from streams as well, as `loadConfig` got an InputStream from `URL::openStream` anyway.
The method `Config::getDefaultConfigInputStream` acts as a fallback incase the default config URL is null, meaning that running systems won't affected.

Let me know if there are any questions.