### PR TITLE
Add alpha to particle colors in 1.20.3->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
@@ -414,7 +414,7 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
         filter().type(EntityTypes1_20_5.LIVINGENTITY).index(10).handler((event, meta) -> {
             final int effectColor = meta.value();
             final Particle particle = new Particle(protocol.getMappingData().getParticleMappings().mappedId("entity_effect"));
-            particle.add(Type.INT, effectColor);
+            particle.add(Type.INT, withAlpha(effectColor));
             meta.setTypeAndValue(Types1_20_5.META_TYPES.particlesType, new Particle[]{particle});
         });
 
@@ -457,7 +457,7 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
 
         final Particle particle = particleMeta.value();
         if (particle.id() == protocol.getMappingData().getParticleMappings().mappedId("entity_effect")) {
-            particle.getArgument(0).setValue(color);
+            particle.getArgument(0).setValue(withAlpha(color));
         }
     }
 
@@ -467,6 +467,10 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
         if (particle.id() == protocol.getMappingData().getParticleMappings().mappedId("entity_effect")) {
             particle.add(Type.INT, 0); // Default color, changed in the area effect handler
         }
+    }
+
+    private int withAlpha(int rgb) {
+        return 255 << 24 | rgb & 16777215;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
@@ -385,6 +385,10 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
         }
     }
 
+    private int withAlpha(final int rgb) {
+        return 255 << 24 | rgb & 16777215;
+    }
+
     @Override
     protected void registerRewrites() {
         filter().mapMetaType(typeId -> {
@@ -467,10 +471,6 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
         if (particle.id() == protocol.getMappingData().getParticleMappings().mappedId("entity_effect")) {
             particle.add(Type.INT, 0); // Default color, changed in the area effect handler
         }
-    }
-
-    private int withAlpha(int rgb) {
-        return 255 << 24 | rgb & 16777215;
     }
 
     @Override


### PR DESCRIPTION
Fixes entity effects not showing because the alpha channel was missing (which got added in 1.20.5 and was previously always 1, so we are using 1.20.4's default value here). Area effect clouds are still broken, but that's more likely an issue with the handler itself.