### PR TITLE
Update data class names to indicate target version

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitInventoryQuickMoveProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitInventoryQuickMoveProvider.java
@@ -24,7 +24,7 @@ import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.bukkit.tasks.protocol1_12to1_11_1.BukkitInventoryUpdateTask;
 import com.viaversion.viaversion.bukkit.util.NMSUtil;
 import com.viaversion.viaversion.protocols.v1_11_1to1_12.provider.InventoryQuickMoveProvider;
-import com.viaversion.viaversion.protocols.v1_11_1to1_12.storage.ItemTransaction;
+import com.viaversion.viaversion.protocols.v1_11_1to1_12.storage.ItemTransactionStorage;
 import com.viaversion.viaversion.util.ReflectionUtil;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -92,7 +92,7 @@ public class BukkitInventoryQuickMoveProvider extends InventoryQuickMoveProvider
         return true;
     }
 
-    public Object buildWindowClickPacket(Player p, ItemTransaction storage) {
+    public Object buildWindowClickPacket(Player p, ItemTransactionStorage storage) {
         if (!supported) {
             return null;
         }

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/tasks/protocol1_12to1_11_1/BukkitInventoryUpdateTask.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/tasks/protocol1_12to1_11_1/BukkitInventoryUpdateTask.java
@@ -18,7 +18,7 @@
 package com.viaversion.viaversion.bukkit.tasks.protocol1_12to1_11_1;
 
 import com.viaversion.viaversion.bukkit.providers.BukkitInventoryQuickMoveProvider;
-import com.viaversion.viaversion.protocols.v1_11_1to1_12.storage.ItemTransaction;
+import com.viaversion.viaversion.protocols.v1_11_1to1_12.storage.ItemTransactionStorage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +30,7 @@ public class BukkitInventoryUpdateTask implements Runnable {
 
     private final BukkitInventoryQuickMoveProvider provider;
     private final UUID uuid;
-    private final List<ItemTransaction> items;
+    private final List<ItemTransactionStorage> items;
 
     public BukkitInventoryUpdateTask(BukkitInventoryQuickMoveProvider provider, UUID uuid) {
         this.provider = provider;
@@ -39,7 +39,7 @@ public class BukkitInventoryUpdateTask implements Runnable {
     }
 
     public void addItem(short windowId, short slotId, short actionId) {
-        ItemTransaction storage = new ItemTransaction(windowId, slotId, actionId);
+        ItemTransactionStorage storage = new ItemTransactionStorage(windowId, slotId, actionId);
         items.add(storage);
     }
 
@@ -52,7 +52,7 @@ public class BukkitInventoryUpdateTask implements Runnable {
         }
         try {
             synchronized (items) {
-                for (ItemTransaction storage : items) {
+                for (ItemTransactionStorage storage : items) {
                     Object packet = provider.buildWindowClickPacket(p, storage);
                     boolean result = provider.sendPacketToServer(p, packet);
                     if (!result) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/Protocol1_10To1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/Protocol1_10To1_11.java
@@ -29,9 +29,9 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.protocol.remapper.ValueTransformer;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_9_3;
-import com.viaversion.viaversion.protocols.v1_10to1_11.data.BlockEntityNames1_11;
-import com.viaversion.viaversion.protocols.v1_10to1_11.data.EntityNames1_11;
-import com.viaversion.viaversion.protocols.v1_10to1_11.data.PotionColors1_11;
+import com.viaversion.viaversion.protocols.v1_10to1_11.data.BlockEntityMappings1_11;
+import com.viaversion.viaversion.protocols.v1_10to1_11.data.EntityMappings1_11;
+import com.viaversion.viaversion.protocols.v1_10to1_11.data.PotionColorMappings1_11;
 import com.viaversion.viaversion.protocols.v1_10to1_11.rewriter.EntityPacketRewriter1_11;
 import com.viaversion.viaversion.protocols.v1_10to1_11.rewriter.ItemPacketRewriter1_11;
 import com.viaversion.viaversion.protocols.v1_10to1_11.storage.EntityTracker1_11;
@@ -112,11 +112,11 @@ public class Protocol1_10To1_11 extends AbstractProtocol<ClientboundPackets1_9_3
 
                 String identifier = idTag.getValue();
                 if (identifier.equals("MobSpawner")) {
-                    EntityNames1_11.toClientSpawner(tag);
+                    EntityMappings1_11.toClientSpawner(tag);
                 }
 
                 // Handle new identifier
-                idTag.setValue(BlockEntityNames1_11.toNewIdentifier(identifier));
+                idTag.setValue(BlockEntityMappings1_11.toNewIdentifier(identifier));
             }
         });
 
@@ -157,7 +157,7 @@ public class Protocol1_10To1_11 extends AbstractProtocol<ClientboundPackets1_9_3
                     if (effectID == 2002) {
                         int data = packetWrapper.get(Types.INT, 1);
                         boolean isInstant = false;
-                        Pair<Integer, Boolean> newData = PotionColors1_11.getNewData(data);
+                        Pair<Integer, Boolean> newData = PotionColorMappings1_11.getNewData(data);
                         if (newData == null) {
                             getLogger().warning("Received unknown potion data: " + data);
                             data = 0;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/data/BlockEntityMappings1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/data/BlockEntityMappings1_11.java
@@ -21,7 +21,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.viaversion.viaversion.util.Key;
 
-public class BlockEntityNames1_11 {
+public class BlockEntityMappings1_11 {
     private static final BiMap<String, String> OLD_TO_NEW_NAMES = HashBiMap.create();
 
     // Source: https://www.minecraftforum.net/forums/minecraft-java-edition/redstone-discussion-and/commands-command-blocks-and/2724507-1-11-nbt-changes-and-additions#AllTiles

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/data/EntityMappings1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/data/EntityMappings1_11.java
@@ -24,7 +24,7 @@ import com.viaversion.nbt.tag.StringTag;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.util.Key;
 
-public class EntityNames1_11 {
+public class EntityMappings1_11 {
     private static final BiMap<String, String> oldToNewNames = HashBiMap.create();
 
     static {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/data/PotionColorMappings1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/data/PotionColorMappings1_11.java
@@ -21,7 +21,7 @@ import com.viaversion.viaversion.util.Pair;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
-public class PotionColors1_11 {
+public class PotionColorMappings1_11 {
 
     //<oldData> to <newData, isInstant> mapping
     private static final Int2ObjectMap<Pair<Integer, Boolean>> POTIONS = new Int2ObjectOpenHashMap<>(37, 0.99F);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/EntityPacketRewriter1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/EntityPacketRewriter1_11.java
@@ -30,8 +30,8 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.version.Types1_9;
 import com.viaversion.viaversion.protocols.v1_10to1_11.Protocol1_10To1_11;
-import com.viaversion.viaversion.protocols.v1_10to1_11.data.BlockEntityNames1_11;
-import com.viaversion.viaversion.protocols.v1_10to1_11.data.EntityNames1_11;
+import com.viaversion.viaversion.protocols.v1_10to1_11.data.BlockEntityMappings1_11;
+import com.viaversion.viaversion.protocols.v1_10to1_11.data.EntityMappings1_11;
 import com.viaversion.viaversion.protocols.v1_10to1_11.storage.EntityTracker1_11;
 import com.viaversion.viaversion.protocols.v1_9_1to1_9_3.packet.ClientboundPackets1_9_3;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
@@ -144,13 +144,13 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
                 handler(wrapper -> {
                     CompoundTag tag = wrapper.get(Types.NAMED_COMPOUND_TAG, 0);
                     if (wrapper.get(Types.UNSIGNED_BYTE, 0) == 1) {
-                        EntityNames1_11.toClientSpawner(tag);
+                        EntityMappings1_11.toClientSpawner(tag);
                     }
 
                     StringTag idTag = tag.getStringTag("id");
                     if (idTag != null) {
                         // Handle new identifier
-                        idTag.setValue(BlockEntityNames1_11.toNewIdentifier(idTag.getValue()));
+                        idTag.setValue(BlockEntityMappings1_11.toNewIdentifier(idTag.getValue()));
                     }
                 });
             }
@@ -162,7 +162,7 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
         filter().handler((event, meta) -> {
             if (meta.getValue() instanceof DataItem) {
                 // Apply rewrite
-                EntityNames1_11.toClientItem(meta.value());
+                EntityMappings1_11.toClientItem(meta.value());
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/ItemPacketRewriter1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/ItemPacketRewriter1_11.java
@@ -22,7 +22,7 @@ import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.protocols.v1_10to1_11.Protocol1_10To1_11;
-import com.viaversion.viaversion.protocols.v1_10to1_11.data.EntityNames1_11;
+import com.viaversion.viaversion.protocols.v1_10to1_11.data.EntityMappings1_11;
 import com.viaversion.viaversion.protocols.v1_9_1to1_9_3.packet.ClientboundPackets1_9_3;
 import com.viaversion.viaversion.protocols.v1_9_1to1_9_3.packet.ServerboundPackets1_9_3;
 import com.viaversion.viaversion.rewriter.ItemRewriter;
@@ -74,13 +74,13 @@ public class ItemPacketRewriter1_11 extends ItemRewriter<ClientboundPackets1_9_3
 
     @Override
     public Item handleItemToClient(UserConnection connection, Item item) {
-        EntityNames1_11.toClientItem(item);
+        EntityMappings1_11.toClientItem(item);
         return item;
     }
 
     @Override
     public Item handleItemToServer(UserConnection connection, Item item) {
-        EntityNames1_11.toServerItem(item);
+        EntityMappings1_11.toServerItem(item);
         if (item == null) return null;
         boolean newItem = item.identifier() >= 218 && item.identifier() <= 234;
         newItem |= item.identifier() == 449 || item.identifier() == 450;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_11_1to1_12/storage/ItemTransactionStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_11_1to1_12/storage/ItemTransactionStorage.java
@@ -15,21 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.v1_13_2to1_14.data;
+package com.viaversion.viaversion.protocols.v1_11_1to1_12.storage;
 
-import com.google.gson.JsonObject;
-import com.viaversion.viaversion.api.protocol.Protocol;
-import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.ComponentRewriter1_13;
-
-public class ComponentRewriter1_14<C extends ClientboundPacketType> extends ComponentRewriter1_13<C> {
-
-    public ComponentRewriter1_14(Protocol<C, ?, ?, ?> protocol) {
-        super(protocol);
-    }
-
-    @Override
-    protected void handleTranslate(JsonObject object, String translate) {
-        // Nothing
-    }
+public record ItemTransactionStorage(short windowId, short slotId, short actionId) {
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/Protocol1_12_2To1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/Protocol1_12_2To1_13.java
@@ -46,11 +46,11 @@ import com.viaversion.viaversion.protocols.v1_12_2to1_13.blockconnections.Connec
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.blockconnections.providers.BlockConnectionProvider;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.blockconnections.providers.PacketBlockConnectionProvider;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.BlockIdData;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.ComponentRewriter1_13;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.rewriter.ComponentRewriter1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.MappingData1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.RecipeData;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.StatisticData;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.StatisticMappings;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.StatisticMappings1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ClientboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ServerboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.provider.BlockEntityProvider;
@@ -212,7 +212,7 @@ public class Protocol1_12_2To1_13 extends AbstractProtocol<ClientboundPackets1_1
                 if (split.length == 2) {
                     // Custom types
                     categoryId = 8;
-                    Integer newIdRaw = StatisticMappings.CUSTOM_STATS.get(name);
+                    Integer newIdRaw = StatisticMappings1_13.CUSTOM_STATS.get(name);
                     if (newIdRaw != null) {
                         newId = newIdRaw;
                     } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/EntityIdMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/EntityIdMappings1_13.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.protocols.v1_12_2to1_13.data;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
-public class EntityTypeRewriter {
+public class EntityIdMappings1_13 {
     private static final Int2IntMap ENTITY_TYPES = new Int2IntOpenHashMap(83, .99F);
 
     static {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/EntityNameMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/EntityNameMappings1_13.java
@@ -20,30 +20,12 @@ package com.viaversion.viaversion.protocols.v1_12_2to1_13.data;
 import com.viaversion.viaversion.util.Key;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
-/*
-    CHANGED ENTITY NAMES IN 1.13
-
-    commandblock_minecart => command_block_minecart
-    ender_crystal => end_crystal
-    evocation_fangs => evoker_fangs
-    evocation_illager => evoker
-    eye_of_ender_signal => eye_of_ender
-    fireworks_rocket => firework_rocket
-    illusion_illager => illusioner
-    snowman => snow_golem
-    villager_golem => iron_golem
-    vindication_illager => vindicator
-    xp_bottle => experience_bottle
-    xp_orb => experience_orb
- */
-public class EntityNameRewriter {
+public class EntityNameMappings1_13 {
     private static final Map<String, String> entityNames = new HashMap<>();
 
     static {
-        /*
-            CHANGED NAMES IN 1.13
-         */
         reg("commandblock_minecart", "command_block_minecart");
         reg("ender_crystal", "end_crystal");
         reg("evocation_fangs", "evoker_fangs");
@@ -58,7 +40,6 @@ public class EntityNameRewriter {
         reg("xp_orb", "experience_orb");
     }
 
-
     private static void reg(String past, String future) {
         entityNames.put(Key.namespaced(past), Key.namespaced(future));
     }
@@ -69,9 +50,6 @@ public class EntityNameRewriter {
             return entityName;
         }
         entityName = entityNames.get(Key.namespaced(entName));
-        if (entityName != null) {
-            return entityName;
-        } else
-            return entName;
+        return Objects.requireNonNullElse(entityName, entName);
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/NamedSoundMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/NamedSoundMappings1_13.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-public class NamedSoundRewriter {
+public class NamedSoundMappings1_13 {
     private static final Map<String, String> oldToNew = new HashMap<>();
 
     static {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/ParticleIdMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/ParticleIdMappings1_13.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class ParticleRewriter {
+public class ParticleIdMappings1_13 {
     private static final List<NewParticle> particles = new ArrayList<>();
 
     static {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/SoundSource1_12_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/SoundSource1_12_2.java
@@ -19,7 +19,7 @@ package com.viaversion.viaversion.protocols.v1_12_2to1_13.data;
 
 import java.util.Optional;
 
-public enum SoundSource {
+public enum SoundSource1_12_2 {
     MASTER("master", 0),
     MUSIC("music", 1),
     RECORD("record", 2),
@@ -34,13 +34,13 @@ public enum SoundSource {
     private final String name;
     private final int id;
 
-    SoundSource(String name, int id) {
+    SoundSource1_12_2(String name, int id) {
         this.name = name;
         this.id = id;
     }
 
-    public static Optional<SoundSource> findBySource(String source) {
-        for (SoundSource item : SoundSource.values())
+    public static Optional<SoundSource1_12_2> findBySource(String source) {
+        for (SoundSource1_12_2 item : SoundSource1_12_2.values())
             if (item.name.equalsIgnoreCase(source))
                 return Optional.of(item);
         return Optional.empty();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/SpawnEggMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/SpawnEggMappings1_13.java
@@ -22,7 +22,7 @@ import com.google.common.collect.HashBiMap;
 import com.viaversion.viaversion.util.Key;
 import java.util.Optional;
 
-public class SpawnEggRewriter {
+public class SpawnEggMappings1_13 {
     private static final BiMap<String, Integer> spawnEggs = HashBiMap.create();
 
     static {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/StatisticMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/StatisticMappings1_13.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.protocols.v1_12_2to1_13.data;
 import java.util.HashMap;
 import java.util.Map;
 
-public class StatisticMappings {
+public class StatisticMappings1_13 {
 
     public static final Map<String, Integer> CUSTOM_STATS = new HashMap<>();
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/provider/blockentities/SpawnerHandler.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/provider/blockentities/SpawnerHandler.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.protocols.v1_12_2to1_13.provider.blockentities
 import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.nbt.tag.StringTag;
 import com.viaversion.viaversion.api.connection.UserConnection;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.EntityNameRewriter;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.EntityNameMappings1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.provider.BlockEntityProvider;
 
 public class SpawnerHandler implements BlockEntityProvider.BlockEntityHandler {
@@ -30,7 +30,7 @@ public class SpawnerHandler implements BlockEntityProvider.BlockEntityHandler {
         if (data != null) {
             StringTag id = data.getStringTag("id");
             if (id != null) {
-                id.setValue(EntityNameRewriter.rewrite(id.getValue()));
+                id.setValue(EntityNameMappings1_13.rewrite(id.getValue()));
             }
         }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/ComponentRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/ComponentRewriter1_13.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.v1_12_2to1_13.data;
+package com.viaversion.viaversion.protocols.v1_12_2to1_13.rewriter;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/EntityPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/EntityPacketRewriter1_13.java
@@ -28,8 +28,8 @@ import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.version.Types1_12;
 import com.viaversion.viaversion.api.type.types.version.Types1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.Protocol1_12_2To1_13;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.EntityTypeRewriter;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.ParticleRewriter;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.EntityIdMappings1_13;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.ParticleIdMappings1_13;
 import com.viaversion.viaversion.protocols.v1_12to1_12_1.packet.ClientboundPackets1_12_1;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.util.ComponentUtil;
@@ -210,7 +210,7 @@ public class EntityPacketRewriter1_13 extends EntityRewriter<ClientboundPackets1
                 int parameter1 = parameter1Meta != null ? parameter1Meta.value() : 0;
                 int parameter2 = parameter2Meta != null ? parameter2Meta.value() : 0;
 
-                Particle particle = ParticleRewriter.rewriteParticle(particleId, new Integer[]{parameter1, parameter2});
+                Particle particle = ParticleIdMappings1_13.rewriteParticle(particleId, new Integer[]{parameter1, parameter2});
                 if (particle != null && particle.id() != -1) {
                     event.createExtraData(new EntityData(9, Types1_13.ENTITY_DATA_TYPES.particleType, particle));
                 }
@@ -223,7 +223,7 @@ public class EntityPacketRewriter1_13 extends EntityRewriter<ClientboundPackets1
 
     @Override
     public int newEntityId(final int id) {
-        return EntityTypeRewriter.getNewId(id);
+        return EntityIdMappings1_13.getNewId(id);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/ItemPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/ItemPacketRewriter1_13.java
@@ -33,8 +33,8 @@ import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.Protocol1_12_2To1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.BlockIdData;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.MappingData1_13;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.SoundSource;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.SpawnEggRewriter;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.SoundSource1_12_2;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.SpawnEggMappings1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ClientboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ServerboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_12to1_12_1.packet.ClientboundPackets1_12_1;
@@ -117,12 +117,12 @@ public class ItemPacketRewriter1_13 extends ItemRewriter<ClientboundPackets1_12_
                         wrapper.write(Types.BYTE, flags); // Placeholder
                         if (!originalSource.isEmpty()) {
                             flags |= 1;
-                            Optional<SoundSource> finalSource = SoundSource.findBySource(originalSource);
+                            Optional<SoundSource1_12_2> finalSource = SoundSource1_12_2.findBySource(originalSource);
                             if (finalSource.isEmpty()) {
                                 if (!Via.getConfig().isSuppressConversionWarnings()) {
                                     Protocol1_12_2To1_13.LOGGER.warning("Could not handle unknown sound source " + originalSource + " falling back to default: master");
                                 }
-                                finalSource = Optional.of(SoundSource.MASTER);
+                                finalSource = Optional.of(SoundSource1_12_2.MASTER);
                             }
 
                             wrapper.write(Types.VAR_INT, finalSource.get().getId());
@@ -430,7 +430,7 @@ public class ItemPacketRewriter1_13 extends ItemRewriter<ClientboundPackets1_12_
                 if (entityTag != null) {
                     StringTag idTag = entityTag.getStringTag("id");
                     if (idTag != null) {
-                        rawId = SpawnEggRewriter.getSpawnEggId(idTag.getValue());
+                        rawId = SpawnEggMappings1_13.getSpawnEggId(idTag.getValue());
                         if (rawId == -1) {
                             rawId = 25100288; // Bat fallback
                         } else {
@@ -528,7 +528,7 @@ public class ItemPacketRewriter1_13 extends ItemRewriter<ClientboundPackets1_12_
             int oldId = Protocol1_12_2To1_13.MAPPINGS.getItemMappings().inverse().getNewId(item.identifier());
             if (oldId != -1) {
                 // Handle spawn eggs
-                Optional<String> eggEntityId = SpawnEggRewriter.getEntityId(oldId);
+                Optional<String> eggEntityId = SpawnEggMappings1_13.getEntityId(oldId);
                 if (eggEntityId.isPresent()) {
                     rawId = 383 << 16;
                     if (tag == null)

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/WorldPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/WorldPacketRewriter1_13.java
@@ -37,8 +37,8 @@ import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_9_3;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.Protocol1_12_2To1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.blockconnections.ConnectionData;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.blockconnections.ConnectionHandler;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.NamedSoundRewriter;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.ParticleRewriter;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.NamedSoundMappings1_13;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.data.ParticleIdMappings1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ClientboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ServerboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.provider.BlockEntityProvider;
@@ -318,7 +318,7 @@ public class WorldPacketRewriter1_13 {
                 map(Types.STRING);
                 handler(wrapper -> {
                     String sound = Key.stripMinecraftNamespace(wrapper.get(Types.STRING, 0));
-                    String newSoundId = NamedSoundRewriter.getNewId(sound);
+                    String newSoundId = NamedSoundMappings1_13.getNewId(sound);
                     wrapper.set(Types.STRING, 0, newSoundId);
                 });
             }
@@ -496,7 +496,7 @@ public class WorldPacketRewriter1_13 {
                     for (int i = 0; i < data.length; i++)
                         data[i] = wrapper.read(Types.VAR_INT);
 
-                    Particle particle = ParticleRewriter.rewriteParticle(particleId, data);
+                    Particle particle = ParticleIdMappings1_13.rewriteParticle(particleId, data);
 
                     // Cancel if null or completely removed
                     if (particle == null || particle.id() == -1) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/Protocol1_13_2To1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/Protocol1_13_2To1_14.java
@@ -27,7 +27,7 @@ import com.viaversion.viaversion.api.type.types.version.Types1_13_2;
 import com.viaversion.viaversion.api.type.types.version.Types1_14;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ClientboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ServerboundPackets1_13;
-import com.viaversion.viaversion.protocols.v1_13_2to1_14.data.ComponentRewriter1_14;
+import com.viaversion.viaversion.protocols.v1_13_2to1_14.rewriter.ComponentRewriter1_14;
 import com.viaversion.viaversion.protocols.v1_13_2to1_14.data.MappingData1_14;
 import com.viaversion.viaversion.protocols.v1_13_2to1_14.packet.ClientboundPackets1_14;
 import com.viaversion.viaversion.protocols.v1_13_2to1_14.packet.ServerboundPackets1_14;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/ComponentRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/ComponentRewriter1_14.java
@@ -15,7 +15,21 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.v1_11_1to1_12.storage;
+package com.viaversion.viaversion.protocols.v1_13_2to1_14.rewriter;
 
-public record ItemTransaction(short windowId, short slotId, short actionId) {
+import com.google.gson.JsonObject;
+import com.viaversion.viaversion.api.protocol.Protocol;
+import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
+import com.viaversion.viaversion.protocols.v1_12_2to1_13.rewriter.ComponentRewriter1_13;
+
+public class ComponentRewriter1_14<C extends ClientboundPacketType> extends ComponentRewriter1_13<C> {
+
+    public ComponentRewriter1_14(Protocol<C, ?, ?, ?> protocol) {
+        super(protocol);
+    }
+
+    @Override
+    protected void handleTranslate(JsonObject object, String translate) {
+        // Nothing
+    }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/data/AttributeMappings1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/data/AttributeMappings1_16.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.protocols.v1_15_2to1_16.data;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 
-public final class Attributes1_16 {
+public final class AttributeMappings1_16 {
     private static final BiMap<String, String> ATTRIBUTE_MAPPINGS = HashBiMap.create();
 
     static {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
@@ -29,7 +29,7 @@ import com.viaversion.viaversion.api.type.types.version.Types1_14;
 import com.viaversion.viaversion.api.type.types.version.Types1_16;
 import com.viaversion.viaversion.protocols.v1_14_4to1_15.packet.ClientboundPackets1_15;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.Protocol1_15_2To1_16;
-import com.viaversion.viaversion.protocols.v1_15_2to1_16.data.Attributes1_16;
+import com.viaversion.viaversion.protocols.v1_15_2to1_16.data.AttributeMappings1_16;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.data.DimensionRegistries1_16;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.packet.ClientboundPackets1_16;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.packet.ServerboundPackets1_16;
@@ -161,7 +161,7 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
             for (int i = 0; i < size; i++) {
                 // Attributes have been renamed and are now namespaced identifiers
                 String key = wrapper.read(Types.STRING);
-                String attributeIdentifier = Attributes1_16.attributeIdentifierMappings().get(key);
+                String attributeIdentifier = AttributeMappings1_16.attributeIdentifierMappings().get(key);
                 if (attributeIdentifier == null) {
                     attributeIdentifier = Key.namespaced(key);
                     if (!Key.isValid(attributeIdentifier)) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/ItemPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/ItemPacketRewriter1_16.java
@@ -30,7 +30,7 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.protocols.v1_14_4to1_15.packet.ClientboundPackets1_15;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.Protocol1_15_2To1_16;
-import com.viaversion.viaversion.protocols.v1_15_2to1_16.data.Attributes1_16;
+import com.viaversion.viaversion.protocols.v1_15_2to1_16.data.AttributeMappings1_16;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.packet.ClientboundPackets1_16;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.packet.ServerboundPackets1_16;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.storage.InventoryTracker1_16;
@@ -239,8 +239,8 @@ public class ItemPacketRewriter1_16 extends ItemRewriter<ClientboundPackets1_15,
             attributeName = Key.namespaced(attributeName);
         }
 
-        String mappedAttribute = (inverse ? Attributes1_16.attributeIdentifierMappings().inverse()
-            : Attributes1_16.attributeIdentifierMappings()).get(attributeName);
+        String mappedAttribute = (inverse ? AttributeMappings1_16.attributeIdentifierMappings().inverse()
+            : AttributeMappings1_16.attributeIdentifierMappings()).get(attributeName);
         if (mappedAttribute == null) return;
 
         attributeNameTag.setValue(mappedAttribute);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_17_1to1_18/data/BlockEntityMappings1_18.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_17_1to1_18/data/BlockEntityMappings1_18.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.protocols.v1_17_1to1_18.data;
 import com.viaversion.viaversion.protocols.v1_17_1to1_18.Protocol1_17_1To1_18;
 import java.util.Arrays;
 
-public final class BlockEntityIds1_18 {
+public final class BlockEntityMappings1_18 {
 
     private static final int[] IDS = new int[14];
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_17_1to1_18/rewriter/WorldPacketRewriter1_18.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_17_1to1_18/rewriter/WorldPacketRewriter1_18.java
@@ -36,7 +36,7 @@ import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_17;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_18;
 import com.viaversion.viaversion.protocols.v1_17_1to1_18.Protocol1_17_1To1_18;
 import com.viaversion.viaversion.protocols.v1_17_1to1_18.data.BlockEntities1_18;
-import com.viaversion.viaversion.protocols.v1_17_1to1_18.data.BlockEntityIds1_18;
+import com.viaversion.viaversion.protocols.v1_17_1to1_18.data.BlockEntityMappings1_18;
 import com.viaversion.viaversion.protocols.v1_17_1to1_18.packet.ClientboundPackets1_18;
 import com.viaversion.viaversion.protocols.v1_17_1to1_18.storage.ChunkLightStorage;
 import com.viaversion.viaversion.protocols.v1_17to1_17_1.packet.ClientboundPackets1_17_1;
@@ -55,7 +55,7 @@ public final class WorldPacketRewriter1_18 {
                 map(Types.BLOCK_POSITION1_14);
                 handler(wrapper -> {
                     final short id = wrapper.read(Types.UNSIGNED_BYTE);
-                    final int newId = BlockEntityIds1_18.newId(id);
+                    final int newId = BlockEntityMappings1_18.newId(id);
                     wrapper.write(Types.VAR_INT, newId);
 
                     handleSpawners(newId, wrapper.passthrough(Types.NAMED_COMPOUND_TAG));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/data/PotionEffects1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/data/PotionEffects1_20_2.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.viaversion.viaversion.protocols.v1_20to1_20_2.util;
+package com.viaversion.viaversion.protocols.v1_20to1_20_2.data;
 
 import com.viaversion.viaversion.util.Key;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/rewriter/BlockItemPacketRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/rewriter/BlockItemPacketRewriter1_20_2.java
@@ -42,7 +42,7 @@ import com.viaversion.viaversion.protocols.v1_19_3to1_19_4.packet.ClientboundPac
 import com.viaversion.viaversion.protocols.v1_19_3to1_19_4.rewriter.RecipeRewriter1_19_4;
 import com.viaversion.viaversion.protocols.v1_20to1_20_2.Protocol1_20To1_20_2;
 import com.viaversion.viaversion.protocols.v1_20to1_20_2.packet.ServerboundPackets1_20_2;
-import com.viaversion.viaversion.protocols.v1_20to1_20_2.util.PotionEffects1_20_2;
+import com.viaversion.viaversion.protocols.v1_20to1_20_2.data.PotionEffects1_20_2;
 import com.viaversion.viaversion.rewriter.BlockRewriter;
 import com.viaversion.viaversion.rewriter.ItemRewriter;
 import com.viaversion.viaversion.util.MathUtil;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/EffectIdMappings1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/EffectIdMappings1_9.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.protocols.v1_8to1_9.data;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
-public class EffectIds1_8 {
+public class EffectIdMappings1_9 {
 
     private static final Int2IntMap EFFECTS = new Int2IntOpenHashMap(19, .99F);
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/EntityDataIndex1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/EntityDataIndex1_9.java
@@ -28,7 +28,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_9.EntityType.*;
 
-public enum MetaIndex1_8 {
+public enum EntityDataIndex1_9 {
 
     // Entity
     ENTITY_STATUS(ENTITY, 0, EntityDataTypes1_8.BYTE, EntityDataTypes1_9.BYTE),
@@ -189,10 +189,10 @@ public enum MetaIndex1_8 {
     // Ender dragon
     ENDER_DRAGON_PHASE(ENDER_DRAGON, 11, EntityDataTypes1_9.VAR_INT);
 
-    private static final HashMap<Pair<EntityTypes1_9.EntityType, Integer>, MetaIndex1_8> metadataRewrites = new HashMap<>();
+    private static final HashMap<Pair<EntityTypes1_9.EntityType, Integer>, EntityDataIndex1_9> metadataRewrites = new HashMap<>();
 
     static {
-        for (MetaIndex1_8 index : MetaIndex1_8.values()) {
+        for (EntityDataIndex1_9 index : EntityDataIndex1_9.values()) {
             metadataRewrites.put(new Pair<>(index.clazz, index.index), index);
         }
     }
@@ -203,7 +203,7 @@ public enum MetaIndex1_8 {
     private final EntityDataTypes1_8 oldType;
     private final int index;
 
-    MetaIndex1_8(EntityTypes1_9.EntityType type, int index, EntityDataTypes1_8 oldType, @Nullable EntityDataTypes1_9 newType) {
+    EntityDataIndex1_9(EntityTypes1_9.EntityType type, int index, EntityDataTypes1_8 oldType, @Nullable EntityDataTypes1_9 newType) {
         this.clazz = type;
         this.index = index;
         this.newIndex = index;
@@ -211,7 +211,7 @@ public enum MetaIndex1_8 {
         this.newType = newType;
     }
 
-    MetaIndex1_8(EntityTypes1_9.EntityType type, int newIndex, @Nullable EntityDataTypes1_9 newType) {
+    EntityDataIndex1_9(EntityTypes1_9.EntityType type, int newIndex, @Nullable EntityDataTypes1_9 newType) {
         this.clazz = type;
         this.index = -1;
         this.oldType = null;
@@ -219,7 +219,7 @@ public enum MetaIndex1_8 {
         this.newType = newType;
     }
 
-    MetaIndex1_8(EntityTypes1_9.EntityType type, int index, EntityDataTypes1_8 oldType, int newIndex, @Nullable EntityDataTypes1_9 newType) {
+    EntityDataIndex1_9(EntityTypes1_9.EntityType type, int index, EntityDataTypes1_8 oldType, int newIndex, @Nullable EntityDataTypes1_9 newType) {
         this.clazz = type;
         this.index = index;
         this.oldType = oldType;
@@ -247,15 +247,15 @@ public enum MetaIndex1_8 {
         return index;
     }
 
-    private static Optional<MetaIndex1_8> getIndex(EntityType type, int index) {
+    private static Optional<EntityDataIndex1_9> getIndex(EntityType type, int index) {
         Pair pair = new Pair<>(type, index);
         return Optional.ofNullable(metadataRewrites.get(pair));
     }
 
-    public static MetaIndex1_8 searchIndex(EntityType type, int index) {
+    public static EntityDataIndex1_9 searchIndex(EntityType type, int index) {
         EntityType currentType = type;
         do {
-            Optional<MetaIndex1_8> optMeta = getIndex(currentType, index);
+            Optional<EntityDataIndex1_9> optMeta = getIndex(currentType, index);
 
             if (optMeta.isPresent()) {
                 return optMeta.get();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/PotionIdMappings1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/PotionIdMappings1_9.java
@@ -22,7 +22,7 @@ import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import java.util.HashMap;
 import java.util.Map;
 
-public class PotionIds1_8 {
+public class PotionIdMappings1_9 {
 
     public static final Map<String, Integer> POTION_NAME_TO_ID = new HashMap<>();
     public static final Map<Integer, String> POTION_ID_TO_NAME = new HashMap<>();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/SoundEffectMappings1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/SoundEffectMappings1_9.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.protocols.v1_8to1_9.data;
 import java.util.HashMap;
 import java.util.Map;
 
-public enum SoundEffects1_8 {
+public enum SoundEffectMappings1_9 {
 
     MOB_HORSE_ZOMBIE_IDLE("mob.horse.zombie.idle", "entity.zombie_horse.ambient", SoundCategories1_8.NEUTRAL),
     NOTE_SNARE("note.snare", "block.note.snare", SoundCategories1_8.RECORD),
@@ -274,30 +274,30 @@ public enum SoundEffects1_8 {
     private final SoundCategories1_8 category;
     private final boolean breakSound;
 
-    private static final Map<String, SoundEffects1_8> effects;
+    private static final Map<String, SoundEffectMappings1_9> effects;
 
     static {
         effects = new HashMap<>();
-        for (SoundEffects1_8 e : SoundEffects1_8.values()) {
+        for (SoundEffectMappings1_9 e : SoundEffectMappings1_9.values()) {
             effects.put(e.getName(), e);
         }
     }
 
-    SoundEffects1_8(String name, String newName, SoundCategories1_8 category) {
+    SoundEffectMappings1_9(String name, String newName, SoundCategories1_8 category) {
         this.category = category;
         this.newName = newName;
         this.name = name;
         this.breakSound = name.startsWith("dig.");
     }
 
-    SoundEffects1_8(String name, String newName, SoundCategories1_8 category, boolean shouldIgnore) {
+    SoundEffectMappings1_9(String name, String newName, SoundCategories1_8 category, boolean shouldIgnore) {
         this.category = category;
         this.newName = newName;
         this.name = name;
         this.breakSound = name.startsWith("dig.") || shouldIgnore;
     }
 
-    public static SoundEffects1_8 getByName(String name) {
+    public static SoundEffectMappings1_9 getByName(String name) {
         return effects.get(name);
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
@@ -34,7 +34,7 @@ import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.version.Types1_8;
 import com.viaversion.viaversion.api.type.types.version.Types1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.Protocol1_8To1_9;
-import com.viaversion.viaversion.protocols.v1_8to1_9.data.MetaIndex1_8;
+import com.viaversion.viaversion.protocols.v1_8to1_9.data.EntityDataIndex1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ClientboundPackets1_8;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ClientboundPackets1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ServerboundPackets1_9;
@@ -393,7 +393,7 @@ public class EntityPacketRewriter1_9 extends EntityRewriter<ClientboundPackets1_
 
     private void handleMetadata(EntityDataHandlerEvent event, EntityData metadata) {
         EntityType type = event.entityType();
-        MetaIndex1_8 metaIndex = MetaIndex1_8.searchIndex(type, metadata.id());
+        EntityDataIndex1_9 metaIndex = EntityDataIndex1_9.searchIndex(type, metadata.id());
         if (metaIndex == null) {
             // Almost certainly bad data, remove it
             event.cancel();
@@ -419,13 +419,13 @@ public class EntityPacketRewriter1_9 extends EntityRewriter<ClientboundPackets1_
                     metadata.setValue(((Integer) value).byteValue());
                 }
                 // After writing the last one
-                if (metaIndex == MetaIndex1_8.ENTITY_STATUS && type == EntityTypes1_9.EntityType.PLAYER) {
+                if (metaIndex == EntityDataIndex1_9.ENTITY_STATUS && type == EntityTypes1_9.EntityType.PLAYER) {
                     byte val = 0;
                     if ((((Byte) value) & 0x10) == 0x10) { // Player eating/aiming/drinking
                         val = 1;
                     }
-                    int newIndex = MetaIndex1_8.PLAYER_HAND.getNewIndex();
-                    EntityDataType metaType = MetaIndex1_8.PLAYER_HAND.getNewType();
+                    int newIndex = EntityDataIndex1_9.PLAYER_HAND.getNewIndex();
+                    EntityDataType metaType = EntityDataIndex1_9.PLAYER_HAND.getNewType();
                     event.createExtraData(new EntityData(newIndex, metaType, val));
                 }
                 break;
@@ -456,7 +456,7 @@ public class EntityPacketRewriter1_9 extends EntityRewriter<ClientboundPackets1_
                 metadata.setValue(value);
                 break;
             case BOOLEAN:
-                if (metaIndex == MetaIndex1_8.ABSTRACT_AGEABLE_AGE)
+                if (metaIndex == EntityDataIndex1_9.ABSTRACT_AGEABLE_AGE)
                     metadata.setValue((Byte) value < 0);
                 else
                     metadata.setValue((Byte) value != 0);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
@@ -27,7 +27,7 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.protocols.v1_8to1_9.Protocol1_8To1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.data.EntityIds1_8;
-import com.viaversion.viaversion.protocols.v1_8to1_9.data.PotionIds1_8;
+import com.viaversion.viaversion.protocols.v1_8to1_9.data.PotionIdMappings1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ClientboundPackets1_8;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ClientboundPackets1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ServerboundPackets1_9;
@@ -405,7 +405,7 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
                 item.setIdentifier(438); // splash id
                 item.setData((short) (item.data() - 8192));
             }
-            String name = PotionIds1_8.potionNameFromDamage(item.data());
+            String name = PotionIdMappings1_9.potionNameFromDamage(item.data());
             StringTag potion = new StringTag(Key.namespaced(name));
             tag.put("Potion", potion);
             item.setTag(tag);
@@ -457,8 +457,8 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
             if (tag != null && tag.getStringTag("Potion") != null) {
                 StringTag potion = tag.getStringTag("Potion");
                 String potionName = Key.stripMinecraftNamespace(potion.getValue());
-                if (PotionIds1_8.POTION_NAME_TO_ID.containsKey(potionName)) {
-                    data = PotionIds1_8.POTION_NAME_TO_ID.get(potionName);
+                if (PotionIdMappings1_9.POTION_NAME_TO_ID.containsKey(potionName)) {
+                    data = PotionIdMappings1_9.POTION_NAME_TO_ID.get(potionName);
                 }
                 tag.remove("Potion");
             }
@@ -473,8 +473,8 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
             if (tag != null && tag.getStringTag("Potion") != null) {
                 StringTag potion = tag.getStringTag("Potion");
                 String potionName = Key.stripMinecraftNamespace(potion.getValue());
-                if (PotionIds1_8.POTION_NAME_TO_ID.containsKey(potionName)) {
-                    data = PotionIds1_8.POTION_NAME_TO_ID.get(potionName) + 8192;
+                if (PotionIdMappings1_9.POTION_NAME_TO_ID.containsKey(potionName)) {
+                    data = PotionIdMappings1_9.POTION_NAME_TO_ID.get(potionName) + 8192;
                 }
                 tag.remove("Potion");
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/WorldPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/WorldPacketRewriter1_9.java
@@ -36,9 +36,9 @@ import com.viaversion.viaversion.api.type.types.chunk.BulkChunkType1_8;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_8;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_9_1;
 import com.viaversion.viaversion.protocols.v1_8to1_9.Protocol1_8To1_9;
-import com.viaversion.viaversion.protocols.v1_8to1_9.data.EffectIds1_8;
-import com.viaversion.viaversion.protocols.v1_8to1_9.data.PotionIds1_8;
-import com.viaversion.viaversion.protocols.v1_8to1_9.data.SoundEffects1_8;
+import com.viaversion.viaversion.protocols.v1_8to1_9.data.EffectIdMappings1_9;
+import com.viaversion.viaversion.protocols.v1_8to1_9.data.PotionIdMappings1_9;
+import com.viaversion.viaversion.protocols.v1_8to1_9.data.SoundEffectMappings1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ClientboundPackets1_8;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ClientboundPackets1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ServerboundPackets1_8;
@@ -77,7 +77,7 @@ public class WorldPacketRewriter1_9 {
                 handler(wrapper -> {
                     int id = wrapper.get(Types.INT, 0);
 
-                    id = EffectIds1_8.getNewId(id);
+                    id = EffectIdMappings1_9.getNewId(id);
                     wrapper.set(Types.INT, 0, id);
                 });
                 // Rewrite potion effect as it changed to use a dynamic registry
@@ -85,7 +85,7 @@ public class WorldPacketRewriter1_9 {
                     int id = wrapper.get(Types.INT, 0);
                     if (id == 2002) {
                         int data = wrapper.get(Types.INT, 1);
-                        int newData = PotionIds1_8.getNewPotionID(data);
+                        int newData = PotionIdMappings1_9.getNewPotionID(data);
                         wrapper.set(Types.INT, 1, newData);
                     }
                 });
@@ -102,7 +102,7 @@ public class WorldPacketRewriter1_9 {
                 handler(wrapper -> {
                     String name = Key.stripMinecraftNamespace(wrapper.get(Types.STRING, 0));
 
-                    SoundEffects1_8 effect = SoundEffects1_8.getByName(name);
+                    SoundEffectMappings1_9 effect = SoundEffectMappings1_9.getByName(name);
                     int catid = 0;
                     String newname = name;
                     if (effect != null) {


### PR DESCRIPTION
Renames data classes to indicate the version they target, e.g:
- PotionIdMappings1_9 converts 1.8 ids to 1.9 names vs.
- ArmorTypes1_8 is just a registry with 1.8 armor types 

should be last renamings in v5