### PR TITLE
Improve horse armor patch in 1.8->1.9

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/storage/EntityTracker1_9.java
@@ -192,11 +192,13 @@ public class EntityTracker1_9 extends EntityTrackerBase {
                 }
             }
 
-            //ECHOPET Patch
-            if (type == EntityType.HORSE) {
-                // Wrong metadata value from EchoPet, patch since it's discontinued. (https://github.com/DSH105/EchoPet/blob/06947a8b08ce40be9a518c2982af494b3b99d140/modules/API/src/main/java/com/dsh105/echopet/compat/api/entity/HorseArmour.java#L22)
-                if (metadata.id() == 16 && (int) metadata.getValue() == Integer.MIN_VALUE)
+            // 1.8 can handle out of range values and will just not show any armor, 1.9+ clients will get
+            // exceptions and won't render the entity at all
+            if (type == EntityType.HORSE && metadata.id() == 16) {
+                final int value = metadata.value();
+                if (value < 0 || value > 3) { // no armor, iron armor, gold armor and diamond armor
                     metadata.setValue(0);
+                }
             }
 
             if (type == EntityType.PLAYER) {


### PR DESCRIPTION
1.8 can handle out of range values for the horse armor and will just not show any armor, 1.9+ clients will get exceptions and won't render the entity at all, this is nothing EchoPet related so I improved the fix to filter bad values in general.

1.8 handling:
<img width="797" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/af66c94f-8ec6-447c-ac0b-f48603983efc">
<img width="1222" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/78186c3e-6b97-4f1f-8b81-fffae391b50b">
![image](https://github.com/ViaVersion/ViaVersion/assets/60033407/cb10189c-53d8-4d7f-b4ec-b2e5e5bcd084)
