### PR TITLE
Fixup ComponentUtil#legacyToJsonString behavior with styles

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
@@ -30,6 +30,7 @@ import net.lenni0451.mcstructs.text.events.hover.AHoverEvent;
 import net.lenni0451.mcstructs.text.events.hover.impl.TextHoverEvent;
 import net.lenni0451.mcstructs.text.serializer.LegacyStringDeserializer;
 import net.lenni0451.mcstructs.text.serializer.TextComponentSerializer;
+import net.lenni0451.mcstructs.text.utils.TextUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -151,10 +152,16 @@ public final class ComponentUtil {
 
     public static String legacyToJsonString(final String message, final boolean itemData) {
         final ATextComponent component = LegacyStringDeserializer.parse(message, true);
-        if (itemData && !component.getStyle().isEmpty()) {
+        if (itemData && hasStyle(component)) {
             component.setParentStyle(new Style().setItalic(false));
         }
         return SerializerVersion.V1_12.toString(component);
+    }
+
+    public static boolean hasStyle(final ATextComponent component) {
+        final boolean[] hasStyle = {false};
+        TextUtils.iterateAll(component, c -> hasStyle[0] |= !c.getStyle().isEmpty());
+        return hasStyle[0];
     }
 
     public static String jsonToLegacy(final String value) {

--- a/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
@@ -151,8 +151,8 @@ public final class ComponentUtil {
 
     public static String legacyToJsonString(final String message, final boolean itemData) {
         final ATextComponent component = LegacyStringDeserializer.parse(message, true);
-        if (itemData) {
-            component.setParentStyle(new Style().setItalic(true));
+        if (itemData && !component.getStyle().isEmpty()) {
+            component.setParentStyle(new Style().setItalic(false));
         }
         return SerializerVersion.V1_12.toString(component);
     }

--- a/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
@@ -152,7 +152,7 @@ public final class ComponentUtil {
     public static String legacyToJsonString(final String message, final boolean itemData) {
         final ATextComponent component = LegacyStringDeserializer.parse(message, true);
         if (itemData) {
-            component.setParentStyle(new Style().setItalic(false));
+            component.setParentStyle(new Style().setItalic(true));
         }
         return SerializerVersion.V1_12.toString(component);
     }


### PR DESCRIPTION
Looking at the git history and the old code it seems that this was missed previously, item name in 1.12->1.13 and item lore in 1.13->1.14 should both be italic default (I tested this using native server and client versions).