### PR TITLE
Port of internals and API to ProtocolVersion

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/ViaAPI.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/ViaAPI.java
@@ -27,10 +27,13 @@ import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.legacy.LegacyViaAPI;
 import com.viaversion.viaversion.api.platform.ViaPlatform;
 import com.viaversion.viaversion.api.protocol.ProtocolManager;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.protocol.version.ServerProtocolVersion;
 import io.netty.buffer.ByteBuf;
 import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -80,7 +83,18 @@ public interface ViaAPI<T> {
      * @param player the platform's player object, e.g. Bukkit this is Player
      * @return protocol version, for example (47=1.8-1.8.8, 107=1.9, 108=1.9.1), or -1 if no longer connected
      */
-    int getPlayerVersion(T player);
+    default int getPlayerVersion(T player) {
+        return getPlayerProtocolVersion(player).getVersion();
+    }
+
+    /**
+     * Returns the protocol version of a player.
+     * This will also retrieve the version from ProtocolSupport if it's being used.
+     *
+     * @param player the platform's player object, e.g. Bukkit this is Player
+     * @return the protocol version object (see {@link ProtocolVersion}), or ProtocolVersion.unknown if not connected
+     */
+    ProtocolVersion getPlayerProtocolVersion(T player);
 
     /**
      * Returns the protocol version of a player.
@@ -88,7 +102,19 @@ public interface ViaAPI<T> {
      * @param uuid UUID of a player
      * @return protocol version, for example (47=1.8-1.8.8, 107=1.9, 108=1.9.1), or -1 if not connected
      */
-    int getPlayerVersion(UUID uuid);
+    default int getPlayerVersion(UUID uuid) {
+        return getPlayerProtocolVersion(uuid).getVersion();
+    }
+
+
+    /**
+     * Returns the protocol version of a player.
+     * This will also retrieve the version from ProtocolSupport if it's being used.
+     *
+     * @param uuid UUID of a player
+     * @return the protocol version object (see {@link ProtocolVersion}), or ProtocolVersion.unknown if not connected
+     */
+    ProtocolVersion getPlayerProtocolVersion(UUID uuid);
 
     /**
      * Returns whether Via injected into this player connection.
@@ -131,6 +157,16 @@ public interface ViaAPI<T> {
      */
     void sendRawPacket(UUID uuid, ByteBuf packet);
 
+    @Deprecated
+    default SortedSet<Integer> getSupportedVersions() {
+        return getSupportedProtocolVersions().stream().map(ProtocolVersion::getVersion).collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    @Deprecated
+    default SortedSet<Integer> getFullSupportedVersions() {
+        return getFullSupportedProtocolVersions().stream().map(ProtocolVersion::getVersion).collect(Collectors.toCollection(TreeSet::new));
+    }
+
     /**
      * Returns the supported protocol versions.
      * This method removes any blocked protocol versions.
@@ -138,14 +174,15 @@ public interface ViaAPI<T> {
      * @return a sorted set of protocol versions
      * @see #getFullSupportedVersions() for a full list
      */
-    SortedSet<Integer> getSupportedVersions();
+    SortedSet<ProtocolVersion> getSupportedProtocolVersions();
+
 
     /**
      * Returns the supported protocol versions, including blocked protocols.
      *
      * @return a sorted set of protocol versions
      */
-    SortedSet<Integer> getFullSupportedVersions();
+    SortedSet<ProtocolVersion> getFullSupportedProtocolVersions();
 
     /**
      * Returns legacy api only applicable on/to legacy versions.

--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -273,17 +273,6 @@ public interface ViaVersionConfig extends Config {
     BlockedProtocolVersions blockedProtocolVersions();
 
     /**
-     * Get the blocked protocols
-     *
-     * @return An Integer list
-     * @deprecated use {@link #blockedProtocolVersions()}
-     */
-    @Deprecated/*(forRemoval = true)*/
-    default IntSet getBlockedProtocols() {
-        return blockedProtocolVersions().singleBlockedVersions();
-    }
-
-    /**
      * Get the custom disconnect message
      *
      * @return Disconnect message

--- a/api/src/main/java/com/viaversion/viaversion/api/platform/ProtocolDetectorService.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/platform/ProtocolDetectorService.java
@@ -22,6 +22,7 @@
  */
 package com.viaversion.viaversion.api.platform;
 
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 
 public interface ProtocolDetectorService {
@@ -32,7 +33,7 @@ public interface ProtocolDetectorService {
      * @param serverName name of the proxied server
      * @return protocol version of the proxied server, or -1 if unknown
      */
-    int serverProtocolVersion(String serverName);
+    ProtocolVersion serverProtocolVersion(String serverName);
 
     /**
      * Probes all registered proxied servers for their protocol version.

--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
@@ -31,6 +31,7 @@ import com.viaversion.viaversion.api.protocol.packet.ServerboundPacketType;
 import com.viaversion.viaversion.api.protocol.packet.VersionedPacketTransformer;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.protocol.version.ServerProtocolVersion;
+import com.viaversion.viaversion.api.protocol.version.VersionType;
 import io.netty.buffer.ByteBuf;
 import java.util.Collection;
 import java.util.List;
@@ -62,21 +63,8 @@ public interface ProtocolManager {
      * @param clientVersion client protocol version
      * @param serverVersion server protocol version
      * @return protocol if present, else null
-     * @see #getProtocolPath(int, int) to get a full path of Protocols between a larger gap of versions
      */
-    default @Nullable Protocol getProtocol(ProtocolVersion clientVersion, ProtocolVersion serverVersion) {
-        return getProtocol(clientVersion.getVersion(), serverVersion.getVersion());
-    }
-
-    /**
-     * Returns a protocol transforming packets for server version to the given client version.
-     *
-     * @param clientVersion client protocol version
-     * @param serverVersion server protocol version
-     * @return protocol if present, else null
-     * @see #getProtocolPath(int, int) to get a full path of Protocols between a larger gap of versions
-     */
-    @Nullable Protocol getProtocol(int clientVersion, int serverVersion);
+    @Nullable Protocol getProtocol(ProtocolVersion clientVersion, ProtocolVersion serverVersion);
 
     /**
      * Returns the base protocol handling serverbound handshake packets.
@@ -93,7 +81,7 @@ public interface ProtocolManager {
      * @return base protocol for the given server protocol version
      * @throws IllegalStateException if no base protocol could be found
      */
-    Protocol getBaseProtocol(int serverVersion);
+    Protocol getBaseProtocol(ProtocolVersion serverVersion);
 
     /**
      * Returns an immutable collection of registered protocols.
@@ -128,7 +116,7 @@ public interface ProtocolManager {
      * @param serverVersion          output server protocol version the protocol converts to
      * @throws IllegalArgumentException if a supported client protocol version is equal to the server protocol version
      */
-    void registerProtocol(Protocol protocol, List<Integer> supportedClientVersion, int serverVersion);
+    void registerProtocol(Protocol protocol, List<ProtocolVersion> supportedClientVersion, ProtocolVersion serverVersion);
 
     /**
      * Registers and initializes a base protocol. Base Protocols registered later have higher priority.
@@ -138,7 +126,7 @@ public interface ProtocolManager {
      * @param supportedProtocols protocol versions supported by the base protocol
      * @throws IllegalArgumentException if the protocol is not a base protocol as given by {@link Protocol#isBaseProtocol()}
      */
-    void registerBaseProtocol(Protocol baseProtocol, Range<Integer> supportedProtocols);
+    void registerBaseProtocol(Protocol baseProtocol, Range<ProtocolVersion> supportedProtocols);
 
     /**
      * Calculates and returns the protocol path from a client protocol version to server protocol version.
@@ -148,7 +136,7 @@ public interface ProtocolManager {
      * @param serverVersion desired output server protocol version
      * @return path generated, or null if not supported or the length exceeds {@link #getMaxProtocolPathSize()}
      */
-    @Nullable List<ProtocolPathEntry> getProtocolPath(int clientVersion, int serverVersion);
+    @Nullable List<ProtocolPathEntry> getProtocolPath(ProtocolVersion clientVersion, ProtocolVersion serverVersion);
 
     /**
      * Returns a versioned packet transformer to transform and send packets from a given base version to any client version supported by Via.
@@ -226,14 +214,14 @@ public interface ProtocolManager {
     }
 
     /**
-     * Returns the maximum protocol path size applied to {@link #getProtocolPath(int, int)}.
+     * Returns the maximum protocol path size applied to {@link #getProtocolPath(ProtocolVersion, ProtocolVersion)}.
      *
      * @return maximum protocol path size
      */
     int getMaxProtocolPathSize();
 
     /**
-     * Sets the maximum protocol path size applied to {@link #getProtocolPath(int, int)}.
+     * Sets the maximum protocol path size applied to {@link #getProtocolPath(ProtocolVersion, ProtocolVersion)}.
      * Its default is 50.
      *
      * @param maxProtocolPathSize maximum protocol path size
@@ -245,7 +233,7 @@ public interface ProtocolManager {
      *
      * @return sorted, immutable set of supported protocol versions
      */
-    SortedSet<Integer> getSupportedVersions();
+    SortedSet<ProtocolVersion> getSupportedVersions();
 
     /**
      * Check if this plugin is useful to the server.

--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolPathEntry.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolPathEntry.java
@@ -22,6 +22,8 @@
  */
 package com.viaversion.viaversion.api.protocol;
 
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+
 public interface ProtocolPathEntry {
 
     /**
@@ -30,7 +32,7 @@ public interface ProtocolPathEntry {
      *
      * @return output protocol version after transformation
      */
-    int outputProtocolVersion();
+    ProtocolVersion outputProtocolVersion();
 
     /**
      * Returns the protocol to be applied with this entry.
@@ -39,13 +41,4 @@ public interface ProtocolPathEntry {
      */
     Protocol<?, ?, ?, ?> protocol();
 
-    @Deprecated/*(forRemoval = true)*/
-    default int getOutputProtocolVersion() {
-        return outputProtocolVersion();
-    }
-
-    @Deprecated/*(forRemoval = true)*/
-    default Protocol getProtocol() {
-        return protocol();
-    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolPathKey.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolPathKey.java
@@ -22,6 +22,8 @@
  */
 package com.viaversion.viaversion.api.protocol;
 
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+
 public interface ProtocolPathKey {
 
     /**
@@ -29,22 +31,13 @@ public interface ProtocolPathKey {
      *
      * @return client protocol version
      */
-    int clientProtocolVersion();
+    ProtocolVersion clientProtocolVersion();
 
     /**
      * Returns the server protocol version.
      *
      * @return server protocol version
      */
-    int serverProtocolVersion();
+    ProtocolVersion serverProtocolVersion();
 
-    @Deprecated/*(forRemoval = true)*/
-    default int getClientProtocolVersion() {
-        return clientProtocolVersion();
-    }
-
-    @Deprecated/*(forRemoval = true)*/
-    default int getServerProtocolVersion() {
-        return serverProtocolVersion();
-    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/version/BlockedProtocolVersions.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/version/BlockedProtocolVersions.java
@@ -22,7 +22,7 @@
  */
 package com.viaversion.viaversion.api.protocol.version;
 
-import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.Set;
 
 public interface BlockedProtocolVersions {
 
@@ -32,26 +32,26 @@ public interface BlockedProtocolVersions {
      * @param protocolVersion protocol version
      * @return whether the given protocol version is blocked
      */
-    boolean contains(int protocolVersion);
+    boolean contains(ProtocolVersion protocolVersion);
 
     /**
      * Returns the boundary below which protocol versions are blocked, or -1 if none is set.
      *
      * @return exclusive boundary below which protocol versions are blocked, or -1 if none
      */
-    int blocksBelow();
+    ProtocolVersion blocksBelow();
 
     /**
      * Returns the boundary above which protocol versions are blocked, or -1 if none is set.
      *
      * @return exclusive boundary above which protocol versions are blocked, or -1 if none
      */
-    int blocksAbove();
+    ProtocolVersion blocksAbove();
 
     /**
      * Returns a set of blocked protocol versions between the outer block ranges.
      *
      * @return set of blocked protocol versions between the outer block ranges
      */
-    IntSet singleBlockedVersions();
+    Set<ProtocolVersion> singleBlockedVersions();
 }

--- a/bukkit-legacy/src/main/java/com/viaversion/viaversion/bukkit/util/ProtocolSupportUtil.java
+++ b/bukkit-legacy/src/main/java/com/viaversion/viaversion/bukkit/util/ProtocolSupportUtil.java
@@ -19,6 +19,8 @@ package com.viaversion.viaversion.bukkit.util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import com.viaversion.viaversion.api.protocol.version.VersionType;
 import org.bukkit.entity.Player;
 
 public final class ProtocolSupportUtil {
@@ -38,16 +40,19 @@ public final class ProtocolSupportUtil {
         GET_ID_METHOD = getIdMethod;
     }
 
-    public static int getProtocolVersion(Player player) {
+    public static ProtocolVersion getProtocolVersion(Player player) {
         if (PROTOCOL_VERSION_METHOD == null) {
-            return -1;
+            return ProtocolVersion.unknown;
         }
         try {
-            Object version = PROTOCOL_VERSION_METHOD.invoke(null, player);
-            return (int) GET_ID_METHOD.invoke(version);
+            final Object version = PROTOCOL_VERSION_METHOD.invoke(null, player);
+            final int id = (int) GET_ID_METHOD.invoke(version);
+            final boolean preNetty = id == 78 || id == 74 || id == 73 || id == 61 || id == 60 || id == 51;
+
+            return ProtocolVersion.getProtocol(preNetty ? VersionType.RELEASE_INITIAL : VersionType.RELEASE, id);
         } catch (IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
         }
-        return -1;
+        return ProtocolVersion.unknown;
     }
 }

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19to1_18_2/BlockBreakListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19to1_18_2/BlockBreakListener.java
@@ -53,8 +53,8 @@ public final class BlockBreakListener extends ViaBukkitListener {
         }
 
         // We need to resend the block entity data after an ack has been sent out
-        final int serverProtocolVersion = Via.getAPI().getServerVersion().highestSupportedVersion();
-        final long delay = serverProtocolVersion > ProtocolVersion.v1_8.getVersion() && serverProtocolVersion < ProtocolVersion.v1_14.getVersion() ? 2 : 1;
+        final ProtocolVersion serverProtocolVersion = Via.getAPI().getServerVersion().highestSupportedProtocolVersion();
+        final long delay = serverProtocolVersion.higherThan(ProtocolVersion.v1_8) && serverProtocolVersion.lowerThan(ProtocolVersion.v1_14) ? 2 : 1;
         getPlugin().getServer().getScheduler().runTaskLater(getPlugin(), () -> {
             final BlockState state = block.getState();
             if (isBlockEntity(state)) {

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19to1_18_2/BlockBreakListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_19to1_18_2/BlockBreakListener.java
@@ -54,7 +54,7 @@ public final class BlockBreakListener extends ViaBukkitListener {
 
         // We need to resend the block entity data after an ack has been sent out
         final ProtocolVersion serverProtocolVersion = Via.getAPI().getServerVersion().highestSupportedProtocolVersion();
-        final long delay = serverProtocolVersion.higherThan(ProtocolVersion.v1_8) && serverProtocolVersion.lowerThan(ProtocolVersion.v1_14) ? 2 : 1;
+        final long delay = serverProtocolVersion.newerThan(ProtocolVersion.v1_8) && serverProtocolVersion.olderThan(ProtocolVersion.v1_14) ? 2 : 1;
         getPlugin().getServer().getScheduler().runTaskLater(getPlugin(), () -> {
             final BlockState state = block.getState();
             if (isBlockEntity(state)) {

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaAPI.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaAPI.java
@@ -21,6 +21,7 @@ import com.viaversion.viaversion.ViaAPIBase;
 import com.viaversion.viaversion.ViaVersionPlugin;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.bukkit.util.ProtocolSupportUtil;
 import io.netty.buffer.ByteBuf;
 import java.util.UUID;
@@ -35,15 +36,15 @@ public class BukkitViaAPI extends ViaAPIBase<Player> {
     }
 
     @Override
-    public int getPlayerVersion(Player player) {
-        return getPlayerVersion(player.getUniqueId());
+    public ProtocolVersion getPlayerProtocolVersion(Player player) {
+        return getPlayerProtocolVersion(player.getUniqueId());
     }
 
     @Override
-    public int getPlayerVersion(UUID uuid) {
+    public ProtocolVersion getPlayerProtocolVersion(UUID uuid) {
         UserConnection connection = Via.getManager().getConnectionManager().getConnectedClient(uuid);
         if (connection != null) {
-            return connection.getProtocolInfo().protocolVersion().getVersion();
+            return connection.getProtocolInfo().protocolVersion();
         }
 
         if (isProtocolSupport()) {
@@ -52,7 +53,7 @@ public class BukkitViaAPI extends ViaAPIBase<Player> {
                 return ProtocolSupportUtil.getProtocolVersion(player);
             }
         }
-        return -1;
+        return ProtocolVersion.unknown;
     }
 
     @Override

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitInventoryQuickMoveProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitInventoryQuickMoveProvider.java
@@ -71,7 +71,7 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
             if (slotId >= 36 && slotId <= 45) {
                 final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
                 // this seems to be working just fine.
-                if (protocol.equals(ProtocolVersion.v1_8)) { // TODO | use equalTo here
+                if (protocol.equalTo(ProtocolVersion.v1_8)) {
                     return false;
                 }
             }
@@ -102,7 +102,7 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
         InventoryType tinvtype = tinv == null ? null : tinv.getType(); // can this even be null?
         if (tinvtype != null) {
             final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
-            if (protocol.equals(ProtocolVersion.v1_8)) { // TODO | use equalTo here
+            if (protocol.equalTo(ProtocolVersion.v1_8)) {
                 if (tinvtype == InventoryType.BREWING) {
                     // 1.9 added the blaze powder slot to brewing stand fix for 1.8 servers
                     if (slotId >= 5 && slotId <= 40) {
@@ -131,9 +131,9 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
             ReflectionUtil.set(packet, "d", storage.getActionId());
             ReflectionUtil.set(packet, "item", nmsItem);
             final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
-            if (protocol.equals(ProtocolVersion.v1_8)) { // TODO | use equalTo here
+            if (protocol.equalTo(ProtocolVersion.v1_8)) {
                 ReflectionUtil.set(packet, "shift", 1);
-            } else if (protocol.higherThanOrEquals(ProtocolVersion.v1_9)) {
+            } else if (protocol.newerThanOrEquals(ProtocolVersion.v1_9)) {
                 ReflectionUtil.set(packet, "shift", clickTypeEnum);
             }
         } catch (Exception e) {
@@ -170,7 +170,7 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
         try {
             this.windowClickPacketClass = NMSUtil.nms("PacketPlayInWindowClick");
             final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
-            if (protocol.higherThanOrEquals(ProtocolVersion.v1_9)) {
+            if (protocol.newerThanOrEquals(ProtocolVersion.v1_9)) {
                 Class<?> eclassz = NMSUtil.nms("InventoryClickType");
                 Object[] constants = eclassz.getEnumConstants();
                 this.clickTypeEnum = constants[1]; // QUICK_MOVE
@@ -199,6 +199,6 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
 
     private boolean isSupported() {
         final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
-        return protocol.higherThanOrEquals(ProtocolVersion.v1_8) && protocol.lowerThanOrEquals(ProtocolVersion.v1_11_1);
+        return protocol.newerThanOrEquals(ProtocolVersion.v1_8) && protocol.olderThanOrEquals(ProtocolVersion.v1_11_1);
     }
 }

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitInventoryQuickMoveProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitInventoryQuickMoveProvider.java
@@ -69,9 +69,9 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
             // windowId is always 0 for player inventory.
             // This has almost definitely something to do with the offhand slot.
             if (slotId >= 36 && slotId <= 45) {
-                int protocolId = Via.getAPI().getServerVersion().lowestSupportedVersion();
+                final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
                 // this seems to be working just fine.
-                if (protocolId == ProtocolVersion.v1_8.getVersion()) {
+                if (protocol.equals(ProtocolVersion.v1_8)) { // TODO | use equalTo here
                     return false;
                 }
             }
@@ -101,8 +101,8 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
         Inventory tinv = inv.getTopInventory();
         InventoryType tinvtype = tinv == null ? null : tinv.getType(); // can this even be null?
         if (tinvtype != null) {
-            int protocolId = Via.getAPI().getServerVersion().lowestSupportedVersion();
-            if (protocolId == ProtocolVersion.v1_8.getVersion()) {
+            final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
+            if (protocol.equals(ProtocolVersion.v1_8)) { // TODO | use equalTo here
                 if (tinvtype == InventoryType.BREWING) {
                     // 1.9 added the blaze powder slot to brewing stand fix for 1.8 servers
                     if (slotId >= 5 && slotId <= 40) {
@@ -130,10 +130,10 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
             ReflectionUtil.set(packet, "button", 0); // shift + left mouse click
             ReflectionUtil.set(packet, "d", storage.getActionId());
             ReflectionUtil.set(packet, "item", nmsItem);
-            int protocolId = Via.getAPI().getServerVersion().lowestSupportedVersion();
-            if (protocolId == ProtocolVersion.v1_8.getVersion()) {
+            final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
+            if (protocol.equals(ProtocolVersion.v1_8)) { // TODO | use equalTo here
                 ReflectionUtil.set(packet, "shift", 1);
-            } else if (protocolId >= ProtocolVersion.v1_9.getVersion()) { // 1.9+
+            } else if (protocol.higherThanOrEquals(ProtocolVersion.v1_9)) {
                 ReflectionUtil.set(packet, "shift", clickTypeEnum);
             }
         } catch (Exception e) {
@@ -169,8 +169,8 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
         }
         try {
             this.windowClickPacketClass = NMSUtil.nms("PacketPlayInWindowClick");
-            int protocolId = Via.getAPI().getServerVersion().lowestSupportedVersion();
-            if (protocolId >= ProtocolVersion.v1_9.getVersion()) {
+            final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
+            if (protocol.higherThanOrEquals(ProtocolVersion.v1_9)) {
                 Class<?> eclassz = NMSUtil.nms("InventoryClickType");
                 Object[] constants = eclassz.getEnumConstants();
                 this.clickTypeEnum = constants[1]; // QUICK_MOVE
@@ -198,7 +198,7 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
     }
 
     private boolean isSupported() {
-        int protocolId = Via.getAPI().getServerVersion().lowestSupportedVersion();
-        return protocolId >= ProtocolVersion.v1_8.getVersion() && protocolId <= ProtocolVersion.v1_11_1.getVersion(); // 1.8-1.11.2, not needed with 1.12
+        final ProtocolVersion protocol = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
+        return protocol.higherThanOrEquals(ProtocolVersion.v1_8) && protocol.lowerThanOrEquals(ProtocolVersion.v1_11_1);
     }
 }

--- a/bungee/src/main/java/com/viaversion/viaversion/bungee/handlers/BungeeServerHandler.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/bungee/handlers/BungeeServerHandler.java
@@ -99,14 +99,14 @@ public class BungeeServerHandler implements Listener {
             user.put(new BungeeStorage(event.getPlayer()));
         }
 
-        int serverProtocolVersion = Via.proxyPlatform().protocolDetectorService().serverProtocolVersion(event.getTarget().getName());
-        int clientProtocolVersion = user.getProtocolInfo().protocolVersion().getVersion();
+        ProtocolVersion serverProtocolVersion = Via.proxyPlatform().protocolDetectorService().serverProtocolVersion(event.getTarget().getName());
+        ProtocolVersion clientProtocolVersion = user.getProtocolInfo().protocolVersion();
         List<ProtocolPathEntry> protocols = Via.getManager().getProtocolManager().getProtocolPath(clientProtocolVersion, serverProtocolVersion);
 
         // Check if ViaVersion can support that version
         try {
             Object handshake = getHandshake.invoke(event.getPlayer().getPendingConnection());
-            setProtocol.invoke(handshake, protocols == null ? clientProtocolVersion : serverProtocolVersion);
+            setProtocol.invoke(handshake, protocols == null ? clientProtocolVersion.getVersion() : serverProtocolVersion.getVersion());
         } catch (InvocationTargetException | IllegalAccessException e) {
             e.printStackTrace();
         }
@@ -172,7 +172,7 @@ public class BungeeServerHandler implements Listener {
 
         String serverName = server.getInfo().getName();
         storage.setCurrentServer(serverName);
-        ProtocolVersion serverProtocolVersion = ProtocolVersion.getProtocol(Via.proxyPlatform().protocolDetectorService().serverProtocolVersion(serverName));
+        ProtocolVersion serverProtocolVersion = Via.proxyPlatform().protocolDetectorService().serverProtocolVersion(serverName);
         if (serverProtocolVersion.lowerThanOrEquals(ProtocolVersion.v1_8) && storage.getBossbar() != null) { // 1.8 doesn't have BossBar packet
             // This ensures we can encode it properly as only the 1.9 protocol is currently implemented.
             if (user.getProtocolInfo().getPipeline().contains(Protocol1_9To1_8.class)) {
@@ -190,8 +190,7 @@ public class BungeeServerHandler implements Listener {
         ProtocolVersion previousServerProtocol = info.serverProtocolVersion();
 
         // Refresh the pipes
-        List<ProtocolPathEntry> protocolPath = Via.getManager().getProtocolManager()
-            .getProtocolPath(info.protocolVersion().getVersion(), serverProtocolVersion.getVersion());
+        List<ProtocolPathEntry> protocolPath = Via.getManager().getProtocolManager().getProtocolPath(info.protocolVersion(), serverProtocolVersion);
         ProtocolPipeline pipeline = user.getProtocolInfo().getPipeline();
         user.clearStoredObjects(true);
         pipeline.cleanPipes();
@@ -208,7 +207,7 @@ public class BungeeServerHandler implements Listener {
 
         info.setServerProtocolVersion(serverProtocolVersion);
         // Add version-specific base Protocol
-        pipeline.add(Via.getManager().getProtocolManager().getBaseProtocol(serverProtocolVersion.getVersion()));
+        pipeline.add(Via.getManager().getProtocolManager().getBaseProtocol(serverProtocolVersion));
 
         // Workaround 1.13 server change
         boolean toNewId = previousServerProtocol.lowerThan(ProtocolVersion.v1_13) && serverProtocolVersion.higherThanOrEquals(ProtocolVersion.v1_13);

--- a/bungee/src/main/java/com/viaversion/viaversion/bungee/platform/BungeeViaAPI.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/bungee/platform/BungeeViaAPI.java
@@ -19,6 +19,7 @@ package com.viaversion.viaversion.bungee.platform;
 
 import com.viaversion.viaversion.ViaAPIBase;
 import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.bungee.service.ProtocolDetectorService;
 import io.netty.buffer.ByteBuf;
 import net.md_5.bungee.api.config.ServerInfo;
@@ -27,8 +28,8 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 public class BungeeViaAPI extends ViaAPIBase<ProxiedPlayer> {
 
     @Override
-    public int getPlayerVersion(ProxiedPlayer player) {
-        return getPlayerVersion(player.getUniqueId());
+    public ProtocolVersion getPlayerProtocolVersion(ProxiedPlayer player) {
+        return getPlayerProtocolVersion(player.getUniqueId());
     }
 
     @Override

--- a/bungee/src/main/java/com/viaversion/viaversion/bungee/providers/BungeeVersionProvider.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/bungee/providers/BungeeVersionProvider.java
@@ -50,7 +50,7 @@ public class BungeeVersionProvider extends BaseVersionProvider {
 
         // Older than bungee supports, get the lowest version
         if (clientProtocolVersion.getVersion() < sorted.get(0)) {
-            return ProtocolVersion.getProtocol(getLowestSupportedVersion());
+            return getLowestSupportedVersion();
         }
 
         // Loop through all protocols to get the closest protocol id that bungee supports (and that viaversion does too)
@@ -67,15 +67,15 @@ public class BungeeVersionProvider extends BaseVersionProvider {
         return clientProtocolVersion;
     }
 
-    public static int getLowestSupportedVersion() {
+    public static ProtocolVersion getLowestSupportedVersion() {
         List<Integer> list;
         try {
             list = ReflectionUtil.getStatic(ProtocolConstants.class, "SUPPORTED_VERSION_IDS", List.class);
-            return list.get(0);
+            return ProtocolVersion.getProtocol(list.get(0));
         } catch (NoSuchFieldException | IllegalAccessException e) {
             e.printStackTrace();
         }
         // Fallback
-        return ProxyServer.getInstance().getProtocolVersion();
+        return ProtocolVersion.getProtocol(ProxyServer.getInstance().getProtocolVersion());
     }
 }

--- a/bungee/src/main/java/com/viaversion/viaversion/bungee/service/ProtocolDetectorService.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/bungee/service/ProtocolDetectorService.java
@@ -18,6 +18,7 @@
 package com.viaversion.viaversion.bungee.service;
 
 import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.bungee.platform.BungeeViaConfig;
 import com.viaversion.viaversion.bungee.providers.BungeeVersionProvider;
 import com.viaversion.viaversion.platform.AbstractProtocolDetectorService;
@@ -38,7 +39,7 @@ public final class ProtocolDetectorService extends AbstractProtocolDetectorServi
                 return;
             }
 
-            final int oldProtocolVersion = serverProtocolVersion(serverName);
+            final int oldProtocolVersion = serverProtocolVersion(serverName).getVersion();
             if (oldProtocolVersion == serverPing.getVersion().getProtocol()) {
                 // Same value as previously
                 return;
@@ -87,7 +88,7 @@ public final class ProtocolDetectorService extends AbstractProtocolDetectorServi
     }
 
     @Override
-    protected int lowestSupportedProtocolVersion() {
+    protected ProtocolVersion lowestSupportedProtocolVersion() {
         return BungeeVersionProvider.getLowestSupportedVersion();
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/ViaAPIBase.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaAPIBase.java
@@ -22,6 +22,7 @@ import com.viaversion.viaversion.api.ViaAPI;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.legacy.LegacyViaAPI;
 import com.viaversion.viaversion.api.protocol.version.BlockedProtocolVersions;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.protocol.version.ServerProtocolVersion;
 import com.viaversion.viaversion.legacy.LegacyAPI;
 import io.netty.buffer.ByteBuf;
@@ -40,9 +41,9 @@ public abstract class ViaAPIBase<T> implements ViaAPI<T> {
     }
 
     @Override
-    public int getPlayerVersion(UUID uuid) {
+    public ProtocolVersion getPlayerProtocolVersion(UUID uuid) {
         UserConnection connection = Via.getManager().getConnectionManager().getConnectedClient(uuid);
-        return connection != null ? connection.getProtocolInfo().protocolVersion().getVersion() : -1;
+        return connection != null ? connection.getProtocolInfo().protocolVersion() : ProtocolVersion.unknown;
     }
 
     @Override
@@ -71,15 +72,15 @@ public abstract class ViaAPIBase<T> implements ViaAPI<T> {
     }
 
     @Override
-    public SortedSet<Integer> getSupportedVersions() {
-        SortedSet<Integer> outputSet = new TreeSet<>(Via.getManager().getProtocolManager().getSupportedVersions());
+    public SortedSet<ProtocolVersion> getSupportedProtocolVersions() {
+        SortedSet<ProtocolVersion> outputSet = new TreeSet<>(Via.getManager().getProtocolManager().getSupportedVersions());
         BlockedProtocolVersions blockedVersions = Via.getPlatform().getConf().blockedProtocolVersions();
         outputSet.removeIf(blockedVersions::contains);
         return outputSet;
     }
 
     @Override
-    public SortedSet<Integer> getFullSupportedVersions() {
+    public SortedSet<ProtocolVersion> getFullSupportedProtocolVersions() {
         return Via.getManager().getProtocolManager().getSupportedVersions();
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -207,7 +207,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         if (lowerBound.isKnown() || upperBound.isKnown()) {
             final ProtocolVersion finalLowerBound = lowerBound;
             final ProtocolVersion finalUpperBound = upperBound;
-            blockedProtocols.removeIf((Predicate<? super ProtocolVersion>) version -> {
+            blockedProtocols.removeIf(version -> {
                 if (finalLowerBound.isKnown() && version.lowerThan(finalLowerBound) || finalUpperBound.isKnown() && version.higherThan(finalUpperBound)) {
                     LOGGER.warning("Blocked protocol version " + version + " already covered by upper or lower bound");
                     return true;

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -22,15 +22,16 @@ import com.viaversion.viaversion.api.configuration.ViaVersionConfig;
 import com.viaversion.viaversion.api.minecraft.WorldIdentifiers;
 import com.viaversion.viaversion.api.protocol.version.BlockedProtocolVersions;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import com.viaversion.viaversion.api.protocol.version.VersionType;
 import com.viaversion.viaversion.protocol.BlockedProtocolVersionsImpl;
 import com.viaversion.viaversion.util.Config;
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.ints.IntSet;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract class AbstractViaConfig extends Config implements ViaVersionConfig {
@@ -161,9 +162,9 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private BlockedProtocolVersions loadBlockedProtocolVersions() {
         List<Integer> blockProtocols = getListSafe("block-protocols", Integer.class, "Invalid blocked version protocol found in config: '%s'");
         List<String> blockVersions = getListSafe("block-versions", String.class, "Invalid blocked version found in config: '%s'");
-        IntSet blockedProtocols = new IntOpenHashSet(blockProtocols);
-        int lowerBound = -1;
-        int upperBound = -1;
+        ObjectSet<ProtocolVersion> blockedProtocols = blockProtocols.stream().map(integer -> ProtocolVersion.getProtocol(VersionType.RELEASE, integer)).collect(ObjectOpenHashSet::of, ObjectSet::add, ObjectSet::addAll);
+        ProtocolVersion lowerBound = ProtocolVersion.unknown;
+        ProtocolVersion upperBound = ProtocolVersion.unknown;
         for (String s : blockVersions) {
             if (s.isEmpty()) {
                 continue;
@@ -178,15 +179,15 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
                 }
 
                 if (c == '<') {
-                    if (lowerBound != -1) {
+                    if (lowerBound.isKnown()) {
                         LOGGER.warning("Already set lower bound " + lowerBound + " overridden by " + protocolVersion.getName());
                     }
-                    lowerBound = protocolVersion.getVersion();
+                    lowerBound = protocolVersion;
                 } else {
-                    if (upperBound != -1) {
+                    if (upperBound.isKnown()) {
                         LOGGER.warning("Already set upper bound " + upperBound + " overridden by " + protocolVersion.getName());
                     }
-                    upperBound = protocolVersion.getVersion();
+                    upperBound = protocolVersion;
                 }
                 continue;
             }
@@ -197,19 +198,18 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
             }
 
             // Add single protocol version and check for duplication
-            if (!blockedProtocols.add(protocolVersion.getVersion())) {
-                LOGGER.warning("Duplicated blocked protocol version " + protocolVersion.getName() + "/" + protocolVersion.getVersion());
+            if (!blockedProtocols.add(protocolVersion)) {
+                LOGGER.warning("Duplicated blocked protocol version " + protocolVersion);
             }
         }
 
         // Check for duplicated entries
-        if (lowerBound != -1 || upperBound != -1) {
-            final int finalLowerBound = lowerBound;
-            final int finalUpperBound = upperBound;
-            blockedProtocols.removeIf((IntPredicate) version -> {
-                if (finalLowerBound != -1 && version < finalLowerBound || finalUpperBound != -1 && version > finalUpperBound) {
-                    ProtocolVersion protocolVersion = ProtocolVersion.getProtocol(version);
-                    LOGGER.warning("Blocked protocol version " + protocolVersion.getName() + "/" + protocolVersion.getVersion() + " already covered by upper or lower bound");
+        if (lowerBound.isKnown() || upperBound.isKnown()) {
+            final ProtocolVersion finalLowerBound = lowerBound;
+            final ProtocolVersion finalUpperBound = upperBound;
+            blockedProtocols.removeIf((Predicate<? super ProtocolVersion>) version -> {
+                if (finalLowerBound.isKnown() && version.lowerThan(finalLowerBound) || finalUpperBound.isKnown() && version.higherThan(finalUpperBound)) {
+                    LOGGER.warning("Blocked protocol version " + version.getName() + "/" + version.getVersion() + " already covered by upper or lower bound");
                     return true;
                 }
                 return false;

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -209,7 +209,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
             final ProtocolVersion finalUpperBound = upperBound;
             blockedProtocols.removeIf((Predicate<? super ProtocolVersion>) version -> {
                 if (finalLowerBound.isKnown() && version.lowerThan(finalLowerBound) || finalUpperBound.isKnown() && version.higherThan(finalUpperBound)) {
-                    LOGGER.warning("Blocked protocol version " + version.getName() + "/" + version.getVersion() + " already covered by upper or lower bound");
+                    LOGGER.warning("Blocked protocol version " + version + " already covered by upper or lower bound");
                     return true;
                 }
                 return false;

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -208,7 +208,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
             final ProtocolVersion finalLowerBound = lowerBound;
             final ProtocolVersion finalUpperBound = upperBound;
             blockedProtocols.removeIf(version -> {
-                if (finalLowerBound.isKnown() && version.lowerThan(finalLowerBound) || finalUpperBound.isKnown() && version.higherThan(finalUpperBound)) {
+                if (finalLowerBound.isKnown() && version.olderThan(finalLowerBound) || finalUpperBound.isKnown() && version.newerThan(finalUpperBound)) {
                     LOGGER.warning("Blocked protocol version " + version + " already covered by upper or lower bound");
                     return true;
                 }

--- a/common/src/main/java/com/viaversion/viaversion/dump/VersionInfo.java
+++ b/common/src/main/java/com/viaversion/viaversion/dump/VersionInfo.java
@@ -17,20 +17,21 @@
  */
 package com.viaversion.viaversion.dump;
 
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import java.util.Set;
 
 public class VersionInfo {
     private final String javaVersion;
     private final String operatingSystem;
-    private final int serverProtocol;
-    private final Set<Integer> enabledProtocols;
+    private final ProtocolVersion serverProtocol;
+    private final Set<ProtocolVersion> enabledProtocols;
     private final String platformName;
     private final String platformVersion;
     private final String pluginVersion;
     private final String implementationVersion;
     private final Set<String> subPlatforms;
 
-    public VersionInfo(String javaVersion, String operatingSystem, int serverProtocol, Set<Integer> enabledProtocols,
+    public VersionInfo(String javaVersion, String operatingSystem, ProtocolVersion serverProtocol, Set<ProtocolVersion> enabledProtocols,
                        String platformName, String platformVersion, String pluginVersion, String implementationVersion, Set<String> subPlatforms) {
         this.javaVersion = javaVersion;
         this.operatingSystem = operatingSystem;
@@ -51,11 +52,11 @@ public class VersionInfo {
         return operatingSystem;
     }
 
-    public int getServerProtocol() {
+    public ProtocolVersion getServerProtocol() {
         return serverProtocol;
     }
 
-    public Set<Integer> getEnabledProtocols() {
+    public Set<ProtocolVersion> getEnabledProtocols() {
         return enabledProtocols;
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/platform/AbstractProtocolDetectorService.java
+++ b/common/src/main/java/com/viaversion/viaversion/platform/AbstractProtocolDetectorService.java
@@ -18,6 +18,8 @@
 package com.viaversion.viaversion.platform;
 
 import com.viaversion.viaversion.api.platform.ProtocolDetectorService;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import com.viaversion.viaversion.api.protocol.version.VersionType;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Map;
@@ -33,7 +35,7 @@ public abstract class AbstractProtocolDetectorService implements ProtocolDetecto
     }
 
     @Override
-    public int serverProtocolVersion(final String serverName) {
+    public ProtocolVersion serverProtocolVersion(final String serverName) {
         // Step 1. Check detected
         lock.readLock().lock();
         final int detectedProtocol;
@@ -43,20 +45,20 @@ public abstract class AbstractProtocolDetectorService implements ProtocolDetecto
             lock.readLock().unlock();
         }
         if (detectedProtocol != -1) {
-            return detectedProtocol;
+            return ProtocolVersion.getProtocol(VersionType.RELEASE, detectedProtocol);
         }
 
         // Step 2. Check config (CME moment?)
         final Map<String, Integer> servers = configuredServers();
         final Integer protocol = servers.get(serverName);
         if (protocol != null) {
-            return protocol;
+            return ProtocolVersion.getProtocol(VersionType.RELEASE, protocol);
         }
 
         // Step 3. Use Default (CME moment intensifies?)
         final Integer defaultProtocol = servers.get("default");
         if (defaultProtocol != null) {
-            return defaultProtocol;
+            return ProtocolVersion.getProtocol(VersionType.RELEASE, defaultProtocol);
         }
 
         // Step 4: Use the proxy's lowest supported... *cries*
@@ -95,5 +97,5 @@ public abstract class AbstractProtocolDetectorService implements ProtocolDetecto
 
     protected abstract Map<String, Integer> configuredServers();
 
-    protected abstract int lowestSupportedProtocolVersion();
+    protected abstract ProtocolVersion lowestSupportedProtocolVersion();
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/BlockedProtocolVersionsImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/BlockedProtocolVersionsImpl.java
@@ -18,38 +18,39 @@
 package com.viaversion.viaversion.protocol;
 
 import com.viaversion.viaversion.api.protocol.version.BlockedProtocolVersions;
-import it.unimi.dsi.fastutil.ints.IntSet;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import java.util.Set;
 
 public class BlockedProtocolVersionsImpl implements BlockedProtocolVersions {
-    private final IntSet singleBlockedVersions;
-    private final int blocksBelow;
-    private final int blocksAbove;
+    private final Set<ProtocolVersion> singleBlockedVersions;
+    private final ProtocolVersion blocksBelow;
+    private final ProtocolVersion blocksAbove;
 
-    public BlockedProtocolVersionsImpl(final IntSet singleBlockedVersions, final int blocksBelow, final int blocksAbove) {
+    public BlockedProtocolVersionsImpl(final Set<ProtocolVersion> singleBlockedVersions, final ProtocolVersion blocksBelow, final ProtocolVersion blocksAbove) {
         this.singleBlockedVersions = singleBlockedVersions;
         this.blocksBelow = blocksBelow;
         this.blocksAbove = blocksAbove;
     }
 
     @Override
-    public boolean contains(final int protocolVersion) {
-        return blocksBelow != -1 && protocolVersion < blocksBelow
-                || blocksAbove != -1 && protocolVersion > blocksAbove
+    public boolean contains(final ProtocolVersion protocolVersion) {
+        return blocksBelow.isKnown() && protocolVersion.lowerThan(blocksBelow)
+                || blocksAbove.isKnown() && protocolVersion.higherThan(blocksAbove)
                 || singleBlockedVersions.contains(protocolVersion);
     }
 
     @Override
-    public int blocksBelow() {
+    public ProtocolVersion blocksBelow() {
         return blocksBelow;
     }
 
     @Override
-    public int blocksAbove() {
+    public ProtocolVersion blocksAbove() {
         return blocksAbove;
     }
 
     @Override
-    public IntSet singleBlockedVersions() {
+    public Set<ProtocolVersion> singleBlockedVersions() {
         return singleBlockedVersions;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/BlockedProtocolVersionsImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/BlockedProtocolVersionsImpl.java
@@ -34,8 +34,8 @@ public class BlockedProtocolVersionsImpl implements BlockedProtocolVersions {
 
     @Override
     public boolean contains(final ProtocolVersion protocolVersion) {
-        return blocksBelow.isKnown() && protocolVersion.lowerThan(blocksBelow)
-                || blocksAbove.isKnown() && protocolVersion.higherThan(blocksAbove)
+        return blocksBelow.isKnown() && protocolVersion.olderThan(blocksBelow)
+                || blocksAbove.isKnown() && protocolVersion.newerThan(blocksAbove)
                 || singleBlockedVersions.contains(protocolVersion);
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -134,8 +134,8 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
     public void registerProtocols() {
         // Base Protocol
-        registerBaseProtocol(BASE_PROTOCOL, null);
-        registerBaseProtocol(new BaseProtocol1_7(), Range.lessThan(ProtocolVersion.v1_16));
+        BASE_PROTOCOL.initialize();
+        registerBaseProtocol(new BaseProtocol1_7(), Range.closedOpen(ProtocolVersion.v1_7_1, ProtocolVersion.v1_16));
         registerBaseProtocol(new BaseProtocol1_16(), Range.atLeast(ProtocolVersion.v1_16));
 
         registerProtocol(new Protocol1_9To1_8(), ProtocolVersion.v1_9, ProtocolVersion.v1_8);
@@ -355,7 +355,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
     @Override
     public Protocol getBaseProtocol(ProtocolVersion serverVersion) {
         for (Pair<Range<ProtocolVersion>, Protocol> rangeProtocol : Lists.reverse(baseProtocols)) {
-            if (rangeProtocol.key() != null && rangeProtocol.key().contains(serverVersion)) {
+            if (rangeProtocol.key().contains(serverVersion)) {
                 return rangeProtocol.value();
             }
         }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -79,10 +79,6 @@ import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.Protocol1_9_3T
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.Protocol1_9To1_8;
 import com.viaversion.viaversion.util.Pair;
 import io.netty.buffer.ByteBuf;
-import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectSortedMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -104,6 +100,10 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.logging.Level;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectSortedMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
 
@@ -111,11 +111,11 @@ public class ProtocolManagerImpl implements ProtocolManager {
     private static final Protocol BASE_PROTOCOL = new BaseProtocol();
 
     // Input Version -> Output Version & Protocol (Allows fast lookup)
-    private final Int2ObjectMap<Int2ObjectMap<Protocol>> registryMap = new Int2ObjectOpenHashMap<>(32);
+    private final Object2ObjectMap<ProtocolVersion, Object2ObjectMap<ProtocolVersion, Protocol>> registryMap = new Object2ObjectOpenHashMap<>(32);
     private final Map<Class<? extends Protocol>, Protocol<?, ?, ?, ?>> protocols = new HashMap<>(64);
     private final Map<ProtocolPathKey, List<ProtocolPathEntry>> pathCache = new ConcurrentHashMap<>();
-    private final Set<Integer> supportedVersions = new HashSet<>();
-    private final List<Pair<Range<Integer>, Protocol>> baseProtocols = Lists.newCopyOnWriteArrayList();
+    private final Set<ProtocolVersion> supportedVersions = new HashSet<>();
+    private final List<Pair<Range<ProtocolVersion>, Protocol>> baseProtocols = Lists.newCopyOnWriteArrayList();
 
     private final ReadWriteLock mappingLoaderLock = new ReentrantReadWriteLock();
     private Map<Class<? extends Protocol>, CompletableFuture<Void>> mappingLoaderFutures = new HashMap<>();
@@ -134,12 +134,12 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
     public void registerProtocols() {
         // Base Protocol
-        registerBaseProtocol(BASE_PROTOCOL, Range.lessThan(Integer.MIN_VALUE));
-        registerBaseProtocol(new BaseProtocol1_7(), Range.lessThan(ProtocolVersion.v1_16.getVersion()));
-        registerBaseProtocol(new BaseProtocol1_16(), Range.atLeast(ProtocolVersion.v1_16.getVersion()));
+        registerBaseProtocol(BASE_PROTOCOL, null);
+        registerBaseProtocol(new BaseProtocol1_7(), Range.lessThan(ProtocolVersion.v1_16));
+        registerBaseProtocol(new BaseProtocol1_16(), Range.atLeast(ProtocolVersion.v1_16));
 
         registerProtocol(new Protocol1_9To1_8(), ProtocolVersion.v1_9, ProtocolVersion.v1_8);
-        registerProtocol(new Protocol1_9_1To1_9(), Arrays.asList(ProtocolVersion.v1_9_1.getVersion(), ProtocolVersion.v1_9_2.getVersion()), ProtocolVersion.v1_9.getVersion());
+        registerProtocol(new Protocol1_9_1To1_9(), Arrays.asList(ProtocolVersion.v1_9_1, ProtocolVersion.v1_9_2), ProtocolVersion.v1_9);
         registerProtocol(new Protocol1_9_3To1_9_1_2(), ProtocolVersion.v1_9_3, ProtocolVersion.v1_9_2);
 
         registerProtocol(new Protocol1_10To1_9_3_4(), ProtocolVersion.v1_10, ProtocolVersion.v1_9_3);
@@ -190,11 +190,11 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
     @Override
     public void registerProtocol(Protocol protocol, ProtocolVersion clientVersion, ProtocolVersion serverVersion) {
-        registerProtocol(protocol, Collections.singletonList(clientVersion.getVersion()), serverVersion.getVersion());
+        registerProtocol(protocol, Collections.singletonList(clientVersion), serverVersion);
     }
 
     @Override
-    public void registerProtocol(Protocol protocol, List<Integer> supportedClientVersion, int serverVersion) {
+    public void registerProtocol(Protocol protocol, List<ProtocolVersion> supportedClientVersion, ProtocolVersion serverVersion) {
         // Register the protocol's handlers
         protocol.initialize();
 
@@ -205,11 +205,11 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
         protocols.put(protocol.getClass(), protocol);
 
-        for (int clientVersion : supportedClientVersion) {
+        for (ProtocolVersion clientVersion : supportedClientVersion) {
             // Throw an error if supported client version = server version
-            Preconditions.checkArgument(clientVersion != serverVersion);
+            Preconditions.checkArgument(!clientVersion.equals(serverVersion));
 
-            Int2ObjectMap<Protocol> protocolMap = registryMap.computeIfAbsent(clientVersion, s -> new Int2ObjectOpenHashMap<>(2));
+            Object2ObjectMap<ProtocolVersion, Protocol> protocolMap = registryMap.computeIfAbsent(clientVersion, s -> new Object2ObjectOpenHashMap<>(2));
             protocolMap.put(serverVersion, protocol);
         }
 
@@ -230,7 +230,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
     }
 
     @Override
-    public void registerBaseProtocol(Protocol baseProtocol, Range<Integer> supportedProtocols) {
+    public void registerBaseProtocol(Protocol baseProtocol, Range<ProtocolVersion> supportedProtocols) {
         Preconditions.checkArgument(baseProtocol.isBaseProtocol(), "Protocol is not a base protocol");
         baseProtocol.initialize();
 
@@ -244,12 +244,12 @@ public class ProtocolManagerImpl implements ProtocolManager {
     public void refreshVersions() {
         supportedVersions.clear();
 
-        supportedVersions.add(serverProtocolVersion.lowestSupportedVersion());
+        supportedVersions.add(serverProtocolVersion.lowestSupportedProtocolVersion());
         for (ProtocolVersion version : ProtocolVersion.getProtocols()) {
-            List<ProtocolPathEntry> protocolPath = getProtocolPath(version.getVersion(), serverProtocolVersion.lowestSupportedVersion());
+            List<ProtocolPathEntry> protocolPath = getProtocolPath(version, serverProtocolVersion.lowestSupportedProtocolVersion());
             if (protocolPath == null) continue;
 
-            supportedVersions.add(version.getVersion());
+            supportedVersions.add(version);
             for (ProtocolPathEntry pathEntry : protocolPath) {
                 supportedVersions.add(pathEntry.outputProtocolVersion());
             }
@@ -257,7 +257,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
     }
 
     @Override
-    public @Nullable List<ProtocolPathEntry> getProtocolPath(int clientVersion, int serverVersion) {
+    public @Nullable List<ProtocolPathEntry> getProtocolPath(ProtocolVersion clientVersion, ProtocolVersion serverVersion) {
         if (clientVersion == serverVersion) return null; // Nothing to do!
 
         // Check cache
@@ -268,14 +268,14 @@ public class ProtocolManagerImpl implements ProtocolManager {
         }
 
         // Calculate path
-        Int2ObjectSortedMap<Protocol> outputPath = getProtocolPath(new Int2ObjectLinkedOpenHashMap<>(), clientVersion, serverVersion);
+        Object2ObjectSortedMap<ProtocolVersion, Protocol> outputPath = getProtocolPath(new Object2ObjectLinkedOpenHashMap<>(), clientVersion, serverVersion);
         if (outputPath == null) {
             return null;
         }
 
         List<ProtocolPathEntry> path = new ArrayList<>(outputPath.size());
-        for (Int2ObjectMap.Entry<Protocol> entry : outputPath.int2ObjectEntrySet()) {
-            path.add(new ProtocolPathEntryImpl(entry.getIntKey(), entry.getValue()));
+        for (Map.Entry<ProtocolVersion, Protocol> entry : outputPath.entrySet()) {
+            path.add(new ProtocolPathEntryImpl(entry.getKey(), entry.getValue()));
         }
         pathCache.put(protocolKey, path);
         return path;
@@ -299,11 +299,11 @@ public class ProtocolManagerImpl implements ProtocolManager {
      * @param serverVersion desired output version
      * @return path that has been generated, null if failed
      */
-    private @Nullable Int2ObjectSortedMap<Protocol> getProtocolPath(Int2ObjectSortedMap<Protocol> current, int clientVersion, int serverVersion) {
+    private @Nullable Object2ObjectSortedMap<ProtocolVersion, Protocol> getProtocolPath(Object2ObjectSortedMap<ProtocolVersion, Protocol> current, ProtocolVersion clientVersion, ProtocolVersion serverVersion) {
         if (current.size() > maxProtocolPathSize) return null; // Fail-safe, protocol too complicated.
 
         // First, check if there is any protocols for this
-        Int2ObjectMap<Protocol> toServerProtocolMap = registryMap.get(clientVersion);
+        Object2ObjectMap<ProtocolVersion, Protocol> toServerProtocolMap = registryMap.get(clientVersion);
         if (toServerProtocolMap == null) {
             return null; // Not supported
         }
@@ -316,19 +316,19 @@ public class ProtocolManagerImpl implements ProtocolManager {
         }
 
         // There might be a more advanced solution... So we'll see if any of the others can get us there
-        Int2ObjectSortedMap<Protocol> shortest = null;
-        for (Int2ObjectMap.Entry<Protocol> entry : toServerProtocolMap.int2ObjectEntrySet()) {
+        Object2ObjectSortedMap<ProtocolVersion, Protocol> shortest = null;
+        for (Map.Entry<ProtocolVersion, Protocol> entry : toServerProtocolMap.entrySet()) {
             // Ensure we don't go back to already contained versions
-            int translatedToVersion = entry.getIntKey();
+            ProtocolVersion translatedToVersion = entry.getKey();
             if (current.containsKey(translatedToVersion)) continue;
 
             // Check if the new version is farther away than the current client version
-            if (maxPathDeltaIncrease != -1 && Math.abs(serverVersion - translatedToVersion) - Math.abs(serverVersion - clientVersion) > maxPathDeltaIncrease) {
+            if (maxPathDeltaIncrease != -1 && serverVersion.compareTo(translatedToVersion) - serverVersion.compareTo(clientVersion) > maxPathDeltaIncrease) {
                 continue;
             }
 
             // Create a copy
-            Int2ObjectSortedMap<Protocol> newCurrent = new Int2ObjectLinkedOpenHashMap<>(current);
+            Object2ObjectSortedMap<ProtocolVersion, Protocol> newCurrent = new Object2ObjectLinkedOpenHashMap<>(current);
             newCurrent.put(translatedToVersion, entry.getValue());
 
             // Calculate the rest of the protocol starting from translatedToVersion and take the shortest
@@ -347,14 +347,14 @@ public class ProtocolManagerImpl implements ProtocolManager {
     }
 
     @Override
-    public @Nullable Protocol getProtocol(int clientVersion, int serverVersion) {
-        Int2ObjectMap<Protocol> map = registryMap.get(clientVersion);
+    public @Nullable Protocol getProtocol(ProtocolVersion clientVersion, ProtocolVersion serverVersion) {
+        Object2ObjectMap<ProtocolVersion, Protocol> map = registryMap.get(clientVersion);
         return map != null ? map.get(serverVersion) : null;
     }
 
     @Override
-    public Protocol getBaseProtocol(int serverVersion) {
-        for (Pair<Range<Integer>, Protocol> rangeProtocol : Lists.reverse(baseProtocols)) {
+    public Protocol getBaseProtocol(ProtocolVersion serverVersion) {
+        for (Pair<Range<ProtocolVersion>, Protocol> rangeProtocol : Lists.reverse(baseProtocols)) {
             if (rangeProtocol.key().contains(serverVersion)) {
                 return rangeProtocol.value();
             }
@@ -380,7 +380,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
 
     @Override
     public boolean isWorkingPipe() {
-        for (Int2ObjectMap<Protocol> map : registryMap.values()) {
+        for (Object2ObjectMap<ProtocolVersion, Protocol> map : registryMap.values()) {
             for (ProtocolVersion protocolVersion : serverProtocolVersion.supportedProtocolVersions()) {
                 if (map.containsKey(protocolVersion.getVersion())) {
                     return true;
@@ -391,7 +391,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
     }
 
     @Override
-    public SortedSet<Integer> getSupportedVersions() {
+    public SortedSet<ProtocolVersion> getSupportedVersions() {
         return Collections.unmodifiableSortedSet(new TreeSet<>(supportedVersions));
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -323,8 +323,11 @@ public class ProtocolManagerImpl implements ProtocolManager {
             if (current.containsKey(translatedToVersion)) continue;
 
             // Check if the new version is farther away than the current client version
-            if (maxPathDeltaIncrease != -1 && serverVersion.compareTo(translatedToVersion) - serverVersion.compareTo(clientVersion) > maxPathDeltaIncrease) {
-                continue;
+            if (maxPathDeltaIncrease != -1 && translatedToVersion.getVersionType() == clientVersion.getVersionType()) {
+                final int delta = Math.abs(serverVersion.getVersion() - translatedToVersion.getVersion()) - Math.abs(serverVersion.getVersion() - clientVersion.getVersion());
+                if (delta > maxPathDeltaIncrease) {
+                    continue;
+                }
             }
 
             // Create a copy

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -355,7 +355,7 @@ public class ProtocolManagerImpl implements ProtocolManager {
     @Override
     public Protocol getBaseProtocol(ProtocolVersion serverVersion) {
         for (Pair<Range<ProtocolVersion>, Protocol> rangeProtocol : Lists.reverse(baseProtocols)) {
-            if (rangeProtocol.key().contains(serverVersion)) {
+            if (rangeProtocol.key() != null && rangeProtocol.key().contains(serverVersion)) {
                 return rangeProtocol.value();
             }
         }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolPathEntryImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolPathEntryImpl.java
@@ -19,18 +19,19 @@ package com.viaversion.viaversion.protocol;
 
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.protocol.ProtocolPathEntry;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 
 public class ProtocolPathEntryImpl implements ProtocolPathEntry {
-    private final int outputProtocolVersion;
+    private final ProtocolVersion outputProtocolVersion;
     private final Protocol<?, ?, ?, ?> protocol;
 
-    public ProtocolPathEntryImpl(int outputProtocolVersion, Protocol<?, ?, ?, ?> protocol) {
+    public ProtocolPathEntryImpl(ProtocolVersion outputProtocolVersion, Protocol<?, ?, ?, ?> protocol) {
         this.outputProtocolVersion = outputProtocolVersion;
         this.protocol = protocol;
     }
 
     @Override
-    public int outputProtocolVersion() {
+    public ProtocolVersion outputProtocolVersion() {
         return outputProtocolVersion;
     }
 
@@ -50,9 +51,7 @@ public class ProtocolPathEntryImpl implements ProtocolPathEntry {
 
     @Override
     public int hashCode() {
-        int result = outputProtocolVersion;
-        result = 31 * result + protocol.hashCode();
-        return result;
+        return super.hashCode();
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolPathEntryImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolPathEntryImpl.java
@@ -20,6 +20,7 @@ package com.viaversion.viaversion.protocol;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.protocol.ProtocolPathEntry;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import java.util.Objects;
 
 public class ProtocolPathEntryImpl implements ProtocolPathEntry {
     private final ProtocolVersion outputProtocolVersion;
@@ -51,7 +52,7 @@ public class ProtocolPathEntryImpl implements ProtocolPathEntry {
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        return Objects.hash(outputProtocolVersion, protocol);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolPathKeyImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolPathKeyImpl.java
@@ -18,23 +18,25 @@
 package com.viaversion.viaversion.protocol;
 
 import com.viaversion.viaversion.api.protocol.ProtocolPathKey;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import java.util.Objects;
 
 public class ProtocolPathKeyImpl implements ProtocolPathKey {
-    private final int clientProtocolVersion;
-    private final int serverProtocolVersion;
+    private final ProtocolVersion clientProtocolVersion;
+    private final ProtocolVersion serverProtocolVersion;
 
-    public ProtocolPathKeyImpl(int clientProtocolVersion, int serverProtocolVersion) {
+    public ProtocolPathKeyImpl(ProtocolVersion clientProtocolVersion, ProtocolVersion serverProtocolVersion) {
         this.clientProtocolVersion = clientProtocolVersion;
         this.serverProtocolVersion = serverProtocolVersion;
     }
 
     @Override
-    public int clientProtocolVersion() {
+    public ProtocolVersion clientProtocolVersion() {
         return clientProtocolVersion;
     }
 
     @Override
-    public int serverProtocolVersion() {
+    public ProtocolVersion serverProtocolVersion() {
         return serverProtocolVersion;
     }
 
@@ -49,8 +51,6 @@ public class ProtocolPathKeyImpl implements ProtocolPathKey {
 
     @Override
     public int hashCode() {
-        int result = clientProtocolVersion;
-        result = 31 * result + serverProtocolVersion;
-        return result;
+        return Objects.hash(clientProtocolVersion, serverProtocolVersion);
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/packet/VersionedPacketTransformerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/packet/VersionedPacketTransformerImpl.java
@@ -37,7 +37,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class VersionedPacketTransformerImpl<C extends ClientboundPacketType, S extends ServerboundPacketType> implements VersionedPacketTransformer<C, S> {
 
-    private final int inputProtocolVersion; // TODO Use ProtocolVersion
+    private final ProtocolVersion inputProtocolVersion;
     private final Class<C> clientboundPacketsClass;
     private final Class<S> serverboundPacketsClass;
 
@@ -45,7 +45,7 @@ public class VersionedPacketTransformerImpl<C extends ClientboundPacketType, S e
         Preconditions.checkNotNull(inputVersion);
         Preconditions.checkArgument(clientboundPacketsClass != null || serverboundPacketsClass != null,
                 "Either the clientbound or serverbound packets class has to be non-null");
-        this.inputProtocolVersion = inputVersion.getVersion();
+        this.inputProtocolVersion = inputVersion;
         this.clientboundPacketsClass = clientboundPacketsClass;
         this.serverboundPacketsClass = serverboundPacketsClass;
     }
@@ -142,8 +142,8 @@ public class VersionedPacketTransformerImpl<C extends ClientboundPacketType, S e
         PacketType packetType = packet.getPacketType();
         UserConnection connection = packet.user();
         boolean clientbound = packetType.direction() == Direction.CLIENTBOUND;
-        int serverProtocolVersion = clientbound ? this.inputProtocolVersion : connection.getProtocolInfo().serverProtocolVersion().getVersion();
-        int clientProtocolVersion = clientbound ? connection.getProtocolInfo().protocolVersion().getVersion() : this.inputProtocolVersion;
+        ProtocolVersion serverProtocolVersion = clientbound ? this.inputProtocolVersion : connection.getProtocolInfo().serverProtocolVersion();
+        ProtocolVersion clientProtocolVersion = clientbound ? connection.getProtocolInfo().protocolVersion() : this.inputProtocolVersion;
 
         // Construct protocol pipeline
         List<ProtocolPathEntry> path = Via.getManager().getProtocolManager().getProtocolPath(clientProtocolVersion, serverProtocolVersion);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
@@ -72,8 +72,7 @@ public class BaseProtocol extends AbstractProtocol<BaseClientboundPacket, BaseCl
 
             // Only allow newer clients (or 1.9.2 on 1.9.4 server if the server supports it)
             if (info.protocolVersion().higherThanOrEquals(serverProtocol) || Via.getPlatform().isOldClientsAllowed()) {
-                protocolPath = Via.getManager().getProtocolManager()
-                    .getProtocolPath(info.protocolVersion().getVersion(), serverProtocol.getVersion());
+                protocolPath = Via.getManager().getProtocolManager().getProtocolPath(info.protocolVersion(), serverProtocol);
             }
 
             ProtocolPipeline pipeline = wrapper.user().getProtocolInfo().getPipeline();
@@ -94,7 +93,7 @@ public class BaseProtocol extends AbstractProtocol<BaseClientboundPacket, BaseCl
             }
 
             // Add Base Protocol
-            pipeline.add(Via.getManager().getProtocolManager().getBaseProtocol(serverProtocol.getVersion()));
+            pipeline.add(Via.getManager().getProtocolManager().getBaseProtocol(serverProtocol));
 
             if (Via.getManager().isDebug()) {
                 Via.getPlatform().getLogger().info("User connected with protocol: " + info.protocolVersion() + " and serverProtocol: " + info.serverProtocolVersion());

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
@@ -93,7 +93,7 @@ public class BaseProtocol extends AbstractProtocol<BaseClientboundPacket, BaseCl
             }
 
             // Add Base Protocol
-            pipeline.add(Via.getManager().getProtocolManager().getBaseProtocol(serverProtocol.getVersion()));
+            pipeline.add(Via.getManager().getProtocolManager().getBaseProtocol(serverProtocol));
 
             if (Via.getManager().isDebug()) {
                 Via.getPlatform().getLogger().info("User connected with protocol: " + info.protocolVersion() + " and serverProtocol: " + info.serverProtocolVersion());
@@ -107,7 +107,7 @@ public class BaseProtocol extends AbstractProtocol<BaseClientboundPacket, BaseCl
             } else if (state == TRANSFER_INTENT) {
                 info.setState(State.LOGIN);
 
-                if (serverProtocol.lowerThan(ProtocolVersion.v1_20_5)) {
+                if (serverProtocol.olderThan(ProtocolVersion.v1_20_5)) {
                     wrapper.set(Type.VAR_INT, 1, LOGIN_INTENT);
                 }
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
@@ -106,7 +106,7 @@ public class BaseProtocol1_7 extends AbstractProtocol<BaseClientboundPacket, Bas
                         }
 
                         if (protocols != null) {
-                            if (protocolVersion.equals(closestServerProtocol) || protocolVersion.getVersion() == 0) { // Fix ServerListPlus
+                            if (protocolVersion.equalTo(closestServerProtocol) || protocolVersion.getVersion() == 0) { // Fix ServerListPlus
                                 version.addProperty("protocol", info.protocolVersion().getOriginalVersion());
                             }
                         } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
@@ -106,7 +106,7 @@ public class BaseProtocol1_7 extends AbstractProtocol<BaseClientboundPacket, Bas
                         }
 
                         if (protocols != null) {
-                            if (protocolVersion.equals(closestServerProtocol) || !protocolVersion.isKnown()) { // Fix ServerListPlus
+                            if (protocolVersion.equals(closestServerProtocol) || protocolVersion.getVersion() == 0) { // Fix ServerListPlus
                                 version.addProperty("protocol", info.protocolVersion().getOriginalVersion());
                             }
                         } else {

--- a/common/src/main/java/com/viaversion/viaversion/util/DumpUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/DumpUtil.java
@@ -57,7 +57,7 @@ public final class DumpUtil {
         final VersionInfo version = new VersionInfo(
                 System.getProperty("java.version"),
                 System.getProperty("os.name"),
-                Via.getAPI().getServerVersion().lowestSupportedVersion(),
+                Via.getAPI().getServerVersion().lowestSupportedProtocolVersion(),
                 Via.getManager().getProtocolManager().getSupportedVersions(),
                 Via.getPlatform().getPlatformName(),
                 Via.getPlatform().getPlatformVersion(),

--- a/common/src/test/java/com/viaversion/viaversion/common/dummy/TestPlatform.java
+++ b/common/src/test/java/com/viaversion/viaversion/common/dummy/TestPlatform.java
@@ -24,6 +24,7 @@ import com.viaversion.viaversion.api.command.ViaCommandSender;
 import com.viaversion.viaversion.api.configuration.ViaVersionConfig;
 import com.viaversion.viaversion.api.platform.PlatformTask;
 import com.viaversion.viaversion.api.platform.ViaPlatform;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import io.netty.buffer.ByteBuf;
 import java.io.File;
 import java.util.UUID;
@@ -102,8 +103,8 @@ public final class TestPlatform implements ViaPlatform {
     public ViaAPI getApi() {
         return new ViaAPIBase() {
             @Override
-            public int getPlayerVersion(Object player) {
-                return 0;
+            public ProtocolVersion getPlayerProtocolVersion(Object player) {
+                return ProtocolVersion.unknown;
             }
 
             @Override

--- a/sponge/src/main/java/com/viaversion/viaversion/sponge/platform/SpongeViaAPI.java
+++ b/sponge/src/main/java/com/viaversion/viaversion/sponge/platform/SpongeViaAPI.java
@@ -18,14 +18,15 @@
 package com.viaversion.viaversion.sponge.platform;
 
 import com.viaversion.viaversion.ViaAPIBase;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import io.netty.buffer.ByteBuf;
 import org.spongepowered.api.entity.living.player.Player;
 
 public class SpongeViaAPI extends ViaAPIBase<Player> {
 
     @Override
-    public int getPlayerVersion(Player player) {
-        return getPlayerVersion(player.uniqueId());
+    public ProtocolVersion getPlayerProtocolVersion(Player player) {
+        return getPlayerProtocolVersion(player.uniqueId());
     }
 
     @Override

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaAPI.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaAPI.java
@@ -19,13 +19,14 @@ package com.viaversion.viaversion.velocity.platform;
 
 import com.velocitypowered.api.proxy.Player;
 import com.viaversion.viaversion.ViaAPIBase;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import io.netty.buffer.ByteBuf;
 
 public class VelocityViaAPI extends ViaAPIBase<Player> {
 
     @Override
-    public int getPlayerVersion(Player player) {
-        return getPlayerVersion(player.getUniqueId());
+    public ProtocolVersion getPlayerProtocolVersion(Player player) {
+        return getPlayerProtocolVersion(player.getUniqueId());
     }
 
     @Override

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/providers/VelocityVersionProvider.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/providers/VelocityVersionProvider.java
@@ -51,8 +51,7 @@ public class VelocityVersionProvider extends BaseVersionProvider {
         //TODO use newly added Velocity netty event
         ChannelHandler mcHandler = user.getChannel().pipeline().get("handler");
         ServerConnection serverConnection = (ServerConnection) GET_ASSOCIATION.invoke(mcHandler);
-        final int protocolVersion = Via.proxyPlatform().protocolDetectorService().serverProtocolVersion(serverConnection.getServerInfo().getName());
-        return ProtocolVersion.getProtocol(protocolVersion);
+        return Via.proxyPlatform().protocolDetectorService().serverProtocolVersion(serverConnection.getServerInfo().getName());
     }
 
     private ProtocolVersion getFrontProtocol(UserConnection user) throws Exception {

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/service/ProtocolDetectorService.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/service/ProtocolDetectorService.java
@@ -56,7 +56,7 @@ public final class ProtocolDetectorService extends AbstractProtocolDetectorServi
             }
 
             final ProtocolVersion oldProtocolVersion = serverProtocolVersion(serverName);
-            if (oldProtocolVersion.isKnown() && oldProtocolVersion.getVersion() == serverPing.getVersion().getProtocol()) {
+            if (oldProtocolVersion.isKnown() && oldProtocolVersion.getVersion() == serverPing.getVersion().getProtocol()) { // TODO | use equalTo here
                 // Same value as previously
                 return;
             }

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/service/ProtocolDetectorService.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/service/ProtocolDetectorService.java
@@ -55,8 +55,8 @@ public final class ProtocolDetectorService extends AbstractProtocolDetectorServi
                 return;
             }
 
-            final int oldProtocolVersion = serverProtocolVersion(serverName);
-            if (oldProtocolVersion != -1 && oldProtocolVersion == serverPing.getVersion().getProtocol()) {
+            final ProtocolVersion oldProtocolVersion = serverProtocolVersion(serverName);
+            if (oldProtocolVersion.isKnown() && oldProtocolVersion.getVersion() == serverPing.getVersion().getProtocol()) {
                 // Same value as previously
                 return;
             }
@@ -86,12 +86,12 @@ public final class ProtocolDetectorService extends AbstractProtocolDetectorServi
     }
 
     @Override
-    protected int lowestSupportedProtocolVersion() {
+    protected ProtocolVersion lowestSupportedProtocolVersion() {
         try {
-            return Via.getManager().getInjector().getServerProtocolVersion().getVersion();
+            return Via.getManager().getInjector().getServerProtocolVersion();
         } catch (final Exception e) {
             e.printStackTrace();
-            return ProtocolVersion.v1_8.getVersion();
+            return ProtocolVersion.v1_8;
         }
     }
 }

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/service/ProtocolDetectorService.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/service/ProtocolDetectorService.java
@@ -56,7 +56,7 @@ public final class ProtocolDetectorService extends AbstractProtocolDetectorServi
             }
 
             final ProtocolVersion oldProtocolVersion = serverProtocolVersion(serverName);
-            if (oldProtocolVersion.isKnown() && oldProtocolVersion.getVersion() == serverPing.getVersion().getProtocol()) { // TODO | use equalTo here
+            if (oldProtocolVersion.isKnown() && oldProtocolVersion.getVersion() == serverPing.getVersion().getProtocol()) {
                 // Same value as previously
                 return;
             }


### PR DESCRIPTION
This PR ports all remaining internals and API to use the ProtocolVersion class instead of using raw protocol ids.

This should be merged after https://github.com/ViaVersion/ViaVersion/pull/3693 so I can rebase this changes to use the new method namings. 