### PR TITLE
Fix typo in ViaVersion's description

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 allprojects {
     group = "com.viaversion"
     version = property("projectVersion") as String // from gradle.properties
-    description = "Allow newer clients to join older server versions."
+    description = "Allows newer clients to join older server versions."
 }
 
 val main = setOf(

--- a/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
@@ -58,7 +58,7 @@ import org.slf4j.Logger;
         name = "ViaVersion",
         version = VersionInfo.VERSION,
         authors = {"_MylesC", "creeper123123321", "Gerrygames", "kennytv", "Matsv"},
-        description = "Allow newer Minecraft versions to connect to an older server version.",
+        description = "Allows newer Minecraft versions to connect to an older server version.",
         url = "https://viaversion.com"
 )
 public class VelocityPlugin implements ViaServerProxyPlatform<Player> {


### PR DESCRIPTION
Synced from [ViaBackwards' #686](https://github.com/ViaVersion/ViaBackwards/pull/686), ViaRewind doesn't require this treatment though.