### PR TITLE
Don't require a base protocol for current version in BaseProtocol

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
@@ -78,10 +78,9 @@ public interface ProtocolManager {
      * The standard base protocols deal with status and login packets for userconnection initialization.
      *
      * @param serverVersion server protocol version
-     * @return base protocol for the given server protocol version
-     * @throws IllegalStateException if no base protocol could be found
+     * @return base protocol for the given server protocol version if present, else null
      */
-    Protocol getBaseProtocol(ProtocolVersion serverVersion);
+    @Nullable Protocol getBaseProtocol(ProtocolVersion serverVersion);
 
     /**
      * Returns an immutable collection of registered protocols.

--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -363,13 +363,13 @@ public class ProtocolManagerImpl implements ProtocolManager {
     }
 
     @Override
-    public Protocol getBaseProtocol(ProtocolVersion serverVersion) {
+    public @Nullable Protocol getBaseProtocol(ProtocolVersion serverVersion) {
         for (Pair<Range<ProtocolVersion>, Protocol> rangeProtocol : Lists.reverse(baseProtocols)) {
             if (rangeProtocol.key().contains(serverVersion)) {
                 return rangeProtocol.value();
             }
         }
-        throw new IllegalStateException("No Base Protocol for " + serverVersion);
+        return null;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
@@ -83,10 +83,10 @@ public class BaseProtocol extends AbstractProtocol<BaseClientboundPacket, BaseCl
 
             // Special versions might compare equal to normal versions and would break this getter
             if (serverProtocol.getVersionType() != VersionType.SPECIAL) {
-                try {
-                    pipeline.add(protocolManager.getBaseProtocol(serverProtocol));
-                } catch (Exception ignored) {
-                    // Platforms might add their base protocol manually (e.g. SPECIAL versions)
+                final Protocol baseProtocol = protocolManager.getBaseProtocol(serverProtocol);
+                // Platforms might add their base protocol manually (e.g. SPECIAL versions)
+                if (baseProtocol != null) {
+                    pipeline.add(baseProtocol);
                 }
             }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
@@ -80,8 +80,14 @@ public class BaseProtocol extends AbstractProtocol<BaseClientboundPacket, BaseCl
 
             // Add Base Protocol
             ProtocolPipeline pipeline = info.getPipeline();
+
+            // Special versions might compare equal to normal versions and would break this getter
             if (serverProtocol.getVersionType() != VersionType.SPECIAL) {
-                pipeline.add(protocolManager.getBaseProtocol(serverProtocol));
+                try {
+                    pipeline.add(protocolManager.getBaseProtocol(serverProtocol));
+                } catch (Exception ignored) {
+                    // Platforms might add their base protocol manually (e.g. SPECIAL versions)
+                }
             }
 
             // Add other protocols


### PR DESCRIPTION
ViaLegacy and other platforms containing SPECIAL versions are adding their base protocol manually