### PR TITLE
Rewrite 1.12.2->1.13 ComponentRewriter

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/ComponentRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/ComponentRewriter1_13.java
@@ -17,14 +17,12 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_13to1_12_2.data;
 
-import com.github.steveice10.opennbt.stringified.SNBT;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.NumberTag;
 import com.github.steveice10.opennbt.tag.builtin.ShortTag;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.minecraft.item.DataItem;
 import com.viaversion.viaversion.api.minecraft.item.Item;
@@ -32,6 +30,7 @@ import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;
 import com.viaversion.viaversion.rewriter.ComponentRewriter;
+import net.lenni0451.mcstructs.snbt.SNbtSerializer;
 import java.util.logging.Level;
 
 public class ComponentRewriter1_13<C extends ClientboundPacketType> extends ComponentRewriter<C> {
@@ -43,21 +42,19 @@ public class ComponentRewriter1_13<C extends ClientboundPacketType> extends Comp
     @Override
     protected void handleHoverEvent(JsonObject hoverEvent) {
         super.handleHoverEvent(hoverEvent);
-        String action = hoverEvent.getAsJsonPrimitive("action").getAsString();
+        final String action = hoverEvent.getAsJsonPrimitive("action").getAsString();
         if (!action.equals("show_item")) return;
 
-        JsonElement value = hoverEvent.get("value");
+        final JsonElement value = hoverEvent.get("value");
         if (value == null) return;
 
-        String text = findItemNBT(value);
-        if (text == null) return;
-
+        final String nbt = value.getAsString();
         CompoundTag tag;
         try {
-            tag = SNBT.deserializeCompoundTag(text);
+            tag = SNbtSerializer.V1_12.deserialize(nbt);
         } catch (Exception e) {
             if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                Via.getPlatform().getLogger().log(Level.WARNING, "Error reading NBT in show_item:" + text, e);
+                Via.getPlatform().getLogger().log(Level.WARNING, "Error reading 1.12.2 NBT in show_item: " + nbt, e);
             }
             return;
         }
@@ -85,31 +82,12 @@ public class ComponentRewriter1_13<C extends ClientboundPacketType> extends Comp
         array.add(object);
         String serializedNBT;
         try {
-            serializedNBT = SNBT.serialize(tag);
+            serializedNBT = SNbtSerializer.V1_13.serialize(tag);
             object.addProperty("text", serializedNBT);
             hoverEvent.add("value", array);
         } catch (Exception e) {
-            Via.getPlatform().getLogger().log(Level.WARNING, "Error writing NBT in show_item:" + text, e);
+            Via.getPlatform().getLogger().log(Level.WARNING, "Error writing 1.13 NBT in show_item: " + nbt, e);
         }
-    }
-
-    protected String findItemNBT(JsonElement element) {
-        if (element.isJsonArray()) {
-            for (JsonElement jsonElement : element.getAsJsonArray()) {
-                String value = findItemNBT(jsonElement);
-                if (value != null) {
-                    return value;
-                }
-            }
-        } else if (element.isJsonObject()) {
-            JsonPrimitive text = element.getAsJsonObject().getAsJsonPrimitive("text");
-            if (text != null) {
-                return text.getAsString();
-            }
-        } else if (element.isJsonPrimitive()) {
-            return element.getAsJsonPrimitive().getAsString();
-        }
-        return null;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/ComponentRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/data/ComponentRewriter1_13.java
@@ -31,6 +31,8 @@ import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;
 import com.viaversion.viaversion.rewriter.ComponentRewriter;
 import net.lenni0451.mcstructs.snbt.SNbtSerializer;
+import net.lenni0451.mcstructs.text.ATextComponent;
+import net.lenni0451.mcstructs.text.serializer.TextComponentSerializer;
 import java.util.logging.Level;
 
 public class ComponentRewriter1_13<C extends ClientboundPacketType> extends ComponentRewriter<C> {
@@ -48,10 +50,10 @@ public class ComponentRewriter1_13<C extends ClientboundPacketType> extends Comp
         final JsonElement value = hoverEvent.get("value");
         if (value == null) return;
 
-        final String nbt = value.getAsString();
+        final ATextComponent nbt = TextComponentSerializer.V1_12.deserialize(value);
         CompoundTag tag;
         try {
-            tag = SNbtSerializer.V1_12.deserialize(nbt);
+            tag = SNbtSerializer.V1_12.deserialize(nbt.asUnformattedString());
         } catch (Exception e) {
             if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
                 Via.getPlatform().getLogger().log(Level.WARNING, "Error reading 1.12.2 NBT in show_item: " + nbt, e);


### PR DESCRIPTION
Move away from ViaNBT's SNBT parsing and replaces the code with proper MCStructs parsing