### PR TITLE
Fixed legacy custom payload channel comparisons

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/packets/InventoryPackets.java
@@ -45,7 +45,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, Serv
                 map(Type.STRING); // 0 - Channel
 
                 handler(wrapper -> {
-                    if (wrapper.get(Type.STRING, 0).equalsIgnoreCase("MC|TrList")) {
+                    if (wrapper.get(Type.STRING, 0).equals("MC|TrList")) {
                         wrapper.passthrough(Type.INT); // Passthrough Window ID
 
                         int size = wrapper.passthrough(Type.UNSIGNED_BYTE);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
@@ -47,7 +47,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, Serv
                 map(Type.STRING); // 0 - Channel
 
                 handler(wrapper -> {
-                    if (wrapper.get(Type.STRING, 0).equalsIgnoreCase("MC|TrList")) {
+                    if (wrapper.get(Type.STRING, 0).equals("MC|TrList")) {
                         wrapper.passthrough(Type.INT); // Passthrough Window ID
 
                         int size = wrapper.passthrough(Type.UNSIGNED_BYTE);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -99,7 +99,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                 handler(wrapper -> {
                     String channel = wrapper.get(Type.STRING, 0);
                     // Handle stopsound change
-                    if (channel.equalsIgnoreCase("MC|StopSound")) {
+                    if (channel.equals("MC|StopSound")) {
                         String originalSource = wrapper.read(Type.STRING);
                         String originalSound = wrapper.read(Type.STRING);
 
@@ -129,7 +129,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
 
                         wrapper.set(Type.BYTE, 0, flags); // Update flags
                         return;
-                    } else if (channel.equalsIgnoreCase("MC|TrList")) {
+                    } else if (channel.equals("MC|TrList")) {
                         channel = "minecraft:trader_list";
                         wrapper.passthrough(Type.INT); // Passthrough Window ID
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
@@ -265,9 +265,9 @@ public class PlayerPackets {
                 map(Type.STRING); // 0 - Channel Name
                 handler(wrapper -> {
                     String name = wrapper.get(Type.STRING, 0);
-                    if (name.equalsIgnoreCase("MC|BOpen")) {
+                    if (name.equals("MC|BOpen")) {
                         wrapper.write(Type.VAR_INT, 0);
-                    } else if (name.equalsIgnoreCase("MC|TrList")) {
+                    } else if (name.equals("MC|TrList")) {
                         wrapper.passthrough(Type.INT); // ID
 
                         Short size = wrapper.passthrough(Type.UNSIGNED_BYTE);
@@ -406,14 +406,14 @@ public class PlayerPackets {
                 map(Type.STRING); // 0 - Channel Name
                 handler(wrapper -> {
                     String name = wrapper.get(Type.STRING, 0);
-                    if (name.equalsIgnoreCase("MC|BSign")) {
+                    if (name.equals("MC|BSign")) {
                         Item item = wrapper.passthrough(Type.ITEM1_8);
                         if (item != null) {
                             item.setIdentifier(387); // Written Book
                             ItemRewriter.rewriteBookToServer(item);
                         }
                     }
-                    if (name.equalsIgnoreCase("MC|AutoCmd")) {
+                    if (name.equals("MC|AutoCmd")) {
                         wrapper.set(Type.STRING, 0, "MC|AdvCdm");
                         wrapper.write(Type.BYTE, (byte) 0);
                         wrapper.passthrough(Type.INT); // X
@@ -423,7 +423,7 @@ public class PlayerPackets {
                         wrapper.passthrough(Type.BOOLEAN); // Flag
                         wrapper.clearInputBuffer();
                     }
-                    if (name.equalsIgnoreCase("MC|AdvCmd")) {
+                    if (name.equals("MC|AdvCmd")) {
                         wrapper.set(Type.STRING, 0, "MC|AdvCdm");
                     }
                 });


### PR DESCRIPTION
Legacy (<=1.12.2) versions of minecraft are using .equals() to compare the custom payload channels