### PR TITLE
Prevent ItemRewriter from spamming item types

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_10to1_9_3/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_10to1_9_3/packets/InventoryPackets.java
@@ -27,12 +27,12 @@ import com.viaversion.viaversion.rewriter.ItemRewriter;
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, ServerboundPackets1_9_3, Protocol1_10To1_9_3_4> {
 
     public InventoryPackets(Protocol1_10To1_9_3_4 protocol) {
-        super(protocol, null, null);
+        super(protocol, Type.ITEM1_8, null);
     }
 
     @Override
     public void registerPackets() {
-        registerCreativeInvAction(ServerboundPackets1_9_3.CREATIVE_INVENTORY_ACTION, Type.ITEM1_8);
+        registerCreativeInvAction(ServerboundPackets1_9_3.CREATIVE_INVENTORY_ACTION);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11_1to1_11/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11_1to1_11/packets/InventoryPackets.java
@@ -27,12 +27,12 @@ import com.viaversion.viaversion.rewriter.ItemRewriter;
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, ServerboundPackets1_9_3, Protocol1_11_1To1_11> {
 
     public InventoryPackets(Protocol1_11_1To1_11 protocol) {
-        super(protocol, null, null);
+        super(protocol, Type.ITEM1_8, null);
     }
 
     @Override
     public void registerPackets() {
-        registerCreativeInvAction(ServerboundPackets1_9_3.CREATIVE_INVENTORY_ACTION, Type.ITEM1_8);
+        registerCreativeInvAction(ServerboundPackets1_9_3.CREATIVE_INVENTORY_ACTION);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/packets/InventoryPackets.java
@@ -29,14 +29,14 @@ import com.viaversion.viaversion.rewriter.ItemRewriter;
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, ServerboundPackets1_9_3, Protocol1_11To1_10> {
 
     public InventoryPackets(Protocol1_11To1_10 protocol) {
-        super(protocol, null, null);
+        super(protocol, Type.ITEM1_8, Type.ITEM1_8_SHORT_ARRAY);
     }
 
     @Override
     public void registerPackets() {
-        registerSetSlot(ClientboundPackets1_9_3.SET_SLOT, Type.ITEM1_8);
-        registerWindowItems(ClientboundPackets1_9_3.WINDOW_ITEMS, Type.ITEM1_8_SHORT_ARRAY);
-        registerEntityEquipment(ClientboundPackets1_9_3.ENTITY_EQUIPMENT, Type.ITEM1_8);
+        registerSetSlot(ClientboundPackets1_9_3.SET_SLOT);
+        registerWindowItems(ClientboundPackets1_9_3.WINDOW_ITEMS);
+        registerEntityEquipment(ClientboundPackets1_9_3.ENTITY_EQUIPMENT);
 
         // Plugin message Packet -> Trading
         protocol.registerClientbound(ClientboundPackets1_9_3.PLUGIN_MESSAGE, new PacketHandlers() {
@@ -66,8 +66,8 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, Serv
             }
         });
 
-        registerClickWindow(ServerboundPackets1_9_3.CLICK_WINDOW, Type.ITEM1_8);
-        registerCreativeInvAction(ServerboundPackets1_9_3.CREATIVE_INVENTORY_ACTION, Type.ITEM1_8);
+        registerClickWindow(ServerboundPackets1_9_3.CLICK_WINDOW);
+        registerCreativeInvAction(ServerboundPackets1_9_3.CREATIVE_INVENTORY_ACTION);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
@@ -31,16 +31,16 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, ServerboundPackets1_12, Protocol1_12To1_11_1> {
 
     public InventoryPackets(Protocol1_12To1_11_1 protocol) {
-        super(protocol, null, null);
+        super(protocol, Type.ITEM1_8, Type.ITEM1_8_SHORT_ARRAY);
     }
 
     @Override
     public void registerPackets() {
-        registerSetSlot(ClientboundPackets1_9_3.SET_SLOT, Type.ITEM1_8);
-        registerWindowItems(ClientboundPackets1_9_3.WINDOW_ITEMS, Type.ITEM1_8_SHORT_ARRAY);
-        registerEntityEquipment(ClientboundPackets1_9_3.ENTITY_EQUIPMENT, Type.ITEM1_8);
+        registerSetSlot(ClientboundPackets1_9_3.SET_SLOT);
+        registerWindowItems(ClientboundPackets1_9_3.WINDOW_ITEMS);
+        registerEntityEquipment(ClientboundPackets1_9_3.ENTITY_EQUIPMENT);
 
-        // Plugin message Packet -> Trading
+        // Plugin message -> Trading
         protocol.registerClientbound(ClientboundPackets1_9_3.PLUGIN_MESSAGE, new PacketHandlers() {
             @Override
             public void register() {
@@ -107,8 +107,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, Serv
                 }
         );
 
-        // Creative Inventory Action
-        registerCreativeInvAction(ServerboundPackets1_12.CREATIVE_INVENTORY_ACTION, Type.ITEM1_8);
+        registerCreativeInvAction(ServerboundPackets1_12.CREATIVE_INVENTORY_ACTION);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/packets/InventoryPackets.java
@@ -30,14 +30,14 @@ import com.viaversion.viaversion.util.Key;
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, ServerboundPackets1_13, Protocol1_13_1To1_13> {
 
     public InventoryPackets(Protocol1_13_1To1_13 protocol) {
-        super(protocol, Type.ITEM1_13, Type.ITEM1_13_ARRAY);
+        super(protocol, Type.ITEM1_13, Type.ITEM1_13_SHORT_ARRAY);
     }
 
     @Override
     public void registerPackets() {
-        registerSetSlot(ClientboundPackets1_13.SET_SLOT, Type.ITEM1_13);
-        registerWindowItems(ClientboundPackets1_13.WINDOW_ITEMS, Type.ITEM1_13_SHORT_ARRAY);
-        registerAdvancements(ClientboundPackets1_13.ADVANCEMENTS, Type.ITEM1_13);
+        registerSetSlot(ClientboundPackets1_13.SET_SLOT);
+        registerWindowItems(ClientboundPackets1_13.WINDOW_ITEMS);
+        registerAdvancements(ClientboundPackets1_13.ADVANCEMENTS);
         registerSetCooldown(ClientboundPackets1_13.COOLDOWN);
 
         protocol.registerClientbound(ClientboundPackets1_13.PLUGIN_MESSAGE, new PacketHandlers() {
@@ -71,7 +71,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
             }
         });
 
-        registerEntityEquipment(ClientboundPackets1_13.ENTITY_EQUIPMENT, Type.ITEM1_13);
+        registerEntityEquipment(ClientboundPackets1_13.ENTITY_EQUIPMENT);
 
         RecipeRewriter<ClientboundPackets1_13> recipeRewriter = new RecipeRewriter<ClientboundPackets1_13>(protocol) {
             @Override
@@ -94,9 +94,9 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
             }
         });
 
-        registerClickWindow(ServerboundPackets1_13.CLICK_WINDOW, Type.ITEM1_13);
-        registerCreativeInvAction(ServerboundPackets1_13.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13);
+        registerClickWindow(ServerboundPackets1_13.CLICK_WINDOW);
+        registerCreativeInvAction(ServerboundPackets1_13.CREATIVE_INVENTORY_ACTION);
 
-        registerSpawnParticle(ClientboundPackets1_13.SPAWN_PARTICLE, Type.ITEM1_13, Type.FLOAT);
+        registerSpawnParticle(ClientboundPackets1_13.SPAWN_PARTICLE, Type.FLOAT);
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/packets/InventoryPackets.java
@@ -60,13 +60,13 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
     };
 
     public InventoryPackets(Protocol1_14To1_13_2 protocol) {
-        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_ARRAY);
+        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_SHORT_ARRAY);
     }
 
     @Override
     public void registerPackets() {
         registerSetCooldown(ClientboundPackets1_13.COOLDOWN);
-        registerAdvancements(ClientboundPackets1_13.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerAdvancements(ClientboundPackets1_13.ADVANCEMENTS);
 
         protocol.registerClientbound(ClientboundPackets1_13.OPEN_WINDOW, null, wrapper -> {
             Short windowId = wrapper.read(Type.UNSIGNED_BYTE);
@@ -136,8 +136,8 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
             }
         });
 
-        registerWindowItems(ClientboundPackets1_13.WINDOW_ITEMS, Type.ITEM1_13_2_SHORT_ARRAY);
-        registerSetSlot(ClientboundPackets1_13.SET_SLOT, Type.ITEM1_13_2);
+        registerWindowItems(ClientboundPackets1_13.WINDOW_ITEMS);
+        registerSetSlot(ClientboundPackets1_13.SET_SLOT);
 
         protocol.registerClientbound(ClientboundPackets1_13.PLUGIN_MESSAGE, new PacketHandlers() {
             @Override
@@ -190,7 +190,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
             }
         });
 
-        registerEntityEquipment(ClientboundPackets1_13.ENTITY_EQUIPMENT, Type.ITEM1_13_2);
+        registerEntityEquipment(ClientboundPackets1_13.ENTITY_EQUIPMENT);
 
         RecipeRewriter<ClientboundPackets1_13> recipeRewriter = new RecipeRewriter<>(protocol);
         protocol.registerClientbound(ClientboundPackets1_13.DECLARE_RECIPES, wrapper -> {
@@ -212,7 +212,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
         });
 
 
-        registerClickWindow(ServerboundPackets1_14.CLICK_WINDOW, Type.ITEM1_13_2);
+        registerClickWindow(ServerboundPackets1_14.CLICK_WINDOW);
 
         protocol.registerServerbound(ServerboundPackets1_14.SELECT_TRADE, wrapper -> {
             // Selecting trade now moves the items, we need to resync the inventory
@@ -229,9 +229,9 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
             resyncPacket.scheduleSendToServer(Protocol1_14To1_13_2.class);
         });
 
-        registerCreativeInvAction(ServerboundPackets1_14.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerCreativeInvAction(ServerboundPackets1_14.CREATIVE_INVENTORY_ACTION);
 
-        registerSpawnParticle(ClientboundPackets1_13.SPAWN_PARTICLE, Type.ITEM1_13_2, Type.FLOAT);
+        registerSpawnParticle(ClientboundPackets1_13.SPAWN_PARTICLE, Type.FLOAT);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_15to1_14_4/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_15to1_14_4/packets/InventoryPackets.java
@@ -27,21 +27,21 @@ import com.viaversion.viaversion.rewriter.RecipeRewriter;
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_14_4, ServerboundPackets1_14, Protocol1_15To1_14_4> {
 
     public InventoryPackets(Protocol1_15To1_14_4 protocol) {
-        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_ARRAY);
+        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_SHORT_ARRAY);
     }
 
     @Override
     public void registerPackets() {
         registerSetCooldown(ClientboundPackets1_14_4.COOLDOWN);
-        registerWindowItems(ClientboundPackets1_14_4.WINDOW_ITEMS, Type.ITEM1_13_2_SHORT_ARRAY);
+        registerWindowItems(ClientboundPackets1_14_4.WINDOW_ITEMS);
         registerTradeList(ClientboundPackets1_14_4.TRADE_LIST);
-        registerSetSlot(ClientboundPackets1_14_4.SET_SLOT, Type.ITEM1_13_2);
-        registerEntityEquipment(ClientboundPackets1_14_4.ENTITY_EQUIPMENT, Type.ITEM1_13_2);
-        registerAdvancements(ClientboundPackets1_14_4.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerSetSlot(ClientboundPackets1_14_4.SET_SLOT);
+        registerEntityEquipment(ClientboundPackets1_14_4.ENTITY_EQUIPMENT);
+        registerAdvancements(ClientboundPackets1_14_4.ADVANCEMENTS);
 
         new RecipeRewriter<>(protocol).register(ClientboundPackets1_14_4.DECLARE_RECIPES);
 
-        registerClickWindow(ServerboundPackets1_14.CLICK_WINDOW, Type.ITEM1_13_2);
-        registerCreativeInvAction(ServerboundPackets1_14.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerClickWindow(ServerboundPackets1_14.CLICK_WINDOW);
+        registerCreativeInvAction(ServerboundPackets1_14.CREATIVE_INVENTORY_ACTION);
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16_2to1_16_1/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16_2to1_16_1/packets/InventoryPackets.java
@@ -27,17 +27,17 @@ import com.viaversion.viaversion.rewriter.RecipeRewriter;
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_16, ServerboundPackets1_16_2, Protocol1_16_2To1_16_1> {
 
     public InventoryPackets(Protocol1_16_2To1_16_1 protocol) {
-        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_ARRAY);
+        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_SHORT_ARRAY);
     }
 
     @Override
     public void registerPackets() {
         registerSetCooldown(ClientboundPackets1_16.COOLDOWN);
-        registerWindowItems(ClientboundPackets1_16.WINDOW_ITEMS, Type.ITEM1_13_2_SHORT_ARRAY);
+        registerWindowItems(ClientboundPackets1_16.WINDOW_ITEMS);
         registerTradeList(ClientboundPackets1_16.TRADE_LIST);
-        registerSetSlot(ClientboundPackets1_16.SET_SLOT, Type.ITEM1_13_2);
+        registerSetSlot(ClientboundPackets1_16.SET_SLOT);
         registerEntityEquipmentArray(ClientboundPackets1_16.ENTITY_EQUIPMENT);
-        registerAdvancements(ClientboundPackets1_16.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerAdvancements(ClientboundPackets1_16.ADVANCEMENTS);
 
         protocol.registerClientbound(ClientboundPackets1_16.UNLOCK_RECIPES, wrapper -> {
             wrapper.passthrough(Type.VAR_INT);
@@ -54,10 +54,10 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_16, Serve
 
         new RecipeRewriter<>(protocol).register(ClientboundPackets1_16.DECLARE_RECIPES);
 
-        registerClickWindow(ServerboundPackets1_16_2.CLICK_WINDOW, Type.ITEM1_13_2);
-        registerCreativeInvAction(ServerboundPackets1_16_2.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerClickWindow(ServerboundPackets1_16_2.CLICK_WINDOW);
+        registerCreativeInvAction(ServerboundPackets1_16_2.CREATIVE_INVENTORY_ACTION);
         protocol.registerServerbound(ServerboundPackets1_16_2.EDIT_BOOK, wrapper -> handleItemToServer(wrapper.passthrough(Type.ITEM1_13_2)));
 
-        registerSpawnParticle(ClientboundPackets1_16.SPAWN_PARTICLE, Type.ITEM1_13_2, Type.DOUBLE);
+        registerSpawnParticle(ClientboundPackets1_16.SPAWN_PARTICLE, Type.DOUBLE);
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
@@ -43,7 +43,7 @@ import java.util.UUID;
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_15, ServerboundPackets1_16, Protocol1_16To1_15_2> {
 
     public InventoryPackets(Protocol1_16To1_15_2 protocol) {
-        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_ARRAY);
+        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_SHORT_ARRAY);
     }
 
     @Override
@@ -107,10 +107,10 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_15, Serve
         });
 
         registerSetCooldown(ClientboundPackets1_15.COOLDOWN);
-        registerWindowItems(ClientboundPackets1_15.WINDOW_ITEMS, Type.ITEM1_13_2_SHORT_ARRAY);
+        registerWindowItems(ClientboundPackets1_15.WINDOW_ITEMS);
         registerTradeList(ClientboundPackets1_15.TRADE_LIST);
-        registerSetSlot(ClientboundPackets1_15.SET_SLOT, Type.ITEM1_13_2);
-        registerAdvancements(ClientboundPackets1_15.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerSetSlot(ClientboundPackets1_15.SET_SLOT);
+        registerAdvancements(ClientboundPackets1_15.ADVANCEMENTS);
 
         protocol.registerClientbound(ClientboundPackets1_15.ENTITY_EQUIPMENT, new PacketHandlers() {
             @Override
@@ -127,8 +127,8 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_15, Serve
 
         new RecipeRewriter<>(protocol).register(ClientboundPackets1_15.DECLARE_RECIPES);
 
-        registerClickWindow(ServerboundPackets1_16.CLICK_WINDOW, Type.ITEM1_13_2);
-        registerCreativeInvAction(ServerboundPackets1_16.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerClickWindow(ServerboundPackets1_16.CLICK_WINDOW);
+        registerCreativeInvAction(ServerboundPackets1_16.CREATIVE_INVENTORY_ACTION);
 
         protocol.registerServerbound(ServerboundPackets1_16.CLOSE_WINDOW, wrapper -> {
             InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
@@ -137,7 +137,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_15, Serve
 
         protocol.registerServerbound(ServerboundPackets1_16.EDIT_BOOK, wrapper -> handleItemToServer(wrapper.passthrough(Type.ITEM1_13_2)));
 
-        registerSpawnParticle(ClientboundPackets1_15.SPAWN_PARTICLE, Type.ITEM1_13_2, Type.DOUBLE);
+        registerSpawnParticle(ClientboundPackets1_15.SPAWN_PARTICLE, Type.DOUBLE);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/InventoryPackets.java
@@ -36,22 +36,22 @@ import com.viaversion.viaversion.rewriter.RecipeRewriter;
 public final class InventoryPackets extends ItemRewriter<ClientboundPackets1_16_2, ServerboundPackets1_17, Protocol1_17To1_16_4> {
 
     public InventoryPackets(Protocol1_17To1_16_4 protocol) {
-        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_ARRAY);
+        super(protocol, Type.ITEM1_13_2, Type.ITEM1_13_2_SHORT_ARRAY);
     }
 
     @Override
     public void registerPackets() {
         registerSetCooldown(ClientboundPackets1_16_2.COOLDOWN);
-        registerWindowItems(ClientboundPackets1_16_2.WINDOW_ITEMS, Type.ITEM1_13_2_SHORT_ARRAY);
+        registerWindowItems(ClientboundPackets1_16_2.WINDOW_ITEMS);
         registerTradeList(ClientboundPackets1_16_2.TRADE_LIST);
-        registerSetSlot(ClientboundPackets1_16_2.SET_SLOT, Type.ITEM1_13_2);
-        registerAdvancements(ClientboundPackets1_16_2.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerSetSlot(ClientboundPackets1_16_2.SET_SLOT);
+        registerAdvancements(ClientboundPackets1_16_2.ADVANCEMENTS);
         registerEntityEquipmentArray(ClientboundPackets1_16_2.ENTITY_EQUIPMENT);
-        registerSpawnParticle(ClientboundPackets1_16_2.SPAWN_PARTICLE, Type.ITEM1_13_2, Type.DOUBLE);
+        registerSpawnParticle(ClientboundPackets1_16_2.SPAWN_PARTICLE, Type.DOUBLE);
 
         new RecipeRewriter<>(protocol).register(ClientboundPackets1_16_2.DECLARE_RECIPES);
 
-        registerCreativeInvAction(ServerboundPackets1_17.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerCreativeInvAction(ServerboundPackets1_17.CREATIVE_INVENTORY_ACTION);
 
         protocol.registerServerbound(ServerboundPackets1_17.EDIT_BOOK, wrapper -> handleItemToServer(wrapper.passthrough(Type.ITEM1_13_2)));
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/InventoryPackets.java
@@ -38,7 +38,7 @@ public final class InventoryPackets extends ItemRewriter<ClientboundPackets1_17_
         registerWindowItems1_17_1(ClientboundPackets1_17_1.WINDOW_ITEMS);
         registerTradeList(ClientboundPackets1_17_1.TRADE_LIST);
         registerSetSlot1_17_1(ClientboundPackets1_17_1.SET_SLOT);
-        registerAdvancements(ClientboundPackets1_17_1.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerAdvancements(ClientboundPackets1_17_1.ADVANCEMENTS);
         registerEntityEquipmentArray(ClientboundPackets1_17_1.ENTITY_EQUIPMENT);
 
         protocol.registerClientbound(ClientboundPackets1_17_1.EFFECT, new PacketHandlers() {
@@ -100,6 +100,6 @@ public final class InventoryPackets extends ItemRewriter<ClientboundPackets1_17_
         new RecipeRewriter<>(protocol).register(ClientboundPackets1_17_1.DECLARE_RECIPES);
 
         registerClickWindow1_17_1(ServerboundPackets1_17.CLICK_WINDOW);
-        registerCreativeInvAction(ServerboundPackets1_17.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerCreativeInvAction(ServerboundPackets1_17.CREATIVE_INVENTORY_ACTION);
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_3to1_19_1/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_3to1_19_1/packets/InventoryPackets.java
@@ -50,11 +50,11 @@ public final class InventoryPackets extends ItemRewriter<ClientboundPackets1_19_
         registerSetCooldown(ClientboundPackets1_19_1.COOLDOWN);
         registerWindowItems1_17_1(ClientboundPackets1_19_1.WINDOW_ITEMS);
         registerSetSlot1_17_1(ClientboundPackets1_19_1.SET_SLOT);
-        registerAdvancements(ClientboundPackets1_19_1.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerAdvancements(ClientboundPackets1_19_1.ADVANCEMENTS);
         registerEntityEquipmentArray(ClientboundPackets1_19_1.ENTITY_EQUIPMENT);
         registerClickWindow1_17_1(ServerboundPackets1_19_3.CLICK_WINDOW);
         registerTradeList1_19(ClientboundPackets1_19_1.TRADE_LIST);
-        registerCreativeInvAction(ServerboundPackets1_19_3.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerCreativeInvAction(ServerboundPackets1_19_3.CREATIVE_INVENTORY_ACTION);
         registerWindowPropertyEnchantmentHandler(ClientboundPackets1_19_1.WINDOW_PROPERTY);
         registerSpawnParticle1_19(ClientboundPackets1_19_1.SPAWN_PARTICLE);
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_4to1_19_3/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_4to1_19_3/packets/InventoryPackets.java
@@ -86,12 +86,12 @@ public final class InventoryPackets extends ItemRewriter<ClientboundPackets1_19_
         registerSetCooldown(ClientboundPackets1_19_3.COOLDOWN);
         registerWindowItems1_17_1(ClientboundPackets1_19_3.WINDOW_ITEMS);
         registerSetSlot1_17_1(ClientboundPackets1_19_3.SET_SLOT);
-        registerAdvancements(ClientboundPackets1_19_3.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerAdvancements(ClientboundPackets1_19_3.ADVANCEMENTS);
         registerEntityEquipmentArray(ClientboundPackets1_19_3.ENTITY_EQUIPMENT);
         registerTradeList1_19(ClientboundPackets1_19_3.TRADE_LIST);
         registerWindowPropertyEnchantmentHandler(ClientboundPackets1_19_3.WINDOW_PROPERTY);
         registerSpawnParticle1_19(ClientboundPackets1_19_3.SPAWN_PARTICLE);
-        registerCreativeInvAction(ServerboundPackets1_19_4.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerCreativeInvAction(ServerboundPackets1_19_4.CREATIVE_INVENTORY_ACTION);
         registerClickWindow1_17_1(ServerboundPackets1_19_4.CLICK_WINDOW);
 
         new RecipeRewriter1_19_3<ClientboundPackets1_19_3>(protocol) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/InventoryPackets.java
@@ -41,7 +41,7 @@ public final class InventoryPackets extends ItemRewriter<ClientboundPackets1_18,
         registerSetCooldown(ClientboundPackets1_18.COOLDOWN);
         registerWindowItems1_17_1(ClientboundPackets1_18.WINDOW_ITEMS);
         registerSetSlot1_17_1(ClientboundPackets1_18.SET_SLOT);
-        registerAdvancements(ClientboundPackets1_18.ADVANCEMENTS, Type.ITEM1_13_2);
+        registerAdvancements(ClientboundPackets1_18.ADVANCEMENTS);
         registerEntityEquipmentArray(ClientboundPackets1_18.ENTITY_EQUIPMENT);
         protocol.registerClientbound(ClientboundPackets1_18.SPAWN_PARTICLE, new PacketHandlers() {
             @Override
@@ -74,7 +74,7 @@ public final class InventoryPackets extends ItemRewriter<ClientboundPackets1_18,
         });
 
         registerClickWindow1_17_1(ServerboundPackets1_19.CLICK_WINDOW);
-        registerCreativeInvAction(ServerboundPackets1_19.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerCreativeInvAction(ServerboundPackets1_19.CREATIVE_INVENTORY_ACTION);
 
         registerWindowPropertyEnchantmentHandler(ClientboundPackets1_18.WINDOW_PROPERTY);
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20to1_19_4/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20to1_19_4/packets/InventoryPackets.java
@@ -57,7 +57,7 @@ public final class InventoryPackets extends ItemRewriter<ClientboundPackets1_19_
         registerEntityEquipmentArray(ClientboundPackets1_19_4.ENTITY_EQUIPMENT);
         registerClickWindow1_17_1(ServerboundPackets1_19_4.CLICK_WINDOW);
         registerTradeList1_19(ClientboundPackets1_19_4.TRADE_LIST);
-        registerCreativeInvAction(ServerboundPackets1_19_4.CREATIVE_INVENTORY_ACTION, Type.ITEM1_13_2);
+        registerCreativeInvAction(ServerboundPackets1_19_4.CREATIVE_INVENTORY_ACTION);
         registerWindowPropertyEnchantmentHandler(ClientboundPackets1_19_4.WINDOW_PROPERTY);
         registerSpawnParticle1_19(ClientboundPackets1_19_4.SPAWN_PARTICLE);
 


### PR DESCRIPTION
Improves API usage by using the existing constructor parameters in ItemRewriter implementations.