### PR TITLE
Fix minor inconsistencies in protocol packages

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
@@ -39,7 +39,7 @@ import com.viaversion.viaversion.debug.DebugHandlerImpl;
 import com.viaversion.viaversion.protocol.ProtocolManagerImpl;
 import com.viaversion.viaversion.protocol.ServerProtocolVersionRange;
 import com.viaversion.viaversion.protocol.ServerProtocolVersionSingleton;
-import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.TabCompleteThread;
+import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.task.TabCompleteThread;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.ViaIdleThread;
 import com.viaversion.viaversion.scheduler.TaskScheduler;
 import com.viaversion.viaversion.update.UpdateUtil;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/Protocol1_11To1_10.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/Protocol1_11To1_10.java
@@ -34,6 +34,8 @@ import com.viaversion.viaversion.api.type.types.version.Types1_9;
 import com.viaversion.viaversion.protocols.protocol1_11to1_10.data.PotionColorMapping;
 import com.viaversion.viaversion.protocols.protocol1_11to1_10.metadata.MetadataRewriter1_11To1_10;
 import com.viaversion.viaversion.protocols.protocol1_11to1_10.packets.InventoryPackets;
+import com.viaversion.viaversion.protocols.protocol1_11to1_10.rewriter.BlockEntityRewriter;
+import com.viaversion.viaversion.protocols.protocol1_11to1_10.rewriter.EntityIdRewriter;
 import com.viaversion.viaversion.protocols.protocol1_11to1_10.storage.EntityTracker1_11;
 import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.ClientboundPackets1_9_3;
 import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.ServerboundPackets1_9_3;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/metadata/MetadataRewriter1_11To1_10.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/metadata/MetadataRewriter1_11To1_10.java
@@ -25,7 +25,7 @@ import com.viaversion.viaversion.api.minecraft.metadata.Metadata;
 import com.viaversion.viaversion.api.minecraft.metadata.types.MetaType1_9;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Type;
-import com.viaversion.viaversion.protocols.protocol1_11to1_10.EntityIdRewriter;
+import com.viaversion.viaversion.protocols.protocol1_11to1_10.rewriter.EntityIdRewriter;
 import com.viaversion.viaversion.protocols.protocol1_11to1_10.Protocol1_11To1_10;
 import com.viaversion.viaversion.protocols.protocol1_11to1_10.storage.EntityTracker1_11;
 import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.ClientboundPackets1_9_3;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/packets/InventoryPackets.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.protocols.protocol1_11to1_10.packets;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
-import com.viaversion.viaversion.protocols.protocol1_11to1_10.EntityIdRewriter;
+import com.viaversion.viaversion.protocols.protocol1_11to1_10.rewriter.EntityIdRewriter;
 import com.viaversion.viaversion.protocols.protocol1_11to1_10.Protocol1_11To1_10;
 import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.ClientboundPackets1_9_3;
 import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.ServerboundPackets1_9_3;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/rewriter/BlockEntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/rewriter/BlockEntityRewriter.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.protocol1_11to1_10;
+package com.viaversion.viaversion.protocols.protocol1_11to1_10.rewriter;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/rewriter/EntityIdRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_11to1_10/rewriter/EntityIdRewriter.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.protocol1_11to1_10;
+package com.viaversion.viaversion.protocols.protocol1_11to1_10.rewriter;
 
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/task/TabCompleteThread.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/task/TabCompleteThread.java
@@ -15,10 +15,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.protocol1_13to1_12_2;
+package com.viaversion.viaversion.protocols.protocol1_13to1_12_2.task;
 
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.storage.TabCompleteTracker;
 
 public class TabCompleteThread implements Runnable {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/data/BlockEntityIds.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/data/BlockEntityIds.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.protocol1_18to1_17_1;
+package com.viaversion.viaversion.protocols.protocol1_18to1_17_1.data;
 
 import com.viaversion.viaversion.api.Via;
 import java.util.Arrays;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/WorldPackets.java
@@ -35,7 +35,7 @@ import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_17;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_18;
 import com.viaversion.viaversion.protocols.protocol1_17_1to1_17.ClientboundPackets1_17_1;
-import com.viaversion.viaversion.protocols.protocol1_18to1_17_1.BlockEntityIds;
+import com.viaversion.viaversion.protocols.protocol1_18to1_17_1.data.BlockEntityIds;
 import com.viaversion.viaversion.protocols.protocol1_18to1_17_1.Protocol1_18To1_17_1;
 import com.viaversion.viaversion.protocols.protocol1_18to1_17_1.data.BlockEntities;
 import com.viaversion.viaversion.protocols.protocol1_18to1_17_1.storage.ChunkLightStorage;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/Protocol1_9_3To1_9_1_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/Protocol1_9_3To1_9_1_2.java
@@ -35,7 +35,7 @@ import com.viaversion.viaversion.api.protocol.remapper.ValueTransformer;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_9_1;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_9_3;
-import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.chunks.FakeTileEntity;
+import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.data.FakeTileEntity;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.ClientboundPackets1_9;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.ServerboundPackets1_9;
 import java.util.List;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/data/FakeTileEntity.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9_3to1_9_1_2/data/FakeTileEntity.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.chunks;
+package com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.data;
 
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.IntTag;


### PR DESCRIPTION
Just some very minor stuff I noticed while going through older protocols, 1.8 will get it's own pull request once I am done with ViaRewind