### PR TITLE
Remove outdated dependencies/plugins from plugin.yml

### DIFF
--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ description: ${description}
 api-version: 1.13
 folia-supported: true
 loadbefore: [ ProtocolLib, ProxyPipe, SpigotLib, SkinRestorer ]
-softdepend: [ ProtocolSupport, PacketListenerApi ]
+softdepend: [ PacketListenerApi ]
 commands:
   viaversion:
     permission: viaversion.command # The permission is also referenced here to filter root suggestions (/via<tab>)

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -5,8 +5,7 @@ version: ${version}
 description: ${description}
 api-version: 1.13
 folia-supported: true
-loadbefore: [ ProtocolLib, ProxyPipe, SpigotLib, SkinRestorer ]
-softdepend: [ PacketListenerApi ]
+loadbefore: [ ProtocolLib ]
 commands:
   viaversion:
     permission: viaversion.command # The permission is also referenced here to filter root suggestions (/via<tab>)


### PR DESCRIPTION
PS support got moved to https://github.com/ViaVersionAddons/ProtocolSupportCompat, so I believe this can be removed. Not sure if we could remove other dependencies as well like **PacketListenerApi**