### PR TITLE
Replace string->component conversion in 1.8->1.9

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -236,13 +236,6 @@ public interface ViaVersionConfig extends Config {
     boolean isChunkBorderFix();
 
     /**
-     * Force json transform
-     *
-     * @return true if enabled
-     */
-    boolean isForceJsonTransform();
-
-    /**
      * Should we fix nbt array's in json chat messages for 1.12 clients
      *
      * @return true if enabled

--- a/bukkit-legacy/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_9to1_8/DeathListener.java
+++ b/bukkit-legacy/src/main/java/com/viaversion/viaversion/bukkit/listeners/protocol1_9to1_8/DeathListener.java
@@ -63,7 +63,7 @@ public class DeathListener extends ViaBukkitListener {
                     wrapper.write(Type.VAR_INT, 2); // Event - Entity dead
                     wrapper.write(Type.VAR_INT, p.getEntityId()); // Player ID
                     wrapper.write(Type.INT, p.getEntityId()); // Entity ID
-                    Protocol1_9To1_8.FIX_JSON.write(wrapper, msg); // Message
+                    Protocol1_9To1_8.STRING_TO_JSON.write(wrapper, msg); // Message
 
                     wrapper.scheduleSend(Protocol1_9To1_8.class);
                 } catch (Exception e) {

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -63,7 +63,6 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private int pistonReplacementId;
     private boolean chunkBorderFix;
     private boolean autoTeam;
-    private boolean forceJsonTransform;
     private boolean nbtArrayFix;
     private BlockedProtocolVersions blockedProtocolVersions;
     private String blockedDisconnectMessage;
@@ -128,7 +127,6 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         pistonReplacementId = getInt("replacement-piston-id", 0);
         chunkBorderFix = getBoolean("chunk-border-fix", false);
         autoTeam = getBoolean("auto-team", true);
-        forceJsonTransform = getBoolean("force-json-transform", false);
         nbtArrayFix = getBoolean("chat-nbt-fix", true);
         blockedProtocolVersions = loadBlockedProtocolVersions();
         blockedDisconnectMessage = getString("block-disconnect-msg", "You are using an unsupported Minecraft version!");
@@ -367,11 +365,6 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     public boolean isAutoTeam() {
         // Collision has to be enabled first
         return preventCollision && autoTeam;
-    }
-
-    @Override
-    public boolean isForceJsonTransform() {
-        return forceJsonTransform;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/legacy/bossbar/CommonBoss.java
+++ b/common/src/main/java/com/viaversion/viaversion/legacy/bossbar/CommonBoss.java
@@ -245,7 +245,7 @@ public class CommonBoss implements BossBar {
             wrapper.write(Type.VAR_INT, action.getId());
             switch (action) {
                 case ADD:
-                    Protocol1_9To1_8.FIX_JSON.write(wrapper, title);
+                    Protocol1_9To1_8.STRING_TO_JSON.write(wrapper, title);
                     wrapper.write(Type.FLOAT, health);
                     wrapper.write(Type.VAR_INT, color.getId());
                     wrapper.write(Type.VAR_INT, style.getId());
@@ -257,7 +257,7 @@ public class CommonBoss implements BossBar {
                     wrapper.write(Type.FLOAT, health);
                     break;
                 case UPDATE_TITLE:
-                    Protocol1_9To1_8.FIX_JSON.write(wrapper, title);
+                    Protocol1_9To1_8.STRING_TO_JSON.write(wrapper, title);
                     break;
                 case UPDATE_STYLE:
                     wrapper.write(Type.VAR_INT, color.getId());

--- a/common/src/main/java/com/viaversion/viaversion/legacy/bossbar/CommonBoss.java
+++ b/common/src/main/java/com/viaversion/viaversion/legacy/bossbar/CommonBoss.java
@@ -29,6 +29,7 @@ import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.ClientboundPackets1_9;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.Protocol1_9To1_8;
+import com.viaversion.viaversion.util.ComponentUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -245,7 +246,7 @@ public class CommonBoss implements BossBar {
             wrapper.write(Type.VAR_INT, action.getId());
             switch (action) {
                 case ADD:
-                    Protocol1_9To1_8.STRING_TO_JSON.write(wrapper, title);
+                    wrapper.write(Type.COMPONENT, ComponentUtil.plainToJson(title));
                     wrapper.write(Type.FLOAT, health);
                     wrapper.write(Type.VAR_INT, color.getId());
                     wrapper.write(Type.VAR_INT, style.getId());
@@ -257,7 +258,7 @@ public class CommonBoss implements BossBar {
                     wrapper.write(Type.FLOAT, health);
                     break;
                 case UPDATE_TITLE:
-                    Protocol1_9To1_8.STRING_TO_JSON.write(wrapper, title);
+                    wrapper.write(Type.COMPONENT, ComponentUtil.plainToJson(title));
                     break;
                 case UPDATE_STYLE:
                     wrapper.write(Type.VAR_INT, color.getId());

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
@@ -37,8 +37,8 @@ import com.viaversion.viaversion.protocol.ServerProtocolVersionSingleton;
 import com.viaversion.viaversion.protocols.base.packet.BaseClientboundPacket;
 import com.viaversion.viaversion.protocols.base.packet.BasePacketTypesProvider;
 import com.viaversion.viaversion.protocols.base.packet.BaseServerboundPacket;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.Protocol1_9To1_8;
 import com.viaversion.viaversion.util.ChatColorUtil;
+import com.viaversion.viaversion.util.ComponentUtil;
 import com.viaversion.viaversion.util.GsonUtil;
 import io.netty.channel.ChannelFuture;
 import java.util.List;
@@ -163,8 +163,10 @@ public class BaseProtocol1_7 extends AbstractProtocol<BaseClientboundPacket, Bas
                 if (!wrapper.user().getChannel().isOpen()) return;
                 if (!wrapper.user().shouldApplyBlockProtocol()) return;
 
+                final String disconnectMessage = ChatColorUtil.translateAlternateColorCodes(Via.getConfig().getBlockedDisconnectMsg());
+
                 PacketWrapper disconnectPacket = PacketWrapper.create(ClientboundLoginPackets.LOGIN_DISCONNECT, wrapper.user()); // Disconnect Packet
-                Protocol1_9To1_8.STRING_TO_JSON.write(disconnectPacket, ChatColorUtil.translateAlternateColorCodes(Via.getConfig().getBlockedDisconnectMsg()));
+                wrapper.write(Type.COMPONENT, ComponentUtil.plainToJson(disconnectMessage));
                 wrapper.cancel(); // cancel current
 
                 // Send and close

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol1_7.java
@@ -164,7 +164,7 @@ public class BaseProtocol1_7 extends AbstractProtocol<BaseClientboundPacket, Bas
                 if (!wrapper.user().shouldApplyBlockProtocol()) return;
 
                 PacketWrapper disconnectPacket = PacketWrapper.create(ClientboundLoginPackets.LOGIN_DISCONNECT, wrapper.user()); // Disconnect Packet
-                Protocol1_9To1_8.FIX_JSON.write(disconnectPacket, ChatColorUtil.translateAlternateColorCodes(Via.getConfig().getBlockedDisconnectMsg()));
+                Protocol1_9To1_8.STRING_TO_JSON.write(disconnectPacket, ChatColorUtil.translateAlternateColorCodes(Via.getConfig().getBlockedDisconnectMsg()));
                 wrapper.cancel(); // cancel current
 
                 // Send and close

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_16to1_15_2/packets/InventoryPackets.java
@@ -22,7 +22,6 @@ import com.github.steveice10.opennbt.tag.builtin.IntArrayTag;
 import com.github.steveice10.opennbt.tag.builtin.ListTag;
 import com.github.steveice10.opennbt.tag.builtin.NumberTag;
 import com.github.steveice10.opennbt.tag.builtin.StringTag;
-import com.github.steveice10.opennbt.tag.builtin.Tag;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/ItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/ItemRewriter.java
@@ -283,7 +283,7 @@ public class ItemRewriter {
 
                 for (int i = 0; i < pages.size(); i++) {
                     final StringTag page = pages.get(i);
-                    page.setValue(ComponentUtil.convertJson(page.getValue(), SerializerVersion.V1_8, SerializerVersion.V1_9).toString());
+                    page.setValue(ComponentUtil.convertJsonOrEmpty(page.getValue(), SerializerVersion.V1_8, SerializerVersion.V1_9).toString());
                 }
                 item.setTag(tag);
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
@@ -56,7 +56,7 @@ public class Protocol1_9To1_8 extends AbstractProtocol<ClientboundPackets1_8, Cl
     public static final ValueTransformer<String, JsonElement> STRING_TO_JSON = new ValueTransformer<String, JsonElement>(Type.COMPONENT) {
         @Override
         public JsonElement transform(PacketWrapper wrapper, String line) {
-            return Protocol1_9To1_8.toJson(line);
+            return ComponentUtil.convertJson(line, SerializerVersion.V1_8, SerializerVersion.V1_9);
         }
     };
     private final MetadataRewriter1_9To1_8 metadataRewriter = new MetadataRewriter1_9To1_8(this);
@@ -93,7 +93,7 @@ public class Protocol1_9To1_8 extends AbstractProtocol<ClientboundPackets1_8, Cl
                 return;
             }
 
-            wrapper.write(Type.COMPONENT, toJson(wrapper.read(Type.STRING)));
+            STRING_TO_JSON.write(wrapper, wrapper.read(Type.STRING));
         });
 
         // Other Handlers
@@ -102,16 +102,6 @@ public class Protocol1_9To1_8 extends AbstractProtocol<ClientboundPackets1_8, Cl
         EntityPackets.register(this);
         PlayerPackets.register(this);
         WorldPackets.register(this);
-    }
-
-    public static JsonElement toJson(final String line) {
-        try {
-            // Rewrite to new format if already in json
-            return ComponentUtil.convertJson(line, SerializerVersion.V1_8, SerializerVersion.V1_9);
-        } catch (Exception e) {
-            // If plain text, convert to json
-            return ComponentUtil.plainToJson(line);
-        }
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
@@ -56,13 +56,7 @@ public class Protocol1_9To1_8 extends AbstractProtocol<ClientboundPackets1_8, Cl
     public static final ValueTransformer<String, JsonElement> STRING_TO_JSON = new ValueTransformer<String, JsonElement>(Type.COMPONENT) {
         @Override
         public JsonElement transform(PacketWrapper wrapper, String line) {
-            try {
-                // Rewrite to new format if already in json
-                return ComponentUtil.convertJson(line, SerializerVersion.V1_8, SerializerVersion.V1_9);
-            } catch (Exception e) {
-                // If plain text, convert to json
-                return ComponentUtil.plainToJson(line);
-            }
+            return Protocol1_9To1_8.toJson(line);
         }
     };
     private final MetadataRewriter1_9To1_8 metadataRewriter = new MetadataRewriter1_9To1_8(this);
@@ -112,10 +106,11 @@ public class Protocol1_9To1_8 extends AbstractProtocol<ClientboundPackets1_8, Cl
 
     public static JsonElement toJson(final String line) {
         try {
-            return STRING_TO_JSON.transform(null, line);
+            // Rewrite to new format if already in json
+            return ComponentUtil.convertJson(line, SerializerVersion.V1_8, SerializerVersion.V1_9);
         } catch (Exception e) {
-            Via.getPlatform().getLogger().warning("Invalid JSON String: \"" + line + "\" Please report this issue to the ViaVersion Github: " + e.getMessage());
-            return ComponentUtil.emptyJsonComponent();
+            // If plain text, convert to json
+            return ComponentUtil.plainToJson(line);
         }
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
@@ -56,7 +56,7 @@ public class Protocol1_9To1_8 extends AbstractProtocol<ClientboundPackets1_8, Cl
     public static final ValueTransformer<String, JsonElement> STRING_TO_JSON = new ValueTransformer<String, JsonElement>(Type.COMPONENT) {
         @Override
         public JsonElement transform(PacketWrapper wrapper, String line) {
-            return ComponentUtil.convertJson(line, SerializerVersion.V1_8, SerializerVersion.V1_9);
+            return ComponentUtil.convertJsonOrEmpty(line, SerializerVersion.V1_8, SerializerVersion.V1_9);
         }
     };
     private final MetadataRewriter1_9To1_8 metadataRewriter = new MetadataRewriter1_9To1_8(this);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetaIndex.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetaIndex.java
@@ -159,7 +159,7 @@ public enum MetaIndex {
     ABSTRACT_MINECART_BLOCK_Y(MINECART_ABSTRACT, 21, MetaType1_8.Int, 9, MetaType1_9.VarInt),
     ABSTRACT_MINECART_SHOW_BLOCK(MINECART_ABSTRACT, 22, MetaType1_8.Byte, 10, MetaType1_9.Boolean),
 
-    // Command minecart (they are still broken)
+    // Command minecart
     MINECART_COMMAND_BLOCK_COMMAND(MINECART_ABSTRACT, 23, MetaType1_8.String, 11, MetaType1_9.String),
     MINECART_COMMAND_BLOCK_OUTPUT(MINECART_ABSTRACT, 24, MetaType1_8.String, 12, MetaType1_9.Chat),
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_9to1_8.metadata;
 
+import com.google.gson.JsonElement;
 import com.viaversion.viaversion.api.minecraft.EulerAngle;
 import com.viaversion.viaversion.api.minecraft.Vector;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
@@ -30,6 +31,8 @@ import com.viaversion.viaversion.protocols.protocol1_9to1_8.ItemRewriter;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.Protocol1_9To1_8;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.rewriter.meta.MetaHandlerEvent;
+import com.viaversion.viaversion.util.ComponentUtil;
+import com.viaversion.viaversion.util.SerializerVersion;
 import java.util.UUID;
 
 public class MetadataRewriter1_9To1_8 extends EntityRewriter<ClientboundPackets1_8, Protocol1_9To1_8> {
@@ -127,8 +130,8 @@ public class MetadataRewriter1_9To1_8 extends EntityRewriter<ClientboundPackets1
                 metadata.setValue(angle);
                 break;
             case Chat:
-                value = Protocol1_9To1_8.fixJson(value.toString());
-                metadata.setValue(value);
+                JsonElement json = (JsonElement) value;
+                metadata.setValue(ComponentUtil.convertJson(json, SerializerVersion.V1_8, SerializerVersion.V1_9));
                 break;
             case BlockID:
                 // Convert from int, short, byte

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
@@ -17,7 +17,6 @@
  */
 package com.viaversion.viaversion.protocols.protocol1_9to1_8.metadata;
 
-import com.google.gson.JsonElement;
 import com.viaversion.viaversion.api.minecraft.EulerAngle;
 import com.viaversion.viaversion.api.minecraft.Vector;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
@@ -132,7 +131,7 @@ public class MetadataRewriter1_9To1_8 extends EntityRewriter<ClientboundPackets1
             case Chat:
                 // Was previously also a component, so just convert it
                 String text = (String) value;
-                metadata.setValue(ComponentUtil.convertJson(text, SerializerVersion.V1_8, SerializerVersion.V1_9));
+                metadata.setValue(ComponentUtil.convertJsonOrEmpty(text, SerializerVersion.V1_8, SerializerVersion.V1_9));
                 break;
             case BlockID:
                 // Convert from int, short, byte

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
@@ -130,8 +130,9 @@ public class MetadataRewriter1_9To1_8 extends EntityRewriter<ClientboundPackets1
                 metadata.setValue(angle);
                 break;
             case Chat:
+                // Was previously also a component, so just convert it
                 String text = (String) value;
-                metadata.setValue(Protocol1_9To1_8.toJson(text));
+                metadata.setValue(ComponentUtil.convertJson(text, SerializerVersion.V1_8, SerializerVersion.V1_9));
                 break;
             case BlockID:
                 // Convert from int, short, byte

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/metadata/MetadataRewriter1_9To1_8.java
@@ -130,8 +130,8 @@ public class MetadataRewriter1_9To1_8 extends EntityRewriter<ClientboundPackets1
                 metadata.setValue(angle);
                 break;
             case Chat:
-                JsonElement json = (JsonElement) value;
-                metadata.setValue(ComponentUtil.convertJson(json, SerializerVersion.V1_8, SerializerVersion.V1_9));
+                String text = (String) value;
+                metadata.setValue(Protocol1_9To1_8.toJson(text));
                 break;
             case BlockID:
                 // Convert from int, short, byte

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/EntityPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/EntityPackets.java
@@ -253,7 +253,7 @@ public class EntityPackets {
                     if (wrapper.get(Type.VAR_INT, 0) == 2) { // entity dead
                         wrapper.passthrough(Type.VAR_INT); //Player id
                         wrapper.passthrough(Type.INT); //Entity id
-                        Protocol1_9To1_8.FIX_JSON.write(wrapper, wrapper.read(Type.STRING));
+                        Protocol1_9To1_8.STRING_TO_JSON.write(wrapper, wrapper.read(Type.STRING));
                     }
                 });
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
@@ -69,7 +69,7 @@ public class InventoryPackets {
             public void register() {
                 map(Type.UNSIGNED_BYTE); // 0 - Window ID
                 map(Type.STRING); // 1 - Window Type
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 2 - Window Title
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 2 - Window Title
                 map(Type.UNSIGNED_BYTE); // 3 - Slot Count
                 // There is a horse parameter after this, we don't handle it and let it passthrough
                 // Inventory tracking

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
@@ -44,7 +44,7 @@ public class PlayerPackets {
         protocol.registerClientbound(ClientboundPackets1_8.CHAT_MESSAGE, new PacketHandlers() {
             @Override
             public void register() {
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 0 - Chat Message (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 0 - Chat Message (json)
                 map(Type.BYTE); // 1 - Chat Position
 
                 handler(wrapper -> {
@@ -61,15 +61,15 @@ public class PlayerPackets {
         protocol.registerClientbound(ClientboundPackets1_8.TAB_LIST, new PacketHandlers() {
             @Override
             public void register() {
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 0 - Header
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 1 - Footer
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 0 - Header
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 1 - Footer
             }
         });
 
         protocol.registerClientbound(ClientboundPackets1_8.DISCONNECT, new PacketHandlers() {
             @Override
             public void register() {
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 0 - Reason
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 0 - Reason
             }
         });
 
@@ -81,7 +81,7 @@ public class PlayerPackets {
                 handler(wrapper -> {
                     int action = wrapper.get(Type.VAR_INT, 0);
                     if (action == 0 || action == 1) {
-                        Protocol1_9To1_8.FIX_JSON.write(wrapper, wrapper.read(Type.STRING));
+                        Protocol1_9To1_8.STRING_TO_JSON.write(wrapper, wrapper.read(Type.STRING));
                     }
                 });
                 // Everything else is handled.
@@ -248,13 +248,13 @@ public class PlayerPackets {
                             wrapper.passthrough(Type.VAR_INT); // ping
                             String displayName = wrapper.read(Type.OPTIONAL_STRING);
                             wrapper.write(Type.OPTIONAL_COMPONENT, displayName != null ?
-                                    Protocol1_9To1_8.FIX_JSON.transform(wrapper, displayName) : null);
+                                    Protocol1_9To1_8.STRING_TO_JSON.transform(wrapper, displayName) : null);
                         } else if ((action == 1) || (action == 2)) { // update gamemode || update latency
                             wrapper.passthrough(Type.VAR_INT);
                         } else if (action == 3) { // update display name
                             String displayName = wrapper.read(Type.OPTIONAL_STRING);
                             wrapper.write(Type.OPTIONAL_COMPONENT, displayName != null ?
-                                    Protocol1_9To1_8.FIX_JSON.transform(wrapper, displayName) : null);
+                                    Protocol1_9To1_8.STRING_TO_JSON.transform(wrapper, displayName) : null);
                         }
                     }
                 });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
@@ -37,6 +37,7 @@ import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MainHandPr
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.ClientChunks;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.EntityTracker1_9;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.MovementTracker;
+import com.viaversion.viaversion.util.ComponentUtil;
 import java.util.logging.Level;
 
 public class PlayerPackets {
@@ -248,13 +249,13 @@ public class PlayerPackets {
                             wrapper.passthrough(Type.VAR_INT); // ping
                             String displayName = wrapper.read(Type.OPTIONAL_STRING);
                             wrapper.write(Type.OPTIONAL_COMPONENT, displayName != null ?
-                                    Protocol1_9To1_8.toJson(displayName) : null);
+                                    Protocol1_9To1_8.STRING_TO_JSON.transform(wrapper, displayName) : null);
                         } else if ((action == 1) || (action == 2)) { // update gamemode || update latency
                             wrapper.passthrough(Type.VAR_INT);
                         } else if (action == 3) { // update display name
                             String displayName = wrapper.read(Type.OPTIONAL_STRING);
                             wrapper.write(Type.OPTIONAL_COMPONENT, displayName != null ?
-                                    Protocol1_9To1_8.toJson(displayName) : null);
+                                    Protocol1_9To1_8.STRING_TO_JSON.transform(wrapper, displayName) : null);
                         }
                     }
                 });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
@@ -248,13 +248,13 @@ public class PlayerPackets {
                             wrapper.passthrough(Type.VAR_INT); // ping
                             String displayName = wrapper.read(Type.OPTIONAL_STRING);
                             wrapper.write(Type.OPTIONAL_COMPONENT, displayName != null ?
-                                    Protocol1_9To1_8.STRING_TO_JSON.transform(wrapper, displayName) : null);
+                                    Protocol1_9To1_8.toJson(displayName) : null);
                         } else if ((action == 1) || (action == 2)) { // update gamemode || update latency
                             wrapper.passthrough(Type.VAR_INT);
                         } else if (action == 3) { // update display name
                             String displayName = wrapper.read(Type.OPTIONAL_STRING);
                             wrapper.write(Type.OPTIONAL_COMPONENT, displayName != null ?
-                                    Protocol1_9To1_8.STRING_TO_JSON.transform(wrapper, displayName) : null);
+                                    Protocol1_9To1_8.toJson(displayName) : null);
                         }
                     }
                 });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/WorldPackets.java
@@ -46,7 +46,6 @@ import com.viaversion.viaversion.protocols.protocol1_9to1_8.sounds.SoundEffect;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.ClientChunks;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.EntityTracker1_9;
 import com.viaversion.viaversion.util.ComponentUtil;
-import com.viaversion.viaversion.util.SerializerVersion;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -58,8 +57,8 @@ public class WorldPackets {
                 map(Type.POSITION1_8); // 0 - Sign Position
                 handler(wrapper -> {
                     for (int i = 0; i < 4; i++) {
-                        final String line = wrapper.read(Type.STRING); // Should be Type.COMPONENT but would crash
-                        wrapper.write(Type.COMPONENT, ComponentUtil.convertJson(line, SerializerVersion.V1_8, SerializerVersion.V1_9));
+                        final String line = wrapper.read(Type.STRING); // Should be Type.COMPONENT but would break in some cases
+                        Protocol1_9To1_8.STRING_TO_JSON.write(wrapper, line);
                     }
                 });
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/WorldPackets.java
@@ -54,10 +54,10 @@ public class WorldPackets {
             @Override
             public void register() {
                 map(Type.POSITION1_8); // 0 - Sign Position
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 1 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 2 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 3 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 4 - Sign Line (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 1 - Sign Line (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 2 - Sign Line (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 3 - Sign Line (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 4 - Sign Line (json)
             }
         });
 
@@ -245,10 +245,10 @@ public class WorldPackets {
             @Override
             public void register() {
                 map(Type.POSITION1_8); // 0 - Sign Position
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 1 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 2 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 3 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.FIX_JSON); // 4 - Sign Line (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 1 - Sign Line (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 2 - Sign Line (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 3 - Sign Line (json)
+                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 4 - Sign Line (json)
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/WorldPackets.java
@@ -45,6 +45,8 @@ import com.viaversion.viaversion.protocols.protocol1_9to1_8.sounds.Effect;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.sounds.SoundEffect;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.ClientChunks;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.EntityTracker1_9;
+import com.viaversion.viaversion.util.ComponentUtil;
+import com.viaversion.viaversion.util.SerializerVersion;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -54,10 +56,12 @@ public class WorldPackets {
             @Override
             public void register() {
                 map(Type.POSITION1_8); // 0 - Sign Position
-                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 1 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 2 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 3 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 4 - Sign Line (json)
+                handler(wrapper -> {
+                    for (int i = 0; i < 4; i++) {
+                        final String line = wrapper.read(Type.STRING); // Should be Type.COMPONENT but would crash
+                        wrapper.write(Type.COMPONENT, ComponentUtil.convertJson(line, SerializerVersion.V1_8, SerializerVersion.V1_9));
+                    }
+                });
             }
         });
 
@@ -245,10 +249,12 @@ public class WorldPackets {
             @Override
             public void register() {
                 map(Type.POSITION1_8); // 0 - Sign Position
-                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 1 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 2 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 3 - Sign Line (json)
-                map(Type.STRING, Protocol1_9To1_8.STRING_TO_JSON); // 4 - Sign Line (json)
+                handler(wrapper -> {
+                    for (int i = 0; i < 4; i++) {
+                        final String line = wrapper.read(Type.STRING);
+                        wrapper.write(Type.COMPONENT, ComponentUtil.plainToJson(line));
+                    }
+                });
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
@@ -100,6 +100,14 @@ public final class ComponentUtil {
         return json != null ? convert(from, to, from.jsonSerializer.deserializeReader(json)) : null;
     }
 
+    public static @Nullable JsonElement convertJsonOrEmpty(@Nullable final String json, final SerializerVersion from, final SerializerVersion to) {
+        final ATextComponent component = from.toComponent(json);
+        if (component == null) {
+            return emptyJsonComponent();
+        }
+        return to.toJson(component);
+    }
+
     private static JsonElement convert(final SerializerVersion from, final SerializerVersion to, final ATextComponent component) {
         if (from.ordinal() >= SerializerVersion.V1_16.ordinal() && to.ordinal() < SerializerVersion.V1_16.ordinal()) {
             // Convert hover event to legacy format

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -216,8 +216,6 @@ replace-pistons: false
 replacement-piston-id: 0
 # Fix 1.9+ clients not rendering the far away chunks and improve chunk rendering when moving fast (Increases network usage and decreases client fps slightly)
 chunk-border-fix: false
-# Force the string -> json transform
-force-json-transform: false
 # Minimize the cooldown animation in 1.8 servers
 minimize-cooldown: true
 # Allows 1.9+ left-handedness (main hand) on 1.8 servers


### PR DESCRIPTION
Initial commit of using MCStructs in older protocols in order to fix tons of bugs existing with the current code base. For example, it's currently not possible to write "null" on a sign since the old conversion code would just throw away data.