### PR TITLE
Replace incoming/outgoing usages with client/server bound

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -165,7 +165,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                         channel = getNewPluginChannelId(channel);
                         if (channel == null) {
                             if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                                Via.getPlatform().getLogger().warning("Ignoring outgoing plugin message with channel: " + old);
+                                Via.getPlatform().getLogger().warning("Ignoring client bound plugin message with channel: " + old);
                             }
                             wrapper.cancel();
                             return;
@@ -177,7 +177,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                                 if (rewritten != null) {
                                     rewrittenChannels.add(rewritten);
                                 } else if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                                    Via.getPlatform().getLogger().warning("Ignoring plugin channel in outgoing REGISTER: " + s);
+                                    Via.getPlatform().getLogger().warning("Ignoring plugin channel in client bound " + Key.stripMinecraftNamespace(channel).toUpperCase(Locale.ROOT) + ": " + s);
                                 }
                             }
                             if (!rewrittenChannels.isEmpty()) {
@@ -229,7 +229,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                     channel = getOldPluginChannelId(channel);
                     if (channel == null) {
                         if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                            Via.getPlatform().getLogger().warning("Ignoring incoming plugin message with channel: " + old);
+                            Via.getPlatform().getLogger().warning("Ignoring server bound plugin message with channel: " + old);
                         }
                         wrapper.cancel();
                         return;
@@ -241,7 +241,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                             if (rewritten != null) {
                                 rewrittenChannels.add(rewritten);
                             } else if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                                Via.getPlatform().getLogger().warning("Ignoring plugin channel in incoming REGISTER: " + s);
+                                Via.getPlatform().getLogger().warning("Ignoring plugin channel in server bound " + channel + ": " + s);
                             }
                         }
                         wrapper.write(Type.REMAINING_BYTES, Joiner.on('\0').join(rewrittenChannels).getBytes(StandardCharsets.UTF_8));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -165,7 +165,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                         channel = getNewPluginChannelId(channel);
                         if (channel == null) {
                             if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                                Via.getPlatform().getLogger().warning("Ignoring client bound plugin message with channel: " + old);
+                                Via.getPlatform().getLogger().warning("Ignoring clientbound plugin message with channel: " + old);
                             }
                             wrapper.cancel();
                             return;
@@ -177,7 +177,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                                 if (rewritten != null) {
                                     rewrittenChannels.add(rewritten);
                                 } else if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                                    Via.getPlatform().getLogger().warning("Ignoring plugin channel in client bound " + Key.stripMinecraftNamespace(channel).toUpperCase(Locale.ROOT) + ": " + s);
+                                    Via.getPlatform().getLogger().warning("Ignoring plugin channel in clientbound " + Key.stripMinecraftNamespace(channel).toUpperCase(Locale.ROOT) + ": " + s);
                                 }
                             }
                             if (!rewrittenChannels.isEmpty()) {
@@ -229,7 +229,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                     channel = getOldPluginChannelId(channel);
                     if (channel == null) {
                         if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                            Via.getPlatform().getLogger().warning("Ignoring server bound plugin message with channel: " + old);
+                            Via.getPlatform().getLogger().warning("Ignoring serverbound plugin message with channel: " + old);
                         }
                         wrapper.cancel();
                         return;
@@ -241,7 +241,7 @@ public class InventoryPackets extends ItemRewriter<ClientboundPackets1_12_1, Ser
                             if (rewritten != null) {
                                 rewrittenChannels.add(rewritten);
                             } else if (!Via.getConfig().isSuppressConversionWarnings() || Via.getManager().isDebug()) {
-                                Via.getPlatform().getLogger().warning("Ignoring plugin channel in server bound " + channel + ": " + s);
+                                Via.getPlatform().getLogger().warning("Ignoring plugin channel in serverbound " + channel + ": " + s);
                             }
                         }
                         wrapper.write(Type.REMAINING_BYTES, Joiner.on('\0').join(rewrittenChannels).getBytes(StandardCharsets.UTF_8));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
@@ -169,7 +169,7 @@ public class Protocol1_16To1_15_2 extends AbstractProtocol<ClientboundPackets1_1
                         final String namespacedChannel = Key.namespaced(channel);
                         if (channel.length() > 32) {
                             if (!Via.getConfig().isSuppressConversionWarnings()) {
-                                Via.getPlatform().getLogger().warning("Ignoring incoming plugin channel, as it is longer than 32 characters: " + channel);
+                                Via.getPlatform().getLogger().warning("Ignoring server bound plugin channel, as it is longer than 32 characters: " + channel);
                             }
                             wrapper.cancel();
                         } else if (namespacedChannel.equals("minecraft:register") || namespacedChannel.equals("minecraft:unregister")) {
@@ -178,7 +178,7 @@ public class Protocol1_16To1_15_2 extends AbstractProtocol<ClientboundPackets1_1
                             for (String registeredChannel : channels) {
                                 if (registeredChannel.length() > 32) {
                                     if (!Via.getConfig().isSuppressConversionWarnings()) {
-                                        Via.getPlatform().getLogger().warning("Ignoring incoming plugin channel register of '"
+                                        Via.getPlatform().getLogger().warning("Ignoring server bound plugin channel register of '"
                                                 + registeredChannel + "', as it is longer than 32 characters");
                                     }
                                     continue;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/Protocol1_16To1_15_2.java
@@ -169,7 +169,7 @@ public class Protocol1_16To1_15_2 extends AbstractProtocol<ClientboundPackets1_1
                         final String namespacedChannel = Key.namespaced(channel);
                         if (channel.length() > 32) {
                             if (!Via.getConfig().isSuppressConversionWarnings()) {
-                                Via.getPlatform().getLogger().warning("Ignoring server bound plugin channel, as it is longer than 32 characters: " + channel);
+                                Via.getPlatform().getLogger().warning("Ignoring serverbound plugin channel, as it is longer than 32 characters: " + channel);
                             }
                             wrapper.cancel();
                         } else if (namespacedChannel.equals("minecraft:register") || namespacedChannel.equals("minecraft:unregister")) {
@@ -178,7 +178,7 @@ public class Protocol1_16To1_15_2 extends AbstractProtocol<ClientboundPackets1_1
                             for (String registeredChannel : channels) {
                                 if (registeredChannel.length() > 32) {
                                     if (!Via.getConfig().isSuppressConversionWarnings()) {
-                                        Via.getPlatform().getLogger().warning("Ignoring server bound plugin channel register of '"
+                                        Via.getPlatform().getLogger().warning("Ignoring serverbound plugin channel register of '"
                                                 + registeredChannel + "', as it is longer than 32 characters");
                                     }
                                     continue;


### PR DESCRIPTION
Since VV supports both server and client side, it makes more sense to use client/server bound as wording since incoming/outgoing will always be wrong on one side. Also changed 1.12->1.13 handlers to print the correct channel name.