### PR TITLE
Fix FIREWORKS rewriting in 1.20.5->.3

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -387,7 +387,7 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
             return dataItem;
         }
 
-        if (dataConverter.isBackupInconvertibleData()) {
+        if (dataConverter.backupInconvertibleData()) {
             // In 1.20.6, some items have default values which are not written into the components
             if (item.identifier() == 1105 && !data.contains(StructuredDataKey.FIREWORKS)) {
                 data.set(StructuredDataKey.FIREWORKS, new Fireworks(1, new FireworkExplosion[0]));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -387,6 +387,11 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
             return dataItem;
         }
 
+        // In 1.20.6, some items have default values which are not written into the components
+        if (item.identifier() == 1105 && !data.contains(StructuredDataKey.FIREWORKS)) {
+            data.set(StructuredDataKey.FIREWORKS, new Fireworks(1, new FireworkExplosion[0]));
+        }
+
         for (final StructuredData<?> structuredData : data.data().values()) {
             dataConverter.writeToTag(connection, structuredData, tag);
         }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -387,9 +387,11 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
             return dataItem;
         }
 
-        // In 1.20.6, some items have default values which are not written into the components
-        if (item.identifier() == 1105 && !data.contains(StructuredDataKey.FIREWORKS)) {
-            data.set(StructuredDataKey.FIREWORKS, new Fireworks(1, new FireworkExplosion[0]));
+        if (dataConverter.isBackupInconvertibleData()) {
+            // In 1.20.6, some items have default values which are not written into the components
+            if (item.identifier() == 1105 && !data.contains(StructuredDataKey.FIREWORKS)) {
+                data.set(StructuredDataKey.FIREWORKS, new Fireworks(1, new FireworkExplosion[0]));
+            }
         }
 
         for (final StructuredData<?> structuredData : data.data().values()) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
@@ -873,7 +873,7 @@ public final class StructuredDataConverter {
         rewriters.put(key, c);
     }
 
-    public boolean isBackupInconvertibleData() {
+    public boolean backupInconvertibleData() {
         return backupInconvertibleData;
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
@@ -234,14 +234,16 @@ public final class StructuredDataConverter {
         });
         register(StructuredDataKey.FIREWORKS, (data, tag) -> {
             final CompoundTag fireworksTag = new CompoundTag();
-            fireworksTag.putInt("Flight", data.flightDuration());
+            fireworksTag.putByte("Flight", (byte) data.flightDuration());
             tag.put("Fireworks", fireworksTag);
 
-            final ListTag<CompoundTag> explosionsTag = new ListTag<>(CompoundTag.class);
-            for (final FireworkExplosion explosion : data.explosions()) {
-                explosionsTag.add(convertExplosion(explosion));
+            if (data.explosions().length > 0) {
+                final ListTag<CompoundTag> explosionsTag = new ListTag<>(CompoundTag.class);
+                for (final FireworkExplosion explosion : data.explosions()) {
+                    explosionsTag.add(convertExplosion(explosion));
+                }
+                fireworksTag.put("Explosions", explosionsTag);
             }
-            fireworksTag.put("Explosions", explosionsTag);
         });
         register(StructuredDataKey.FIREWORK_EXPLOSION, (data, tag) -> tag.put("Explosion", convertExplosion(data)));
         register(StructuredDataKey.PROFILE, (data, tag) -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
@@ -873,6 +873,10 @@ public final class StructuredDataConverter {
         rewriters.put(key, c);
     }
 
+    public boolean isBackupInconvertibleData() {
+        return backupInconvertibleData;
+    }
+
     @FunctionalInterface
     interface SimpleDataConverter<T> {
 


### PR DESCRIPTION
Fixes flight duration having the wrong type and also adds duration 1 as default value, it looks like 1.20.6 stopped sending default values to the client like 1.20.4 (so we will need to add them manually for every item where it matters).