### PR TITLE
Fix firework rewriting in 1.20.3->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -499,9 +499,7 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
         final CompoundTag fireworksTag = tag.getCompoundTag("Fireworks");
         if (fireworksTag != null) {
             final ListTag<CompoundTag> explosionsTag = fireworksTag.getListTag("Explosions", CompoundTag.class);
-            if (explosionsTag != null) {
-                updateFireworks(data, fireworksTag, explosionsTag);
-            }
+            updateFireworks(data, fireworksTag, explosionsTag);
         }
 
         if (old.identifier() == 1085) {
@@ -1022,10 +1020,11 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
     }
 
     private void updateFireworks(final StructuredDataContainer data, final CompoundTag fireworksTag, final ListTag<CompoundTag> explosionsTag) {
-        final int flightDuration = fireworksTag.getInt("Flight");
+        final int flightDuration = fireworksTag.getByte("Flight");
         final Fireworks fireworks = new Fireworks(
             flightDuration,
-            explosionsTag.stream().limit(256).map(this::readExplosion).toArray(FireworkExplosion[]::new)
+            explosionsTag != null ? explosionsTag.stream().limit(256).
+                map(this::readExplosion).toArray(FireworkExplosion[]::new) : new FireworkExplosion[0]
         );
         data.set(StructuredDataKey.FIREWORKS, fireworks);
     }


### PR DESCRIPTION
Makes the explosion tag optional like it is in 1.20.4 so the tooltip shows the correct duration when crafting a firework, also fixes the type used for Flight which is byte in 1.20.4

Before:
<img width="263" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/ff8636c4-3ce2-41d2-bcc9-18fa5d0cc6d3">

After:
<img width="252" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/21e8ba76-2728-4629-8a35-c4bb51a96cca">

1.20.4 parsing code:
<img width="955" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/e8ee8663-d217-4ad3-a986-9496a0ac6b8f">
