### PR TITLE
Handle errors properly in <= 1.20 custom payload reading

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/remapper/PacketHandlers.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/remapper/PacketHandlers.java
@@ -22,11 +22,13 @@
  */
 package com.viaversion.viaversion.api.protocol.remapper;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.logging.Level;
 
 public abstract class PacketHandlers implements PacketHandler {
     private final List<PacketHandler> packetHandlers = new ArrayList<>();
@@ -126,6 +128,24 @@ public abstract class PacketHandlers implements PacketHandler {
      */
     public void handler(PacketHandler handler) {
         packetHandlers.add(handler);
+    }
+
+    /**
+     * Adds a packet handler which will suppress any exceptions thrown by the handler.
+     *
+     * @param handler packet handler
+     */
+    public void handlerSoftFail(PacketHandler handler) {
+        packetHandlers.add(h -> {
+            try {
+                handler.handle(h);
+            } catch (Exception e) {
+                if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
+                    Via.getPlatform().getLogger().log(Level.WARNING, "Failed to handle packet", e);
+                }
+                h.cancel();
+            }
+        });
     }
 
     /**

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
@@ -46,7 +46,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_9_3, Serv
             public void register() {
                 map(Type.STRING); // 0 - Channel
 
-                handler(wrapper -> {
+                handlerSoftFail(wrapper -> {
                     if (wrapper.get(Type.STRING, 0).equals("MC|TrList")) {
                         wrapper.passthrough(Type.INT); // Passthrough Window ID
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/packets/InventoryPackets.java
@@ -44,7 +44,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
             @Override
             public void register() {
                 map(Type.STRING); // Channel
-                handler(wrapper -> {
+                handlerSoftFail(wrapper -> {
                     String channel = Key.namespaced(wrapper.get(Type.STRING, 0));
                     if (channel.equals("minecraft:trader_list")) {
                         wrapper.passthrough(Type.INT); // Passthrough Window ID

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_2to1_13_1/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_2to1_13_1/packets/InventoryPackets.java
@@ -47,7 +47,7 @@ public class InventoryPackets {
             @Override
             public void register() {
                 map(Type.STRING); // Channel
-                handler(wrapper -> {
+                handlerSoftFail(wrapper -> {
                     String channel = Key.namespaced(wrapper.get(Type.STRING, 0));
                     if (channel.equals("minecraft:trader_list")) {
                         wrapper.passthrough(Type.INT); // Passthrough Window ID

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -101,7 +101,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
             public void register() {
                 map(Type.STRING); // 0 - Channel
 
-                handler(wrapper -> {
+                handlerSoftFail(wrapper -> {
                     String channel = wrapper.get(Type.STRING, 0);
                     // Handle stopsound change
                     if (channel.equals("MC|StopSound")) {
@@ -224,7 +224,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
             @Override
             public void register() {
                 map(Type.STRING); // Channel
-                handler(wrapper -> {
+                handlerSoftFail(wrapper -> {
                     String channel = wrapper.get(Type.STRING, 0);
                     String old = channel;
                     channel = getOldPluginChannelId(channel);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/packets/InventoryPackets.java
@@ -143,7 +143,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
             @Override
             public void register() {
                 map(Type.STRING); // Channel
-                handler(wrapper -> {
+                handlerSoftFail(wrapper -> {
                     String channel = Key.namespaced(wrapper.get(Type.STRING, 0));
                     if (channel.equals("minecraft:trader_list")) {
                         wrapper.setPacketType(ClientboundPackets1_14.TRADE_LIST);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
@@ -163,8 +163,9 @@ public class Protocol1_16To1_15_2 extends AbstractProtocol<ClientboundPackets1_1
             registerServerbound(ServerboundPackets1_16.PLUGIN_MESSAGE, new PacketHandlers() {
                 @Override
                 public void register() {
-                    handler(wrapper -> {
-                        String channel = wrapper.passthrough(Type.STRING);
+                    map(Type.STRING); // Channel
+                    handlerSoftFail(wrapper -> {
+                        final String channel = wrapper.get(Type.STRING, 0);
                         final String namespacedChannel = Key.namespaced(channel);
                         if (channel.length() > 32) {
                             if (!Via.getConfig().isSuppressConversionWarnings()) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/Protocol1_20_2To1_20.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/Protocol1_20_2To1_20.java
@@ -54,6 +54,7 @@ import com.viaversion.viaversion.protocols.protocol1_20_2to1_20.storage.LastTags
 import com.viaversion.viaversion.rewriter.SoundRewriter;
 import com.viaversion.viaversion.rewriter.TagRewriter;
 import java.util.UUID;
+import com.viaversion.viaversion.util.Key;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class Protocol1_20_2To1_20 extends AbstractProtocol<ClientboundPackets1_19_4, ClientboundPackets1_20_2, ServerboundPackets1_19_4, ServerboundPackets1_20_2> {
@@ -80,7 +81,7 @@ public final class Protocol1_20_2To1_20 extends AbstractProtocol<ClientboundPack
             protected void register() {
                 map(Type.STRING); // Channel
                 handlerSoftFail(wrapper -> {
-                    final String channel = wrapper.get(Type.STRING, 0);
+                    final String channel = Key.namespaced(wrapper.get(Type.STRING, 0));
                     if (channel.equals("minecraft:brand")) {
                         wrapper.passthrough(Type.STRING);
                         wrapper.clearInputBuffer();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/Protocol1_20_2To1_20.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_2to1_20/Protocol1_20_2To1_20.java
@@ -30,6 +30,7 @@ import com.viaversion.viaversion.api.protocol.packet.Direction;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.packet.State;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
+import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.rewriter.EntityRewriter;
 import com.viaversion.viaversion.api.rewriter.ItemRewriter;
@@ -52,7 +53,6 @@ import com.viaversion.viaversion.protocols.protocol1_20_2to1_20.storage.LastReso
 import com.viaversion.viaversion.protocols.protocol1_20_2to1_20.storage.LastTags;
 import com.viaversion.viaversion.rewriter.SoundRewriter;
 import com.viaversion.viaversion.rewriter.TagRewriter;
-import com.viaversion.viaversion.util.Key;
 import java.util.UUID;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -75,8 +75,21 @@ public final class Protocol1_20_2To1_20 extends AbstractProtocol<ClientboundPack
         soundRewriter.register1_19_3Sound(ClientboundPackets1_19_4.SOUND);
         soundRewriter.register1_19_3Sound(ClientboundPackets1_19_4.ENTITY_SOUND);
 
-        registerClientbound(ClientboundPackets1_19_4.PLUGIN_MESSAGE, this::sanitizeCustomPayload);
-        registerServerbound(ServerboundPackets1_20_2.PLUGIN_MESSAGE, this::sanitizeCustomPayload);
+        final PacketHandlers sanitizeCustomPayload = new PacketHandlers() {
+            @Override
+            protected void register() {
+                map(Type.STRING); // Channel
+                handlerSoftFail(wrapper -> {
+                    final String channel = wrapper.get(Type.STRING, 0);
+                    if (channel.equals("minecraft:brand")) {
+                        wrapper.passthrough(Type.STRING);
+                        wrapper.clearInputBuffer();
+                    }
+                });
+            }
+        };
+        registerClientbound(ClientboundPackets1_19_4.PLUGIN_MESSAGE, sanitizeCustomPayload);
+        registerServerbound(ServerboundPackets1_20_2.PLUGIN_MESSAGE, sanitizeCustomPayload);
 
         registerClientbound(ClientboundPackets1_19_4.RESOURCE_PACK, wrapper -> {
             final String url = wrapper.passthrough(Type.STRING);
@@ -313,14 +326,6 @@ public final class Protocol1_20_2To1_20 extends AbstractProtocol<ClientboundPack
             wrapper.user().get(ConfigurationState.class).addPacketToQueue(wrapper, false);
             wrapper.cancel();
         };
-    }
-
-    private void sanitizeCustomPayload(final PacketWrapper wrapper) throws Exception {
-        final String channel = Key.namespaced(wrapper.passthrough(Type.STRING));
-        if (channel.equals("minecraft:brand")) {
-            wrapper.passthrough(Type.STRING);
-            wrapper.clearInputBuffer();
-        }
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
@@ -264,7 +264,7 @@ public class PlayerPackets {
             @Override
             public void register() {
                 map(Type.STRING); // 0 - Channel Name
-                handler(wrapper -> {
+                handlerSoftFail(wrapper -> {
                     String name = wrapper.get(Type.STRING, 0);
                     if (name.equals("MC|BOpen")) {
                         wrapper.write(Type.VAR_INT, 0);
@@ -405,7 +405,7 @@ public class PlayerPackets {
             @Override
             public void register() {
                 map(Type.STRING); // 0 - Channel Name
-                handler(wrapper -> {
+                handlerSoftFail(wrapper -> {
                     String name = wrapper.get(Type.STRING, 0);
                     if (name.equals("MC|BSign")) {
                         Item item = wrapper.passthrough(Type.ITEM1_8);


### PR DESCRIPTION
This PR fixes pre 1.20 custom payload handling, Minecraft try catched the whole data/content reading code causes errors to *silently* fail, here the pre 1.20 custom payload handler:
<img width="660" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/d3416097-8fe4-45f8-af94-cb72aafa16e5">

Therefore I introduced PacketHandlers#handleSoftFail to line up with older protocols code