### PR TITLE
Fix sound mapping lookup in 1.8->1.9

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/WorldPackets.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/packets/WorldPackets.java
@@ -46,6 +46,7 @@ import com.viaversion.viaversion.protocols.protocol1_9to1_8.sounds.SoundEffect;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.ClientChunks;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.storage.EntityTracker1_9;
 import com.viaversion.viaversion.util.ComponentUtil;
+import com.viaversion.viaversion.util.Key;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -98,7 +99,7 @@ public class WorldPackets {
                 // Everything else gets written through
 
                 handler(wrapper -> {
-                    String name = wrapper.get(Type.STRING, 0);
+                    String name = Key.stripMinecraftNamespace(wrapper.get(Type.STRING, 0));
 
                     SoundEffect effect = SoundEffect.getByName(name);
                     int catid = 0;
@@ -109,7 +110,7 @@ public class WorldPackets {
                     }
                     wrapper.set(Type.STRING, 0, newname);
                     wrapper.write(Type.VAR_INT, catid); // Write Category ID
-                    if (effect != null && effect.isBreaksound()) {
+                    if (effect != null && effect.isBreakSound()) {
                         EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_9To1_8.class);
                         int x = wrapper.passthrough(Type.INT); //Position X
                         int y = wrapper.passthrough(Type.INT); //Position Y

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/sounds/SoundEffect.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/sounds/SoundEffect.java
@@ -273,7 +273,7 @@ public enum SoundEffect {
     private final String name;
     private final String newName;
     private final SoundCategory category;
-    private final boolean breaksound;
+    private final boolean breakSound;
 
     private static final Map<String, SoundEffect> effects;
 
@@ -284,22 +284,21 @@ public enum SoundEffect {
         }
     }
 
-    SoundEffect(String name, String newname, SoundCategory cat) {
-        this.category = cat;
-        this.newName = newname;
+    SoundEffect(String name, String newName, SoundCategory category) {
+        this.category = category;
+        this.newName = newName;
         this.name = name;
-        this.breaksound = name.startsWith("dig.");
+        this.breakSound = name.startsWith("dig.");
     }
 
-    SoundEffect(String name, String newname, SoundCategory cat, boolean shouldIgnore) {
-        this.category = cat;
-        this.newName = newname;
+    SoundEffect(String name, String newName, SoundCategory category, boolean shouldIgnore) {
+        this.category = category;
+        this.newName = newName;
         this.name = name;
-        this.breaksound = name.startsWith("dig.") || shouldIgnore;
+        this.breakSound = name.startsWith("dig.") || shouldIgnore;
     }
 
     public static SoundEffect getByName(String name) {
-        name = name.toLowerCase(Locale.ROOT);
         return effects.get(name);
     }
 
@@ -315,7 +314,7 @@ public enum SoundEffect {
         return category;
     }
 
-    public boolean isBreaksound() {
-        return breaksound;
+    public boolean isBreakSound() {
+        return breakSound;
     }
 }


### PR DESCRIPTION
Minecraft doesn't use toLowerCase() when getting a sound from the registry, so we shouldn't do it either. This also fixes fire charges for example don't have any sound because the sound id is "item.fireCharge.use". Also added Key#stripMinecraftNamespace since 1.8 uses ResourceLocation on the packet input (meaning the name also supports namespaces).

<img width="711" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/ac69b85a-5c0e-4958-84cf-2f63a79c5015">
<img width="656" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/ecba7cd0-f3f2-44cc-b5f6-7c12ca8590b0">

Registry util used for sounds:
<img width="384" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/c3f6db73-321e-4d44-9e41-f17007611402">
