### PR TITLE
Handle block states optional in <1.19.4

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/metadata/MetadataRewriter1_13_1To1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13_1to1_13/metadata/MetadataRewriter1_13_1To1_13.java
@@ -32,7 +32,7 @@ public class MetadataRewriter1_13_1To1_13 extends EntityRewriter<ClientboundPack
 
     @Override
     protected void registerRewrites() {
-        registerMetaTypeHandler(Types1_13.META_TYPES.itemType, Types1_13.META_TYPES.blockStateType, null, Types1_13.META_TYPES.particleType);
+        registerMetaTypeHandler(Types1_13.META_TYPES.itemType, Types1_13.META_TYPES.blockStateType, Types1_13.META_TYPES.particleType);
         filter().type(EntityTypes1_13.EntityType.MINECART_ABSTRACT).index(9).handler((event, meta) -> {
             int data = meta.value();
             meta.setValue(protocol.getMappingData().getNewBlockStateId(data));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
@@ -40,7 +40,11 @@ public class MetadataRewriter1_13To1_12_2 extends EntityRewriter<ClientboundPack
     protected void registerRewrites() {
         filter().mapMetaType(typeId -> Types1_13.META_TYPES.byId(typeId > 4 ? typeId + 1 : typeId));
         filter().metaType(Types1_13.META_TYPES.itemType).handler(((event, meta) -> protocol.getItemRewriter().handleItemToClient(meta.value())));
-        filter().metaType(Types1_13.META_TYPES.blockStateType).handler(((event, meta) -> meta.setValue(WorldPackets.toNewId(meta.value()))));
+        filter().metaType(Types1_13.META_TYPES.blockStateType).handler(((event, meta) -> {
+            if ((int) meta.value() != 0) {
+                meta.setValue(WorldPackets.toNewId(meta.value()));
+            }
+        }));
 
         // Previously unused, now swimming
         filter().index(0).handler((event, meta) -> meta.setValue((byte) ((byte) meta.getValue() & ~0x10)));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/metadata/MetadataRewriter1_13To1_12_2.java
@@ -41,8 +41,9 @@ public class MetadataRewriter1_13To1_12_2 extends EntityRewriter<ClientboundPack
         filter().mapMetaType(typeId -> Types1_13.META_TYPES.byId(typeId > 4 ? typeId + 1 : typeId));
         filter().metaType(Types1_13.META_TYPES.itemType).handler(((event, meta) -> protocol.getItemRewriter().handleItemToClient(meta.value())));
         filter().metaType(Types1_13.META_TYPES.blockStateType).handler(((event, meta) -> {
-            if ((int) meta.value() != 0) {
-                meta.setValue(WorldPackets.toNewId(meta.value()));
+            final int stateId = meta.value();
+            if (stateId != 0) {
+                meta.setValue(WorldPackets.toNewId(stateId));
             }
         }));
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/metadata/MetadataRewriter1_14To1_13_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/metadata/MetadataRewriter1_14To1_13_2.java
@@ -45,7 +45,7 @@ public class MetadataRewriter1_14To1_13_2 extends EntityRewriter<ClientboundPack
     @Override
     protected void registerRewrites() {
         filter().mapMetaType(Types1_14.META_TYPES::byId);
-        registerMetaTypeHandler(Types1_14.META_TYPES.itemType, Types1_14.META_TYPES.blockStateType, null, Types1_14.META_TYPES.particleType);
+        registerMetaTypeHandler(Types1_14.META_TYPES.itemType, Types1_14.META_TYPES.blockStateType, Types1_14.META_TYPES.particleType);
 
         filter().type(EntityTypes1_14.ENTITY).addIndex(6);
         filter().type(EntityTypes1_14.LIVINGENTITY).addIndex(12);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_15to1_14_4/metadata/MetadataRewriter1_15To1_14_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_15to1_14_4/metadata/MetadataRewriter1_15To1_14_4.java
@@ -33,7 +33,7 @@ public class MetadataRewriter1_15To1_14_4 extends EntityRewriter<ClientboundPack
 
     @Override
     protected void registerRewrites() {
-        registerMetaTypeHandler(Types1_14.META_TYPES.itemType, Types1_14.META_TYPES.blockStateType, null, Types1_14.META_TYPES.particleType);
+        registerMetaTypeHandler(Types1_14.META_TYPES.itemType, Types1_14.META_TYPES.blockStateType, Types1_14.META_TYPES.particleType);
         filter().type(EntityTypes1_15.MINECART_ABSTRACT).index(10).handler((metadatas, meta) -> {
             int data = meta.value();
             meta.setValue(protocol.getMappingData().getNewBlockStateId(data));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16_2to1_16_1/metadata/MetadataRewriter1_16_2To1_16_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16_2to1_16_1/metadata/MetadataRewriter1_16_2To1_16_1.java
@@ -34,7 +34,7 @@ public class MetadataRewriter1_16_2To1_16_1 extends EntityRewriter<ClientboundPa
 
     @Override
     protected void registerRewrites() {
-        registerMetaTypeHandler(Types1_16.META_TYPES.itemType, Types1_16.META_TYPES.blockStateType, null, Types1_16.META_TYPES.particleType);
+        registerMetaTypeHandler(Types1_16.META_TYPES.itemType, Types1_16.META_TYPES.blockStateType, Types1_16.META_TYPES.particleType);
         filter().type(EntityTypes1_16_2.MINECART_ABSTRACT).index(10).handler((metadatas, meta) -> {
             int data = meta.value();
             meta.setValue(protocol.getMappingData().getNewBlockStateId(data));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/metadata/MetadataRewriter1_16To1_15_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/metadata/MetadataRewriter1_16To1_15_2.java
@@ -37,7 +37,7 @@ public class MetadataRewriter1_16To1_15_2 extends EntityRewriter<ClientboundPack
     @Override
     protected void registerRewrites() {
         filter().mapMetaType(Types1_16.META_TYPES::byId);
-        registerMetaTypeHandler(Types1_16.META_TYPES.itemType, Types1_16.META_TYPES.blockStateType, null, Types1_16.META_TYPES.particleType);
+        registerMetaTypeHandler(Types1_16.META_TYPES.itemType, Types1_16.META_TYPES.blockStateType, Types1_16.META_TYPES.particleType);
         filter().type(EntityTypes1_16.MINECART_ABSTRACT).index(10).handler((metadatas, meta) -> {
             int data = meta.value();
             meta.setValue(protocol.getMappingData().getNewBlockStateId(data));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/EntityPackets.java
@@ -159,7 +159,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_16_2
                 meta.setValue(pose + 1);
             }
         });
-        registerMetaTypeHandler(Types1_17.META_TYPES.itemType, Types1_17.META_TYPES.blockStateType, null, Types1_17.META_TYPES.particleType);
+        registerMetaTypeHandler(Types1_17.META_TYPES.itemType, Types1_17.META_TYPES.blockStateType, Types1_17.META_TYPES.particleType);
 
         // Ticks frozen added with id 7
         filter().type(EntityTypes1_17.ENTITY).addIndex(7);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/EntityPackets.java
@@ -94,7 +94,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_17_1
             }
         });
 
-        registerMetaTypeHandler(Types1_18.META_TYPES.itemType,null, null);
+        registerMetaTypeHandler(Types1_18.META_TYPES.itemType, null, null);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_18to1_17_1/packets/EntityPackets.java
@@ -94,7 +94,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_17_1
             }
         });
 
-        registerMetaTypeHandler(Types1_18.META_TYPES.itemType, null, null, null);
+        registerMetaTypeHandler(Types1_18.META_TYPES.itemType,null, null);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_3to1_19_1/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19_3to1_19_1/packets/EntityPackets.java
@@ -152,7 +152,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_19_1
     @Override
     protected void registerRewrites() {
         filter().mapMetaType(typeId -> Types1_19_3.META_TYPES.byId(typeId >= 2 ? typeId + 1 : typeId)); // Long added
-        registerMetaTypeHandler(Types1_19_3.META_TYPES.itemType, Types1_19_3.META_TYPES.blockStateType, null, Types1_19_3.META_TYPES.particleType);
+        registerMetaTypeHandler(Types1_19_3.META_TYPES.itemType, Types1_19_3.META_TYPES.blockStateType, Types1_19_3.META_TYPES.particleType);
 
         filter().type(EntityTypes1_19_3.ENTITY).index(6).handler((event, meta) -> {
             // Sitting pose added

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_19to1_18_2/packets/EntityPackets.java
@@ -338,7 +338,7 @@ public final class EntityPackets extends EntityRewriter<ClientboundPackets1_18, 
             rewriteParticle(particle);
         });
 
-        registerMetaTypeHandler(Types1_19.META_TYPES.itemType, Types1_19.META_TYPES.blockStateType, null, null);
+        registerMetaTypeHandler(Types1_19.META_TYPES.itemType, Types1_19.META_TYPES.blockStateType, null);
 
         filter().type(EntityTypes1_19.MINECART_ABSTRACT).index(11).handler((event, meta) -> {
             // Convert to new block id

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -20,7 +20,6 @@ package com.viaversion.viaversion.rewriter;
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.NumberTag;
-import com.github.steveice10.opennbt.tag.builtin.Tag;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
@@ -210,19 +209,7 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
      * @param particleType           particle meta type if needed
      */
     public void registerMetaTypeHandler(@Nullable MetaType itemType, @Nullable MetaType blockStateType, @Nullable MetaType particleType) {
-        filter().handler((event, meta) -> {
-            final MetaType type = meta.metaType();
-            if (type == itemType) {
-                meta.setValue(protocol.getItemRewriter().handleItemToClient(meta.value()));
-            } else if (type == blockStateType) { // Actually optional
-                int data = meta.value();
-                if (data != 0) {
-                    meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
-                }
-            } else if (type == particleType) {
-                rewriteParticle(meta.value());
-            }
-        });
+        registerMetaTypeHandler(itemType, null, blockStateType, particleType);
     }
 
     /**

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -214,7 +214,7 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
             final MetaType type = meta.metaType();
             if (type == itemType) {
                 meta.setValue(protocol.getItemRewriter().handleItemToClient(meta.value()));
-            }if (type == blockStateType) { // Actually optional
+            } else if (type == blockStateType) { // Actually optional
                 int data = meta.value();
                 if (data != 0) {
                     meta.setValue(protocol.getMappingData().getNewBlockStateId(data));

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -207,6 +207,29 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
      *
      * @param itemType               item meta type if needed
      * @param blockStateType         block state meta type if needed
+     * @param particleType           particle meta type if needed
+     */
+    public void registerMetaTypeHandler(@Nullable MetaType itemType, @Nullable MetaType blockStateType, @Nullable MetaType particleType) {
+        filter().handler((event, meta) -> {
+            final MetaType type = meta.metaType();
+            if (type == itemType) {
+                meta.setValue(protocol.getItemRewriter().handleItemToClient(meta.value()));
+            }if (type == blockStateType) { // Actually optional
+                int data = meta.value();
+                if (data != 0) {
+                    meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
+                }
+            } else if (type == particleType) {
+                rewriteParticle(meta.value());
+            }
+        });
+    }
+
+    /**
+     * Registers a metadata handler to rewrite, item, block, and particle ids stored in metadata.
+     *
+     * @param itemType               item meta type if needed
+     * @param blockStateType         block state meta type if needed
      * @param optionalBlockStateType optional block state meta type if needed
      * @param particleType           particle meta type if needed
      */


### PR DESCRIPTION
This PR fixes block state reading in versions below 1.19.4 where there was only a block state type which is optional, we can probably also rename some of the meta type fields with ViaVersion 5.

1.19.3 code:
<img width="812" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/e1095631-fead-473e-8c9d-fc75d3fe7c09">

1.19.4 code:
<img width="886" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/0e6c8d98-0e6b-47aa-b9ee-d26ff0e40fc1">
