### PR TITLE
Handle invalid disconnect message in 1.8->1.9

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_9to1_8/Protocol1_9To1_8.java
@@ -92,7 +92,14 @@ public class Protocol1_9To1_8 extends AbstractProtocol<ClientboundPackets1_8, Cl
                 return;
             }
 
-            STRING_TO_JSON.write(wrapper, wrapper.read(Type.STRING));
+            final String reason = wrapper.read(Type.STRING);
+            try {
+                STRING_TO_JSON.write(wrapper, reason);
+            } catch (Exception e) {
+                // Dirty fix for https://github.com/Lenni0451/MCStructs/issues/4, I personally don't think it matters
+                // too much since it's only the login disconnect message and nothing relevant to the gameplay
+                wrapper.write(Type.COMPONENT, ComponentUtil.plainToJson(reason));
+            }
         });
 
         // Other Handlers


### PR DESCRIPTION
This is a dirty fix for a change GSON made to its internal component parsing (see https://github.com/Lenni0451/MCStructs/issues/4). I'm not proud of this change but it's better than the old component conversion (where there wouldn't be a disconnect message at all) so until MCStructs fixes this, it's probably our best way to go for now...

Closes https://github.com/ViaVersion/ViaFabricPlus/issues/408 (can be tested by joining the mentioned server before and after the PR)