### PR TITLE
Update JDK to 17, setup-java to v4

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/checkout@v4
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
         check-latest: true
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     compileOnlyApi(projects.viaversionCommon)
     compileOnly(libs.velocity) {
-        // Requires Java 11
+        // Requires Java 17
         exclude("com.velocitypowered", "velocity-brigadier")
     }
     annotationProcessor(libs.velocity)


### PR DESCRIPTION
1. Updates the JDK version to 17 as velocity 3.3 depends on it and because this version is much more stable,
2. Updates the setup-java dependency in CI to v4.