### PR TITLE
Add conversion methods to SerializerVersion and replace missing MCStructs usages

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/rewriter/ChatItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/rewriter/ChatItemRewriter.java
@@ -23,7 +23,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.viaversion.viaversion.util.ComponentUtil;
 import com.viaversion.viaversion.util.SerializerVersion;
-import com.viaversion.viaversion.util.TagUtil;
 
 public final class ChatItemRewriter {
 
@@ -45,7 +44,7 @@ public final class ChatItemRewriter {
 
                 if (type.equals("show_item")) {
                     final CompoundTag compound = ComponentUtil.deserializeLegacyShowItem(value, SerializerVersion.V1_8);
-                    hoverEvent.addProperty("value", TagUtil.toSNBT(compound, SerializerVersion.V1_12));
+                    hoverEvent.addProperty("value", SerializerVersion.V1_12.toSNBT(compound));
                 }
             } else if (obj.has("extra")) {
                 toClient(obj.get("extra"));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_1to1_19/Protocol1_19_1To1_19.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_1to1_19/Protocol1_19_1To1_19.java
@@ -49,11 +49,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import com.viaversion.viaversion.util.SerializerVersion;
 import net.lenni0451.mcstructs.core.TextFormatting;
 import net.lenni0451.mcstructs.text.ATextComponent;
 import net.lenni0451.mcstructs.text.Style;
 import net.lenni0451.mcstructs.text.components.TranslationComponent;
-import net.lenni0451.mcstructs.text.serializer.TextComponentSerializer;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class Protocol1_19_1To1_19 extends AbstractProtocol<ClientboundPackets1_19, ClientboundPackets1_19_1, ServerboundPackets1_19, ServerboundPackets1_19_1> {
@@ -392,11 +392,11 @@ public final class Protocol1_19_1To1_19 extends AbstractProtocol<ClientboundPack
                         Via.getPlatform().getLogger().warning("Unknown parameter for chat decoration: " + element.getValue());
                 }
                 if (argument != null) {
-                    arguments.add(TextComponentSerializer.V1_18.deserialize(argument));
+                    arguments.add(SerializerVersion.V1_18.toComponent(argument));
                 }
             }
         }
 
-        return TextComponentSerializer.V1_18.serializeJson(new TranslationComponent(translationKey, arguments));
+        return SerializerVersion.V1_18.toJson(new TranslationComponent(translationKey, arguments));
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
@@ -29,7 +29,6 @@ import net.lenni0451.mcstructs.text.Style;
 import net.lenni0451.mcstructs.text.events.hover.AHoverEvent;
 import net.lenni0451.mcstructs.text.events.hover.impl.TextHoverEvent;
 import net.lenni0451.mcstructs.text.serializer.LegacyStringDeserializer;
-import net.lenni0451.mcstructs.text.serializer.TextComponentCodec;
 import net.lenni0451.mcstructs.text.serializer.TextComponentSerializer;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -138,6 +137,6 @@ public final class ComponentUtil {
     }
 
     public static CompoundTag deserializeLegacyShowItem(final JsonElement element, final SerializerVersion version) {
-        return version.toTag(version.toComponent(element).asUnformattedString());
+        return (CompoundTag) version.toTag(version.toComponent(element).asUnformattedString());
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
@@ -54,7 +54,7 @@ public final class ComponentUtil {
 
     public static @Nullable JsonElement tagToJson(@Nullable final Tag tag) {
         try {
-            final ATextComponent component = TextComponentCodec.V1_20_3.deserializeNbtTree(tag);
+            final ATextComponent component = SerializerVersion.V1_20_3.toComponent(tag);
             return component != null ? SerializerVersion.V1_19_4.toJson(component) : null;
         } catch (final Exception e) {
             Via.getPlatform().getLogger().log(Level.SEVERE, "Error converting tag: " + tag, e);
@@ -68,8 +68,8 @@ public final class ComponentUtil {
         }
 
         try {
-            final ATextComponent component = TextComponentSerializer.V1_19_4.deserialize(element);
-            return trimStrings(TextComponentCodec.V1_20_3.serializeNbt(component));
+            final ATextComponent component = SerializerVersion.V1_19_4.toComponent(element);
+            return trimStrings(SerializerVersion.V1_20_3.toTag(component));
         } catch (final Exception e) {
             Via.getPlatform().getLogger().log(Level.SEVERE, "Error converting component: " + element, e);
             return new StringTag("<error>");
@@ -126,7 +126,7 @@ public final class ComponentUtil {
         if (itemData) {
             component.setParentStyle(new Style().setItalic(false));
         }
-        return TextComponentSerializer.V1_12.serialize(component);
+        return SerializerVersion.V1_12.toString(component);
     }
 
     public static String jsonToLegacy(final String value) {
@@ -134,11 +134,10 @@ public final class ComponentUtil {
     }
 
     public static String jsonToLegacy(final JsonElement value) {
-        return TextComponentSerializer.V1_12.deserialize(value).asLegacyFormatString();
+        return SerializerVersion.V1_12.toComponent(value).asLegacyFormatString();
     }
 
     public static CompoundTag deserializeLegacyShowItem(final JsonElement element, final SerializerVersion version) {
-        final ATextComponent component = version.jsonSerializer.deserialize(element);
-        return TagUtil.fromSNBT(component.asUnformattedString(), version);
+        return version.toTag(version.toComponent(element).asUnformattedString());
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/util/SerializerVersion.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/SerializerVersion.java
@@ -28,6 +28,8 @@ import net.lenni0451.mcstructs.text.serializer.TextComponentCodec;
 import net.lenni0451.mcstructs.text.serializer.TextComponentSerializer;
 
 public enum SerializerVersion {
+    V1_6(TextComponentSerializer.V1_6, null),
+    V1_7(TextComponentSerializer.V1_7, SNbtSerializer.V1_7),
     V1_8(TextComponentSerializer.V1_8, SNbtSerializer.V1_8),
     V1_9(TextComponentSerializer.V1_9, SNbtSerializer.V1_8),
     V1_12(TextComponentSerializer.V1_12, SNbtSerializer.V1_12),
@@ -41,16 +43,16 @@ public enum SerializerVersion {
     V1_20_3(TextComponentCodec.V1_20_3, SNbtSerializer.V1_14);
 
     final TextComponentSerializer jsonSerializer;
-    final SNbtSerializer<CompoundTag> snbtSerializer;
+    final SNbtSerializer<? extends Tag> snbtSerializer;
     final TextComponentCodec codec;
 
-    SerializerVersion(final TextComponentSerializer jsonSerializer, final SNbtSerializer<CompoundTag> snbtSerializer) {
+    SerializerVersion(final TextComponentSerializer jsonSerializer, final SNbtSerializer<? extends Tag> snbtSerializer) {
         this.jsonSerializer = jsonSerializer;
         this.snbtSerializer = snbtSerializer;
         this.codec = null;
     }
 
-    SerializerVersion(final TextComponentCodec codec, final SNbtSerializer<CompoundTag> snbtSerializer) {
+    SerializerVersion(final TextComponentCodec codec, final SNbtSerializer<? extends Tag> snbtSerializer) {
         this.codec = codec;
         this.jsonSerializer = codec.asSerializer();
         this.snbtSerializer = snbtSerializer;
@@ -86,7 +88,10 @@ public enum SerializerVersion {
         return codec.deserializeNbtTree(tag);
     }
 
-    public CompoundTag toTag(final String snbt) {
+    public Tag toTag(final String snbt) {
+        if (snbtSerializer == null) {
+            throw new IllegalStateException("Cannot convert SNBT to NBT with this version");
+        }
         try {
             return snbtSerializer.deserialize(snbt);
         } catch (SNbtDeserializeException e) {
@@ -94,7 +99,10 @@ public enum SerializerVersion {
         }
     }
 
-    public String toSNBT(final CompoundTag tag) {
+    public String toSNBT(final Tag tag) {
+        if (snbtSerializer == null) {
+            throw new IllegalStateException("Cannot convert SNBT to NBT with this version");
+        }
         try {
             return snbtSerializer.serialize(tag);
         } catch (SNbtSerializeException e) {

--- a/common/src/main/java/com/viaversion/viaversion/util/SerializerVersion.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/SerializerVersion.java
@@ -17,7 +17,6 @@
  */
 package com.viaversion.viaversion.util;
 
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.Tag;
 import com.google.gson.JsonElement;
 import net.lenni0451.mcstructs.snbt.SNbtSerializer;

--- a/common/src/main/java/com/viaversion/viaversion/util/TagUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/TagUtil.java
@@ -48,22 +48,6 @@ public final class TagUtil {
         listTag.getValue().replaceAll(t -> (T) handleDeep(null, t, consumer));
     }
 
-    public static String toSNBT(final Tag tag, final SerializerVersion version) {
-        try {
-            return version.snbtSerializer.serialize(tag);
-        } catch (final SNbtSerializeException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static CompoundTag fromSNBT(final String snbt, final SerializerVersion version) {
-        try {
-            return version.snbtSerializer.deserialize(snbt);
-        } catch (final SNbtDeserializeException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @FunctionalInterface
     public interface TagUpdater {
 


### PR DESCRIPTION
Allows us to re-use the component conversion abstraction in other projects as well.