### PR TITLE
Fix 1.13 -> 1.12.2 block state metadata translation

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
@@ -41,7 +41,6 @@ public class MetadataRewriter1_13To1_12_2 extends EntityRewriter<ClientboundPack
         filter().mapMetaType(typeId -> Types1_13.META_TYPES.byId(typeId > 4 ? typeId + 1 : typeId));
         filter().metaType(Types1_13.META_TYPES.itemType).handler(((event, meta) -> protocol.getItemRewriter().handleItemToClient(meta.value())));
         filter().metaType(Types1_13.META_TYPES.blockStateType).handler(((event, meta) -> {
-            // Enderman held block and minecart display block
             int oldId = meta.value();
             int combined = (((oldId & 4095) << 4) | (oldId >> 12 & 15));
             int newId = WorldPackets.toNewId(combined);
@@ -65,6 +64,13 @@ public class MetadataRewriter1_13To1_12_2 extends EntityRewriter<ClientboundPack
         });
 
         filter().type(EntityTypes1_13.EntityType.ZOMBIE).addIndex(15); // Shaking
+
+        filter().type(EntityTypes1_13.EntityType.MINECART_ABSTRACT).index(9).handler((event, meta) -> {
+            int oldId = meta.value();
+            int combined = (((oldId & 4095) << 4) | (oldId >> 12 & 15));
+            int newId = WorldPackets.toNewId(combined);
+            meta.setValue(newId);
+        });
 
         filter().type(EntityTypes1_13.EntityType.AREA_EFFECT_CLOUD).handler((event, meta) -> {
             if (meta.id() == 9) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
@@ -40,7 +40,13 @@ public class MetadataRewriter1_13To1_12_2 extends EntityRewriter<ClientboundPack
     protected void registerRewrites() {
         filter().mapMetaType(typeId -> Types1_13.META_TYPES.byId(typeId > 4 ? typeId + 1 : typeId));
         filter().metaType(Types1_13.META_TYPES.itemType).handler(((event, meta) -> protocol.getItemRewriter().handleItemToClient(meta.value())));
-        filter().metaType(Types1_13.META_TYPES.blockStateType).handler(((event, meta) -> meta.setValue(WorldPackets.toNewId(meta.value()))));
+        filter().metaType(Types1_13.META_TYPES.blockStateType).handler(((event, meta) -> {
+            // Enderman held block and minecart display block
+            int oldId = meta.value();
+            int combined = (((oldId & 4095) << 4) | (oldId >> 12 & 15));
+            int newId = WorldPackets.toNewId(combined);
+            meta.setValue(newId);
+        }));
 
         // Previously unused, now swimming
         filter().index(0).handler((event, meta) -> meta.setValue((byte) ((byte) meta.getValue() & ~0x10)));
@@ -53,27 +59,12 @@ public class MetadataRewriter1_13To1_12_2 extends EntityRewriter<ClientboundPack
             }
         }));
 
-        filter().type(EntityTypes1_13.EntityType.ENDERMAN).index(12).handler((event, meta) -> {
-            // Remap held block to match new format for remapping to flat block
-            int stateId = meta.value();
-            int id = stateId & 4095;
-            int data = stateId >> 12 & 15;
-            meta.setValue((id << 4) | (data & 0xF));
-        });
-
         filter().type(EntityTypes1_13.EntityType.WOLF).index(17).handler((event, meta) -> {
             // Handle new colors
             meta.setValue(15 - (int) meta.getValue());
         });
 
         filter().type(EntityTypes1_13.EntityType.ZOMBIE).addIndex(15); // Shaking
-
-        filter().type(EntityTypes1_13.EntityType.MINECART_ABSTRACT).index(9).handler((event, meta) -> {
-            int oldId = meta.value();
-            int combined = (((oldId & 4095) << 4) | (oldId >> 12 & 15));
-            int newId = WorldPackets.toNewId(combined);
-            meta.setValue(newId);
-        });
 
         filter().type(EntityTypes1_13.EntityType.AREA_EFFECT_CLOUD).handler((event, meta) -> {
             if (meta.id() == 9) {


### PR DESCRIPTION
Fixes 1.13 -> 1.12.2 block state metadata translation by applying the transforms in the correct order (Previously it would first try to get the 1.13 block state with the raw 1.12.2 value instead of converting the 1.12.2 value to a proper 1.12.2 blockstate first)