### PR TITLE
Add setting for ocelot->cat translation in 1.13.2->1.14

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -452,4 +452,11 @@ public interface ViaVersionConfig extends Config {
      * @return true if enabled
      */
     boolean isArmorToggleFix();
+
+    /**
+     * Ocelots will always be translated to cats for 1.14+ clients on 1.13 servers.
+     *
+     * @return true if enabled
+     */
+    boolean translateOcelotToCat();
 }

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -89,6 +89,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private JsonElement resourcePack1_17PromptMessage;
     private WorldIdentifiers map1_16WorldNames;
     private boolean cache1_17Light;
+    private boolean translateOcelotToCat;
 
     protected AbstractViaConfig(final File configFile) {
         super(configFile);
@@ -157,6 +158,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
                 worlds.getOrDefault("nether", WorldIdentifiers.NETHER_DEFAULT),
                 worlds.getOrDefault("end", WorldIdentifiers.END_DEFAULT));
         cache1_17Light = getBoolean("cache-1_17-light", true);
+        translateOcelotToCat = getBoolean("translate-ocelot-to-cat", false);
     }
 
     private BlockedProtocolVersions loadBlockedProtocolVersions() {
@@ -527,5 +529,10 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public boolean isArmorToggleFix() {
         return false;
+    }
+
+    @Override
+    public boolean translateOcelotToCat() {
+        return translateOcelotToCat;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/metadata/MetadataRewriter1_14To1_13_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/metadata/MetadataRewriter1_14To1_13_2.java
@@ -164,6 +164,12 @@ public class MetadataRewriter1_14To1_13_2 extends EntityRewriter<ClientboundPack
             event.cancel(); // "Has target (aggressive state)"
         });
 
+        filter().type(EntityTypes1_14.OCELOT).removeIndex(17); // variant
+
+        // Ocelot is not tamable anymore
+        filter().type(EntityTypes1_14.OCELOT).removeIndex(16); // owner uuid
+        filter().type(EntityTypes1_14.OCELOT).removeIndex(15); // data
+
         filter().handler((event, meta) -> {
             EntityType type = event.entityType();
             if (type.is(EntityTypes1_14.WITCH) || type.is(EntityTypes1_14.RAVAGER) || type.isOrHasParent(EntityTypes1_14.ABSTRACT_ILLAGER_BASE)) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/metadata/MetadataRewriter1_14To1_13_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_14to1_13_2/metadata/MetadataRewriter1_14To1_13_2.java
@@ -39,7 +39,12 @@ public class MetadataRewriter1_14To1_13_2 extends EntityRewriter<ClientboundPack
     public MetadataRewriter1_14To1_13_2(Protocol1_14To1_13_2 protocol) {
         super(protocol);
         mapTypes(EntityTypes1_13.EntityType.values(), EntityTypes1_14.class);
-        mapEntityType(EntityTypes1_13.EntityType.OCELOT, EntityTypes1_14.CAT);
+
+        if (Via.getConfig().translateOcelotToCat()) {
+            // A better solution for this would be to despawn the ocelot and spawn a cat in its place, but that would
+            // require a lot of data tracking and is not worth the effort.
+            mapEntityType(EntityTypes1_13.EntityType.OCELOT, EntityTypes1_14.CAT);
+        }
     }
 
     @Override

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -175,6 +175,9 @@ map-1_16-world-names:
   nether: "minecraft:the_nether"
   end: "minecraft:the_end"
 #
+# Ocelots will always be translated to cats for 1.14+ clients on 1.13 servers.
+translate-ocelot-to-cat: false
+#
 #----------------------------------------------------------#
 #             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #
 #----------------------------------------------------------#


### PR DESCRIPTION
A better solution for this would be to despawn the ocelot and spawn a cat in its place, but that would require a lot of data tracking and is not worth the effort.

_Closes_: https://github.com/ViaVersion/ViaVersion/issues/2975