### PR TITLE
Fixed enabled version sorting in DumpUtil

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/util/DumpUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/DumpUtil.java
@@ -35,6 +35,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +60,7 @@ public final class DumpUtil {
                 System.getProperty("java.version"),
                 System.getProperty("os.name"),
                 Via.getAPI().getServerVersion().lowestSupportedProtocolVersion().toString(),
-                Via.getManager().getProtocolManager().getSupportedVersions().stream().map(ProtocolVersion::toString).collect(Collectors.toSet()),
+                Via.getManager().getProtocolManager().getSupportedVersions().stream().map(ProtocolVersion::toString).collect(Collectors.toCollection(LinkedHashSet::new)),
                 Via.getPlatform().getPlatformName(),
                 Via.getPlatform().getPlatformVersion(),
                 Via.getPlatform().getPluginVersion(),


### PR DESCRIPTION
Before:
![image](https://github.com/ViaVersion/ViaVersion/assets/60033407/59f7945e-b067-4b23-8bcb-271aeb568e97)

After:
![image](https://github.com/ViaVersion/ViaVersion/assets/60033407/882f187a-0134-42bb-9d80-5cef5674dd20)
