### PR TITLE
Use global logger for configs, delete Config#LOGGER

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/ViaVersionPlugin.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/ViaVersionPlugin.java
@@ -46,20 +46,18 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitScheduler;
 
 public class ViaVersionPlugin extends JavaPlugin implements ViaPlatform<Player> {
     private static final boolean FOLIA = PaperViaInjector.hasClass("io.papermc.paper.threadedregions.RegionizedServer");
     private static ViaVersionPlugin instance;
     private final BukkitCommandHandler commandHandler = new BukkitCommandHandler();
-    private final BukkitViaConfig conf = new BukkitViaConfig(getDataFolder());
+    private final BukkitViaConfig conf;
     private final ViaAPI<Player> api = new BukkitViaAPI(this);
     private boolean protocolSupport;
     private boolean lateBind;
@@ -67,6 +65,7 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaPlatform<Player> 
     public ViaVersionPlugin() {
         instance = this;
 
+        conf = new BukkitViaConfig(getDataFolder(), getLogger());
         Via.init(ViaManagerImpl.builder()
                 .platform(this)
                 .commandHandler(commandHandler)

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaConfig.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaConfig.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 public class BukkitViaConfig extends AbstractViaConfig {
     private static final List<String> UNSUPPORTED = Arrays.asList("bungee-ping-interval", "bungee-ping-save", "bungee-servers", "velocity-ping-interval", "velocity-ping-save", "velocity-servers");
@@ -32,8 +33,8 @@ public class BukkitViaConfig extends AbstractViaConfig {
     private boolean armorToggleFix;
     private boolean registerUserConnectionOnJoin;
 
-    public BukkitViaConfig(final File folder) {
-        super(new File(folder, "config.yml"));
+    public BukkitViaConfig(final File folder, final Logger logger) {
+        super(new File(folder, "config.yml"), logger);
     }
 
     @Override

--- a/bungee/src/main/java/com/viaversion/viaversion/BungeePlugin.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/BungeePlugin.java
@@ -72,7 +72,7 @@ public class BungeePlugin extends Plugin implements ViaServerProxyPlatform<Proxi
             "Consider moving Via plugins to your backend server or switching to Velocity.");
 
         api = new BungeeViaAPI();
-        config = new BungeeViaConfig(getDataFolder());
+        config = new BungeeViaConfig(getDataFolder(), getLogger());
         BungeeCommandHandler commandHandler = new BungeeCommandHandler();
         ProxyServer.getInstance().getPluginManager().registerCommand(this, new BungeeCommand(commandHandler));
 

--- a/bungee/src/main/java/com/viaversion/viaversion/bungee/platform/BungeeViaConfig.java
+++ b/bungee/src/main/java/com/viaversion/viaversion/bungee/platform/BungeeViaConfig.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 public class BungeeViaConfig extends AbstractViaConfig {
     private static final List<String> UNSUPPORTED = Arrays.asList("nms-player-ticking", "item-cache", "quick-move-action-fix", "velocity-ping-interval", "velocity-ping-save", "velocity-servers", "blockconnection-method", "change-1_9-hitbox", "change-1_14-hitbox");
@@ -33,8 +34,8 @@ public class BungeeViaConfig extends AbstractViaConfig {
     private boolean bungeePingSave;
     private Map<String, Integer> bungeeServerProtocols;
 
-    public BungeeViaConfig(File folder) {
-        super(new File(folder, "config.yml"));
+    public BungeeViaConfig(File folder, Logger logger) {
+        super(new File(folder, "config.yml"), logger);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -89,8 +90,8 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private boolean translateOcelotToCat;
     private boolean enforceSecureChat;
 
-    protected AbstractViaConfig(final File configFile) {
-        super(configFile);
+    protected AbstractViaConfig(final File configFile, final Logger logger) {
+        super(configFile, logger);
     }
 
     @Override
@@ -180,12 +181,12 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
 
                 if (c == '<') {
                     if (lowerBound.isKnown()) {
-                        LOGGER.warning("Already set lower bound " + lowerBound + " overridden by " + protocolVersion.getName());
+                        logger.warning("Already set lower bound " + lowerBound + " overridden by " + protocolVersion.getName());
                     }
                     lowerBound = protocolVersion;
                 } else {
                     if (upperBound.isKnown()) {
-                        LOGGER.warning("Already set upper bound " + upperBound + " overridden by " + protocolVersion.getName());
+                        logger.warning("Already set upper bound " + upperBound + " overridden by " + protocolVersion.getName());
                     }
                     upperBound = protocolVersion;
                 }
@@ -199,7 +200,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
 
             // Add single protocol version and check for duplication
             if (!blockedProtocols.add(protocolVersion)) {
-                LOGGER.warning("Duplicated blocked protocol version " + protocolVersion);
+                logger.warning("Duplicated blocked protocol version " + protocolVersion);
             }
         }
 
@@ -209,7 +210,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
             final ProtocolVersion finalUpperBound = upperBound;
             blockedProtocols.removeIf(version -> {
                 if (finalLowerBound.isKnown() && version.olderThan(finalLowerBound) || finalUpperBound.isKnown() && version.newerThan(finalUpperBound)) {
-                    LOGGER.warning("Blocked protocol version " + version + " already covered by upper or lower bound");
+                    logger.warning("Blocked protocol version " + version + " already covered by upper or lower bound");
                     return true;
                 }
                 return false;
@@ -221,7 +222,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private @Nullable ProtocolVersion protocolVersion(String s) {
         ProtocolVersion protocolVersion = ProtocolVersion.getClosest(s);
         if (protocolVersion == null) {
-            LOGGER.warning("Unknown protocol version in block-versions: " + s);
+            logger.warning("Unknown protocol version in block-versions: " + s);
             return null;
         }
         return protocolVersion;

--- a/common/src/main/java/com/viaversion/viaversion/util/Config.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/Config.java
@@ -38,7 +38,6 @@ import org.yaml.snakeyaml.Yaml;
 
 @SuppressWarnings("VulnerableCodeUsages")
 public abstract class Config {
-    protected static final Logger LOGGER = Logger.getLogger("ViaVersion Config");
     private static final YamlCompat YAMP_COMPAT = YamlCompat.isVersion1() ? new Yaml1Compat() : new Yaml2Compat();
     private static final ThreadLocal<Yaml> YAML = ThreadLocal.withInitial(() -> {
         DumperOptions options = new DumperOptions();
@@ -50,6 +49,7 @@ public abstract class Config {
 
     private final CommentStore commentStore = new CommentStore('.', 2);
     private final File configFile;
+    protected final Logger logger;
     private Map<String, Object> config;
 
     /**
@@ -57,9 +57,11 @@ public abstract class Config {
      * To load config see {@link #reload()}
      *
      * @param configFile The location of where the config is loaded/saved.
+     * @param logger     The logger to use.
      */
-    protected Config(File configFile) {
+    protected Config(File configFile, Logger logger) {
         this.configFile = configFile;
+        this.logger = logger;
     }
 
     public URL getDefaultConfigURL() {
@@ -232,7 +234,7 @@ public abstract class Config {
                 if (type.isInstance(o1)) {
                     filteredValues.add(type.cast(o1));
                 } else if (invalidValueMessage != null) {
-                    LOGGER.warning(String.format(invalidValueMessage, o1));
+                    logger.warning(String.format(invalidValueMessage, o1));
                 }
             }
             return filteredValues;

--- a/common/src/test/java/com/viaversion/viaversion/common/dummy/TestConfig.java
+++ b/common/src/test/java/com/viaversion/viaversion/common/dummy/TestConfig.java
@@ -23,11 +23,12 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 public final class TestConfig extends AbstractViaConfig {
 
-    public TestConfig(File file) {
-        super(file);
+    public TestConfig(File file, Logger logger) {
+        super(file, logger);
     }
 
     @Override

--- a/common/src/test/java/com/viaversion/viaversion/common/dummy/TestPlatform.java
+++ b/common/src/test/java/com/viaversion/viaversion/common/dummy/TestPlatform.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 public final class TestPlatform implements ViaPlatform {
 
     private static final Logger log = Logger.getGlobal();
-    private final TestConfig testConfig = new TestConfig(null);
+    private final TestConfig testConfig = new TestConfig(null, log);
 
     @Override
     public Logger getLogger() {

--- a/sponge/src/main/java/com/viaversion/viaversion/SpongePlugin.java
+++ b/sponge/src/main/java/com/viaversion/viaversion/SpongePlugin.java
@@ -86,7 +86,7 @@ public class SpongePlugin implements ViaPlatform<Player> {
     @Listener
     public void constructPlugin(ConstructPluginEvent event) {
         // Setup Plugin
-        conf = new SpongeViaConfig(configDir.toFile());
+        conf = new SpongeViaConfig(configDir.toFile(), getLogger());
 
         // Init platform
         Via.init(ViaManagerImpl.builder()

--- a/sponge/src/main/java/com/viaversion/viaversion/sponge/platform/SpongeViaConfig.java
+++ b/sponge/src/main/java/com/viaversion/viaversion/sponge/platform/SpongeViaConfig.java
@@ -28,8 +28,8 @@ public class SpongeViaConfig extends AbstractViaConfig {
             "bungee-ping-save", "bungee-servers", "velocity-ping-interval", "velocity-ping-save", "velocity-servers",
             "quick-move-action-fix", "change-1_9-hitbox", "change-1_14-hitbox", "blockconnection-method");
 
-    public SpongeViaConfig(File folder) {
-        super(new File(folder, "config.yml"));
+    public SpongeViaConfig(File folder, java.util.logging.Logger logger) {
+        super(new File(folder, "config.yml"), logger);
     }
 
     @Override

--- a/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
@@ -96,8 +96,8 @@ public class VelocityPlugin implements ViaServerProxyPlatform<Player> {
         VelocityCommandHandler commandHandler = new VelocityCommandHandler();
         PROXY.getCommandManager().register("viaver", commandHandler, "vvvelocity", "viaversion");
         api = new VelocityViaAPI();
-        conf = new VelocityViaConfig(configDir.toFile());
         logger = new LoggerWrapper(loggerslf4j);
+        conf = new VelocityViaConfig(configDir.toFile(), logger);
         Via.init(ViaManagerImpl.builder()
                 .platform(this)
                 .commandHandler(commandHandler)

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaConfig.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaConfig.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 public class VelocityViaConfig extends AbstractViaConfig {
     private static final List<String> UNSUPPORTED = Arrays.asList("nms-player-ticking", "item-cache", "quick-move-action-fix", "bungee-ping-interval", "bungee-ping-save", "bungee-servers", "blockconnection-method", "change-1_9-hitbox", "change-1_14-hitbox");
@@ -32,8 +33,8 @@ public class VelocityViaConfig extends AbstractViaConfig {
     private boolean velocityPingSave;
     private Map<String, Integer> velocityServerProtocols;
 
-    public VelocityViaConfig(File folder) {
-        super(new File(folder, "config.yml"));
+    public VelocityViaConfig(File folder, Logger logger) {
+        super(new File(folder, "config.yml"), logger);
     }
 
     @Override


### PR DESCRIPTION
There is no reason to keep a separate logger for config files, this also doesn't work as intended since creating new Java loggers isn't really possible (they don't match the usually formatting Via.getPlatform().getLogger() would provide). This PR deletes the logger and uses the global/main logger provided by the platform, this has been tested with bukkit.

Before:
![image](https://github.com/ViaVersion/ViaVersion/assets/60033407/a4f94f57-e964-4e66-8fbc-377a2dd98fe9)

After:
<img width="437" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/8c4bb177-2323-4aa4-9b7f-c35b67f3e66e">
