### PR TITLE
Only pass ProtocolVersion#toString into via dumps

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/dump/VersionInfo.java
+++ b/common/src/main/java/com/viaversion/viaversion/dump/VersionInfo.java
@@ -17,21 +17,20 @@
  */
 package com.viaversion.viaversion.dump;
 
-import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import java.util.Set;
 
 public class VersionInfo {
     private final String javaVersion;
     private final String operatingSystem;
-    private final ProtocolVersion serverProtocol;
-    private final Set<ProtocolVersion> enabledProtocols;
+    private final String serverProtocol;
+    private final Set<String> enabledProtocols;
     private final String platformName;
     private final String platformVersion;
     private final String pluginVersion;
     private final String implementationVersion;
     private final Set<String> subPlatforms;
 
-    public VersionInfo(String javaVersion, String operatingSystem, ProtocolVersion serverProtocol, Set<ProtocolVersion> enabledProtocols,
+    public VersionInfo(String javaVersion, String operatingSystem, String serverProtocol, Set<String> enabledProtocols,
                        String platformName, String platformVersion, String pluginVersion, String implementationVersion, Set<String> subPlatforms) {
         this.javaVersion = javaVersion;
         this.operatingSystem = operatingSystem;
@@ -52,11 +51,11 @@ public class VersionInfo {
         return operatingSystem;
     }
 
-    public ProtocolVersion getServerProtocol() {
+    public String getServerProtocol() {
         return serverProtocol;
     }
 
-    public Set<ProtocolVersion> getEnabledProtocols() {
+    public Set<String> getEnabledProtocols() {
         return enabledProtocols;
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/util/DumpUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/DumpUtil.java
@@ -42,6 +42,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class DumpUtil {
@@ -57,8 +58,8 @@ public final class DumpUtil {
         final VersionInfo version = new VersionInfo(
                 System.getProperty("java.version"),
                 System.getProperty("os.name"),
-                Via.getAPI().getServerVersion().lowestSupportedProtocolVersion(),
-                Via.getManager().getProtocolManager().getSupportedVersions(),
+                Via.getAPI().getServerVersion().lowestSupportedProtocolVersion().toString(),
+                Via.getManager().getProtocolManager().getSupportedVersions().stream().map(ProtocolVersion::toString).collect(Collectors.toSet()),
                 Via.getPlatform().getPlatformName(),
                 Via.getPlatform().getPlatformVersion(),
                 Via.getPlatform().getPluginVersion(),


### PR DESCRIPTION
Previously:
<img width="404" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/a80c902a-7d76-4726-a6f0-c828f03ee200">

With the PR:
<img width="302" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/ffaec5cc-799a-407f-95bd-b260dbdc0d0b">
