### PR TITLE
Preventing `NullPointerException` when calling `Via.getManager().addEnableListener()` after manager is initialized

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
@@ -329,7 +329,11 @@ public class ViaManagerImpl implements ViaManager {
      * @param runnable runnable to be executed
      */
     public void addEnableListener(Runnable runnable) {
-        enableListeners.add(runnable);
+        if (enableListeners != null) {
+            enableListeners.add(runnable);
+        } else {
+            runnable.run();
+        }
     }
 
     @Override


### PR DESCRIPTION
If an external plugin calls `Via.getManager().addEnableListener()` after `Via.getManager().init()` has been called, it causes a `NullPointerException`. In this pull request, to prevent this issue, if the manager is already initialized, it immediately executes the listener instead of raising an exception and causing the external plugin to fail during its loading process.