### PR TITLE
Fix particle doesn't use new mapping id (1.20.5)

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -81,8 +81,8 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
             wrapper.passthrough(Type.INT); // Particle Count
 
             // Read data and add it to Particle
-            final Particle particle = new Particle(particleId);
             final ParticleMappings mappings = protocol.getMappingData().getParticleMappings();
+            final Particle particle = new Particle(mappings.getNewId(particleId));
             if (mappings.isBlockParticle(particleId)) {
                 final int blockStateId = wrapper.read(Type.VAR_INT);
                 particle.add(Type.VAR_INT, protocol.getMappingData().getNewBlockStateId(blockStateId));


### PR DESCRIPTION
The particle id was not converted.