### PR TITLE
Fixup LODESTONE_TRACKER rewriting in 1.20.3->.5 and backwards

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -469,10 +469,11 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
             data.set(StructuredDataKey.RECIPES, recipesTag);
         }
 
-        final CompoundTag lodestonePosTag = tag.getCompoundTag("LodestonePos");
-        final String lodestoneDimension = tag.getString("LodestoneDimension");
-        if (lodestonePosTag != null && lodestoneDimension != null) {
-            updateLodestoneTracker(tag, lodestonePosTag, lodestoneDimension, data);
+        final NumberTag trackedTag = tag.getNumberTag("LodestoneTracked");
+        if (trackedTag != null) {
+            final CompoundTag lodestonePosTag = tag.getCompoundTag("LodestonePos");
+            final String lodestoneDimension = tag.getString("LodestoneDimension");
+            updateLodestoneTracker(trackedTag.asBoolean(), lodestonePosTag, lodestoneDimension, data);
         }
 
         final ListTag<CompoundTag> effectsTag = tag.getListTag("effects", CompoundTag.class);
@@ -1048,12 +1049,14 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
         data.set(StructuredDataKey.SUSPICIOUS_STEW_EFFECTS, suspiciousStewEffects);
     }
 
-    private void updateLodestoneTracker(final CompoundTag tag, final CompoundTag lodestonePosTag, final String lodestoneDimensionTag, final StructuredDataContainer data) {
-        final boolean tracked = tag.getBoolean("LodestoneTracked");
-        final int x = lodestonePosTag.getInt("X");
-        final int y = lodestonePosTag.getInt("Y");
-        final int z = lodestonePosTag.getInt("Z");
-        final GlobalPosition position = new GlobalPosition(lodestoneDimensionTag, x, y, z);
+    private void updateLodestoneTracker(final boolean tracked, final CompoundTag lodestonePosTag, final String lodestoneDimensionTag, final StructuredDataContainer data) {
+        GlobalPosition position = null;
+        if (lodestonePosTag != null && lodestoneDimensionTag != null) {
+            final int x = lodestonePosTag.getInt("X");
+            final int y = lodestonePosTag.getInt("Y");
+            final int z = lodestonePosTag.getInt("Z");
+            position = new GlobalPosition(lodestoneDimensionTag, x, y, z);
+        }
         data.set(StructuredDataKey.LODESTONE_TRACKER, new LodestoneTracker(position, tracked));
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
@@ -220,13 +220,15 @@ public final class StructuredDataConverter {
         register(StructuredDataKey.CHARGED_PROJECTILES, (connection, data, tag) -> convertItemList(connection, data, tag, "ChargedProjectiles"));
         register(StructuredDataKey.BUNDLE_CONTENTS, (connection, data, tag) -> convertItemList(connection, data, tag, "Items"));
         register(StructuredDataKey.LODESTONE_TRACKER, (data, tag) -> {
-            final CompoundTag positionTag = new CompoundTag();
-            tag.put("LodestonePos", positionTag);
             tag.putBoolean("LodestoneTracked", data.tracked());
-            tag.putString("LodestoneDimension", data.position().dimension());
-            positionTag.putInt("X", data.position().x());
-            positionTag.putInt("Y", data.position().y());
-            positionTag.putInt("Z", data.position().z());
+            if (data.position() != null) {
+                final CompoundTag positionTag = new CompoundTag();
+                positionTag.putInt("X", data.position().x());
+                positionTag.putInt("Y", data.position().y());
+                positionTag.putInt("Z", data.position().z());
+                tag.put("LodestonePos", positionTag);
+                tag.putString("LodestoneDimension", data.position().dimension());
+            }
         });
         register(StructuredDataKey.FIREWORKS, (data, tag) -> {
             final CompoundTag fireworksTag = new CompoundTag();


### PR DESCRIPTION
Makes LodestonePos and LodestoneDimension optional like in 1.20.4, I'm not sure if the handling is 100% correct (e.g. when having only LodestoneDimension 1.20.4 would still show a glint while 1.20.6 now wouldn't) but issues https://github.com/ViaVersion/ViaBackwards/issues/755 and https://github.com/ViaVersion/ViaVersion/issues/3861 should be fixed now.