### PR TITLE
Remove Protocol1_9To1_8#FIX_JSON usage in 1.11->1.12

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/Protocol1_12To1_11_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_12to1_11_1/Protocol1_12To1_11_1.java
@@ -100,11 +100,11 @@ public class Protocol1_12To1_11_1 extends AbstractProtocol<ClientboundPackets1_9
         registerClientbound(ClientboundPackets1_9_3.CHAT_MESSAGE, wrapper -> {
             if (!Via.getConfig().is1_12NBTArrayFix()) return;
             try {
-                JsonElement obj = Protocol1_9To1_8.FIX_JSON.transform(null, wrapper.passthrough(Type.COMPONENT).toString());
-                TranslateRewriter.toClient(obj);
-                ChatItemRewriter.toClient(obj);
+                final JsonElement element = wrapper.passthrough(Type.COMPONENT);
+                TranslateRewriter.toClient(element);
+                ChatItemRewriter.toClient(element);
 
-                wrapper.set(Type.COMPONENT, 0, obj);
+                wrapper.set(Type.COMPONENT, 0, element);
             } catch (Exception e) {
                 Via.getPlatform().getLogger().log(Level.WARNING, "Error converting 1.11.2 -> 1.12 chat item", e);
             }


### PR DESCRIPTION
The current code doesn't make any sense as it converts an existing **JsonElement** to a string and then back to a **JsonElement**, there is no reason to do this and since I want to remove fixJson() I would like to change this.