### PR TITLE
Fix missing handling of text components in 1.11.1>1.12 chat item rewriter

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/ChatItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/ChatItemRewriter.java
@@ -42,6 +42,15 @@ public class ChatItemRewriter {
                             if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
                                 String newValue = indexRemoval.matcher(value.getAsString()).replaceAll("");
                                 hoverEvent.addProperty("value", newValue);
+                            } else if (value.isJsonObject() && value.getAsJsonObject().has("text")) {
+                                JsonObject newObject = (JsonObject) value;
+                                JsonElement textElement = newObject.get("text");
+
+                                if (textElement.isJsonPrimitive() && textElement.getAsJsonPrimitive().isString()) {
+                                    String newValue = indexRemoval.matcher(textElement.getAsString()).replaceAll("");
+                                    newObject.addProperty("text", newValue);
+                                    hoverEvent.add("value", newObject);
+                                }
                             } else if (value.isJsonArray()) {
                                 JsonArray newArray = new JsonArray();
 
@@ -49,6 +58,15 @@ public class ChatItemRewriter {
                                     if (valueElement.isJsonPrimitive() && valueElement.getAsJsonPrimitive().isString()) {
                                         String newValue = indexRemoval.matcher(valueElement.getAsString()).replaceAll("");
                                         newArray.add(new JsonPrimitive(newValue));
+                                    } else if (valueElement.isJsonObject() && valueElement.getAsJsonObject().has("text")) {
+                                        JsonObject newObject = (JsonObject) valueElement;
+                                        JsonElement textElement = newObject.get("text");
+
+                                        if (textElement.isJsonPrimitive() && textElement.getAsJsonPrimitive().isString()) {
+                                            String newValue = indexRemoval.matcher(textElement.getAsString()).replaceAll("");
+                                            newObject.addProperty("text", newValue);
+                                            newArray.add(newObject);
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
I never noticed that this was not handled by ViaVersion until upgrading to 1.20.3 and above

1.20.3 changed it so a client will be kicked if an invalid chat json text is sent to the client. 

ViaVersion did not check for hover events using a JsonObject with a text element inside, and then made the hover event an empty array instead, which on 1.20.3 and above, would kick the client for the reason seen here: ![image](https://github.com/ViaVersion/ViaVersion/assets/8997490/9c03f573-288d-4dec-960b-38a0983c689f)

I have tested this and it seems to have fixed the issue, now sending a item or entity hoverEvent on a 1.20.3+ client on a 1.8-1.11 server no longer kicks me

Hopefully I described the issue well and submitted an adequate fix for it! Let me know if anything is unclear or if there is changes you'd want me to do to the fix!