### PR TITLE
Add IdAndData util and replace conversions

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/util/IdAndData.java
+++ b/api/src/main/java/com/viaversion/viaversion/util/IdAndData.java
@@ -31,6 +31,10 @@ public class IdAndData {
     private int id;
     private byte data;
 
+    public IdAndData(int id) {
+        this(id, -1);
+    }
+
     public IdAndData(int id, int data) {
         Preconditions.checkArgument(data >= 0 && data <= 15, "Data has to be between 0 and 15: (id: " + id + " data: " + data + ")");
         this.id = id;
@@ -63,6 +67,10 @@ public class IdAndData {
 
     public int toCompressedData() {
         return toCompressedData(id, data);
+    }
+
+    public IdAndData withData(int data) {
+        return new IdAndData(this.id, data);
     }
 
     public int getId() {

--- a/api/src/main/java/com/viaversion/viaversion/util/IdAndData.java
+++ b/api/src/main/java/com/viaversion/viaversion/util/IdAndData.java
@@ -24,6 +24,7 @@
 package com.viaversion.viaversion.util;
 
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 public class IdAndData {
 
@@ -78,5 +79,27 @@ public class IdAndData {
 
     public void setData(final byte data) {
         this.data = data;
+    }
+
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IdAndData idAndData = (IdAndData) o;
+        return id == idAndData.id && data == idAndData.data;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, data);
+    }
+
+    @Override
+    public String toString() {
+        return "IdAndData{" +
+            "id=" + id +
+            ", data=" + data +
+            '}';
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/util/IdAndData.java
+++ b/api/src/main/java/com/viaversion/viaversion/util/IdAndData.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2024 ViaVersion and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.viaversion.viaversion.util;
+
+import com.google.common.base.Preconditions;
+
+public class IdAndData {
+
+    private int id;
+    private byte data;
+
+    public IdAndData(int id, int data) {
+        Preconditions.checkArgument(data >= 0 && data <= 15, "Data has to be between 0 and 15: (id: " + id + " data: " + data + ")");
+        this.id = id;
+        this.data = (byte) data;
+    }
+
+    public static int getId(final int compressedData) {
+        return compressedData >> 4;
+    }
+
+    public static int getData(final int compressedData) {
+        return compressedData & 15;
+    }
+
+    public static int toCompressedData(final int id) {
+        return id << 4;
+    }
+
+    public static int removeData(final int data) {
+        return data & ~15;
+    }
+
+    public static IdAndData fromCompressedData(final int compressedData) {
+        return new IdAndData(compressedData >> 4, compressedData & 15);
+    }
+
+    public static int toCompressedData(final int id, final int data) {
+        return (id << 4) | (data & 15);
+    }
+
+    public int toCompressedData() {
+        return toCompressedData(id, data);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(final int id) {
+        this.id = id;
+    }
+
+    public byte getData() {
+        return data;
+    }
+
+    public void setData(final byte data) {
+        this.data = data;
+    }
+}

--- a/api/src/main/java/com/viaversion/viaversion/util/IdAndData.java
+++ b/api/src/main/java/com/viaversion/viaversion/util/IdAndData.java
@@ -41,15 +41,15 @@ public class IdAndData {
         this.data = (byte) data;
     }
 
-    public static int getId(final int compressedData) {
-        return compressedData >> 4;
+    public static int getId(final int rawData) {
+        return rawData >> 4;
     }
 
-    public static int getData(final int compressedData) {
-        return compressedData & 15;
+    public static int getData(final int rawData) {
+        return rawData & 15;
     }
 
-    public static int toCompressedData(final int id) {
+    public static int toRawData(final int id) {
         return id << 4;
     }
 
@@ -57,16 +57,16 @@ public class IdAndData {
         return data & ~15;
     }
 
-    public static IdAndData fromCompressedData(final int compressedData) {
-        return new IdAndData(compressedData >> 4, compressedData & 15);
+    public static IdAndData fromRawData(final int rawData) {
+        return new IdAndData(rawData >> 4, rawData & 15);
     }
 
-    public static int toCompressedData(final int id, final int data) {
+    public static int toRawData(final int id, final int data) {
         return (id << 4) | (data & 15);
     }
 
-    public int toCompressedData() {
-        return toCompressedData(id, data);
+    public int toRawData() {
+        return toRawData(id, data);
     }
 
     public IdAndData withData(int data) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -318,7 +318,7 @@ public class Protocol1_13To1_12_2 extends AbstractProtocol<ClientboundPackets1_1
                 }
             } else {
                 for (int i = 0; i < 16; i++) {
-                    int newItem = MAPPINGS.getItemMappings().getNewId(IdAndData.toCompressedData(item, i));
+                    int newItem = MAPPINGS.getItemMappings().getNewId(IdAndData.toRawData(item, i));
                     if (newItem != -1) {
                         PacketWrapper packet = wrapper.create(ClientboundPackets1_13.COOLDOWN);
                         packet.write(Type.VAR_INT, newItem);
@@ -343,11 +343,11 @@ public class Protocol1_13To1_12_2 extends AbstractProtocol<ClientboundPackets1_1
                     int id = wrapper.get(Type.INT, 0);
                     int data = wrapper.get(Type.INT, 1);
                     if (id == 1010) { // Play record
-                        wrapper.set(Type.INT, 1, getMappingData().getItemMappings().getNewId(IdAndData.toCompressedData(data)));
+                        wrapper.set(Type.INT, 1, getMappingData().getItemMappings().getNewId(IdAndData.toRawData(data)));
                     } else if (id == 2001) { // Block break + block break sound
                         int blockId = data & 0xFFF;
                         int blockData = data >> 12;
-                        wrapper.set(Type.INT, 1, WorldPackets.toNewId(IdAndData.toCompressedData(blockId, blockData)));
+                        wrapper.set(Type.INT, 1, WorldPackets.toNewId(IdAndData.toRawData(blockId, blockData)));
                     }
                 });
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -65,6 +65,7 @@ import com.viaversion.viaversion.rewriter.SoundRewriter;
 import com.viaversion.viaversion.util.ChatColorUtil;
 import com.viaversion.viaversion.util.ComponentUtil;
 import com.viaversion.viaversion.util.GsonUtil;
+import com.viaversion.viaversion.util.IdAndData;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -317,7 +318,7 @@ public class Protocol1_13To1_12_2 extends AbstractProtocol<ClientboundPackets1_1
                 }
             } else {
                 for (int i = 0; i < 16; i++) {
-                    int newItem = MAPPINGS.getItemMappings().getNewId(item << 4 | i);
+                    int newItem = MAPPINGS.getItemMappings().getNewId(IdAndData.toCompressedData(item, i));
                     if (newItem != -1) {
                         PacketWrapper packet = wrapper.create(ClientboundPackets1_13.COOLDOWN);
                         packet.write(Type.VAR_INT, newItem);
@@ -342,11 +343,11 @@ public class Protocol1_13To1_12_2 extends AbstractProtocol<ClientboundPackets1_1
                     int id = wrapper.get(Type.INT, 0);
                     int data = wrapper.get(Type.INT, 1);
                     if (id == 1010) { // Play record
-                        wrapper.set(Type.INT, 1, getMappingData().getItemMappings().getNewId(data << 4));
+                        wrapper.set(Type.INT, 1, getMappingData().getItemMappings().getNewId(IdAndData.toCompressedData(data)));
                     } else if (id == 2001) { // Block break + block break sound
                         int blockId = data & 0xFFF;
                         int blockData = data >> 12;
-                        wrapper.set(Type.INT, 1, WorldPackets.toNewId(blockId << 4 | blockData));
+                        wrapper.set(Type.INT, 1, WorldPackets.toNewId(IdAndData.toCompressedData(blockId, blockData)));
                     }
                 });
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -39,6 +39,7 @@ import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.data.SoundSource
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.data.SpawnEggRewriter;
 import com.viaversion.viaversion.rewriter.ItemRewriter;
 import com.viaversion.viaversion.util.ComponentUtil;
+import com.viaversion.viaversion.util.IdAndData;
 import com.viaversion.viaversion.util.Key;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -270,7 +271,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
         // Save original id
         int originalId = (item.identifier() << 16 | item.data() & 0xFFFF);
 
-        int rawId = (item.identifier() << 4 | item.data() & 0xF);
+        int rawId = IdAndData.toCompressedData(item.identifier(), item.data());
 
         // NBT Additions
         if (isDamageable(item.identifier())) {
@@ -458,9 +459,9 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                 tag.put(nbtTagName(), new IntTag(originalId)); // Data will be lost, saving original id
             }
             if (item.identifier() == 31 && item.data() == 0) { // Shrub was removed
-                rawId = 32 << 4; // Dead Bush
-            } else if (Protocol1_13To1_12_2.MAPPINGS.getItemMappings().getNewId(rawId & ~0xF) != -1) {
-                rawId &= ~0xF; // Remove data
+                rawId = IdAndData.toCompressedData(32); // Dead Bush
+            } else if (Protocol1_13To1_12_2.MAPPINGS.getItemMappings().getNewId(IdAndData.removeData(rawId)) != -1) {
+                rawId = IdAndData.removeData(rawId);
             } else {
                 if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
                     Via.getPlatform().getLogger().warning("Failed to get 1.13 item for " + item.identifier());
@@ -538,7 +539,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                         tag.put("EntityTag", entityTag);
                     }
                 } else {
-                    rawId = (oldId >> 4) << 16 | oldId & 0xF;
+                    rawId = IdAndData.getId(oldId) << 16 | oldId & 0xF;
                 }
             }
         }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -271,7 +271,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
         // Save original id
         int originalId = (item.identifier() << 16 | item.data() & 0xFFFF);
 
-        int rawId = IdAndData.toCompressedData(item.identifier(), item.data());
+        int rawId = IdAndData.toRawData(item.identifier(), item.data());
 
         // NBT Additions
         if (isDamageable(item.identifier())) {
@@ -459,7 +459,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                 tag.put(nbtTagName(), new IntTag(originalId)); // Data will be lost, saving original id
             }
             if (item.identifier() == 31 && item.data() == 0) { // Shrub was removed
-                rawId = IdAndData.toCompressedData(32); // Dead Bush
+                rawId = IdAndData.toRawData(32); // Dead Bush
             } else if (Protocol1_13To1_12_2.MAPPINGS.getItemMappings().getNewId(IdAndData.removeData(rawId)) != -1) {
                 rawId = IdAndData.removeData(rawId);
             } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -45,6 +45,7 @@ import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.data.ParticleRew
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.providers.BlockEntityProvider;
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.providers.PaintingProvider;
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.storage.BlockStorage;
+import com.viaversion.viaversion.util.IdAndData;
 import com.viaversion.viaversion.util.Key;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -569,7 +570,7 @@ public class WorldPackets {
         if (newId != -1) {
             return newId;
         }
-        newId = Protocol1_13To1_12_2.MAPPINGS.getBlockMappings().getNewId(oldId & ~0xF); // Remove data
+        newId = Protocol1_13To1_12_2.MAPPINGS.getBlockMappings().getNewId(IdAndData.removeData(oldId)); // Remove data
         if (newId != -1) {
             if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
                 Via.getPlatform().getLogger().warning("Missing block " + oldId);


### PR DESCRIPTION
Basically ViaBackwards's Block class but with some additions and error handlers for ViaLegacy/ViaRewind. This replaces https://github.com/ViaVersion/ViaLegacy/blob/main/src/main/java/net/raphimc/vialegacy/api/model/IdAndData.java and https://github.com/ViaVersion/ViaBackwards/blob/dev/common/src/main/java/com/viaversion/viabackwards/utils/Block.java and also some otherwise dirty conversions in existing protocols.