### PR TITLE
Make ViaVersion fake nbt format consistent

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/rewriter/ItemRewriter.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/rewriter/ItemRewriter.java
@@ -47,33 +47,60 @@ public interface ItemRewriter<T extends Protocol> extends Rewriter<T> {
 
     /**
      * Returns the item type of the current protocol.
+     *
      * @return item type
      */
-    @Nullable default Type<Item> itemType() {
+    @Nullable
+    default Type<Item> itemType() {
         return null;
     }
 
     /**
      * Returns the item array type of the current protocol.
+     *
      * @return item array type
      */
-    @Nullable default Type<Item[]> itemArrayType() {
+    @Nullable
+    default Type<Item[]> itemArrayType() {
         return null;
     }
 
     /**
      * Returns the mapped item type of the target protocol.
+     *
      * @return mapped item type
      */
-    @Nullable default Type<Item> mappedItemType() {
+    @Nullable
+    default Type<Item> mappedItemType() {
         return itemType();
     }
 
     /**
      * Returns the mapped item array type of the target protocol.
+     *
      * @return mapped item array type
      */
-    @Nullable default Type<Item[]> mappedItemArrayType() {
+    @Nullable
+    default Type<Item[]> mappedItemArrayType() {
         return itemArrayType();
+    }
+
+    /**
+     * Returns the NBT tag name used for storing original item data.
+     *
+     * @return NBT tag name
+     */
+    default String nbtTagName() {
+        return "VV|" + protocol().getClass().getSimpleName();
+    }
+
+    /**
+     * Prefixes the NBT tag name with the current protocol's {@link #nbtTagName()}.
+     *
+     * @param nbt NBT tag name
+     * @return prefixed NBT tag name
+     */
+    default String nbtTagName(final String nbt) {
+        return nbtTagName() + "|" + nbt;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -47,7 +47,6 @@ import java.util.Locale;
 import java.util.Optional;
 
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, ServerboundPackets1_13, Protocol1_13To1_12_2> {
-    private static final String NBT_TAG_NAME = "ViaVersion|" + Protocol1_13To1_12_2.class.getSimpleName();
 
     public InventoryPackets(Protocol1_13To1_12_2 protocol) {
         super(protocol, null, null);
@@ -319,7 +318,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
             if (display != null) {
                 StringTag name = display.getStringTag("Name");
                 if (name != null) {
-                    display.putString(NBT_TAG_NAME + "|Name", name.getValue());
+                    display.putString(nbtTagName("Name"), name.getValue());
                     name.setValue(ComponentUtil.legacyToJsonString(name.getValue(), true));
                 }
             }
@@ -382,7 +381,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
             ListTag<?> canPlaceOnTag = tag.getListTag("CanPlaceOn");
             if (canPlaceOnTag != null) {
                 ListTag<StringTag> newCanPlaceOn = new ListTag<>(StringTag.class);
-                tag.put(NBT_TAG_NAME + "|CanPlaceOn", canPlaceOnTag.copy());
+                tag.put(nbtTagName("CanPlaceOn"), canPlaceOnTag.copy());
                 for (Tag oldTag : canPlaceOnTag) {
                     Object value = oldTag.getValue();
                     String oldId = Key.stripMinecraftNamespace(value.toString());
@@ -405,7 +404,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
             ListTag<?> canDestroyTag = tag.getListTag("CanDestroy");
             if (canDestroyTag != null) {
                 ListTag<StringTag> newCanDestroy = new ListTag<>(StringTag.class);
-                tag.put(NBT_TAG_NAME + "|CanDestroy", canDestroyTag.copy());
+                tag.put(nbtTagName("CanDestroy"), canDestroyTag.copy());
                 for (Tag oldTag : canDestroyTag) {
                     Object value = oldTag.getValue();
                     String oldId = Key.stripMinecraftNamespace(value.toString());
@@ -456,7 +455,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
         if (Protocol1_13To1_12_2.MAPPINGS.getItemMappings().getNewId(rawId) == -1) {
             if (!isDamageable(item.identifier()) && item.identifier() != 358) { // Map
                 if (tag == null) item.setTag(tag = new CompoundTag());
-                tag.put(NBT_TAG_NAME, new IntTag(originalId)); // Data will be lost, saving original id
+                tag.put(nbtTagName(), new IntTag(originalId)); // Data will be lost, saving original id
             }
             if (item.identifier() == 31 && item.data() == 0) { // Shrub was removed
                 rawId = 32 << 4; // Dead Bush
@@ -515,11 +514,11 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
         // Use tag to get original ID and data
         if (tag != null) {
             // Check for valid tag
-            NumberTag viaTag = tag.getNumberTag(NBT_TAG_NAME);
+            NumberTag viaTag = tag.getNumberTag(nbtTagName());
             if (viaTag != null) {
                 rawId = viaTag.asInt();
                 // Remove the tag
-                tag.remove(NBT_TAG_NAME);
+                tag.remove(nbtTagName());
                 gotRawIdFromTag = true;
             }
         }
@@ -598,7 +597,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
             if (display != null) {
                 StringTag name = display.getStringTag("Name");
                 if (name != null) {
-                    Tag via = display.remove(NBT_TAG_NAME + "|Name");
+                    Tag via = display.remove(nbtTagName("Name"));
                     name.setValue(via instanceof StringTag ? (String) via.getValue() : ComponentUtil.jsonToLegacy(name.getValue()));
                 }
             }
@@ -662,8 +661,8 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                 }
                 tag.put("StoredEnchantments", newStoredEnch);
             }
-            if (tag.getListTag(NBT_TAG_NAME + "|CanPlaceOn") != null) {
-                tag.put("CanPlaceOn", tag.remove(NBT_TAG_NAME + "|CanPlaceOn"));
+            if (tag.getListTag(nbtTagName("CanPlaceOn")) != null) {
+                tag.put("CanPlaceOn", tag.remove(nbtTagName("CanPlaceOn")));
             } else if (tag.getListTag("CanPlaceOn") != null) {
                 ListTag<?> old = tag.getListTag("CanPlaceOn");
                 ListTag<StringTag> newCanPlaceOn = new ListTag<>(StringTag.class);
@@ -682,8 +681,8 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                 }
                 tag.put("CanPlaceOn", newCanPlaceOn);
             }
-            if (tag.getListTag(NBT_TAG_NAME + "|CanDestroy") != null) {
-                tag.put("CanDestroy", tag.remove(NBT_TAG_NAME + "|CanDestroy"));
+            if (tag.getListTag(nbtTagName("CanDestroy")) != null) {
+                tag.put("CanDestroy", tag.remove(nbtTagName("CanDestroy")));
             } else if (tag.getListTag("CanDestroy") != null) {
                 ListTag<?> old = tag.getListTag("CanDestroy");
                 ListTag<StringTag> newCanDestroy = new ListTag<>(StringTag.class);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/packets/InventoryPackets.java
@@ -46,7 +46,6 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, ServerboundPackets1_14, Protocol1_14To1_13_2> {
-    private static final String NBT_TAG_NAME = "ViaVersion|" + Protocol1_14To1_13_2.class.getSimpleName();
     private static final Set<String> REMOVED_RECIPE_TYPES = Sets.newHashSet("crafting_special_banneraddpattern", "crafting_special_repairitem");
     private static final ComponentRewriter<ClientboundPackets1_13> COMPONENT_REWRITER = new ComponentRewriter<ClientboundPackets1_13>(null, ComponentRewriter.ReadType.JSON) {
         @Override
@@ -246,7 +245,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
         if (display != null) {
             ListTag<StringTag> lore = display.getListTag("Lore", StringTag.class);
             if (lore != null) {
-                display.put(NBT_TAG_NAME + "|Lore", new ListTag<>(lore.copy().getValue())); // Save old lore
+                display.put(nbtTagName("Lore"), new ListTag<>(lore.copy().getValue())); // Save old lore
                 for (StringTag loreEntry : lore) {
                     String jsonText = ComponentUtil.legacyToJsonString(loreEntry.getValue(), true);
                     loreEntry.setValue(jsonText);
@@ -268,7 +267,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_13, Serve
         if (display != null) {
             ListTag<StringTag> lore = display.getListTag("Lore", StringTag.class);
             if (lore != null) {
-                Tag savedLore = display.remove(NBT_TAG_NAME + "|Lore");
+                Tag savedLore = display.remove(nbtTagName("Lore"));
                 if (savedLore instanceof ListTag) {
                     display.put("Lore", new ListTag<>(((ListTag<?>) savedLore).getValue()));
                 } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -60,8 +60,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<ClientboundPacket1_20_3, ServerboundPacket1_20_5, Protocol1_20_5To1_20_3> {
 
-    private final String tagMarker = "VV|" + protocol.getClass().getSimpleName();
-
     public BlockItemPacketRewriter1_20_5(final Protocol1_20_5To1_20_3 protocol) {
         super(protocol, Type.ITEM1_20_2, Type.ITEM1_20_2_ARRAY, Types1_20_5.ITEM, Types1_20_5.ITEM_ARRAY);
     }
@@ -318,7 +316,7 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
         //  StructuredDataKey.CONTAINER_LOOT
 
         // Add the original as custom data, to be re-used for creative clients as well
-        tag.putBoolean(tagMarker, true);
+        tag.putBoolean(nbtTagName(), true);
         data.add(StructuredDataKey.CUSTOM_DATA, tag);
         return item;
     }


### PR DESCRIPTION
Adding ItemRewriter#nbtTagName utils to prefix nbt tags with a consistent format: 
`<Platform>|<Protocol name>|<original nbt name>`