### PR TITLE
Fix recipe rewriting in 1.20.3->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -75,6 +75,7 @@ import com.viaversion.viaversion.api.minecraft.item.data.ToolProperties;
 import com.viaversion.viaversion.api.minecraft.item.data.ToolRule;
 import com.viaversion.viaversion.api.minecraft.item.data.Unbreakable;
 import com.viaversion.viaversion.api.minecraft.item.data.WrittenBook;
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_20_2;
 import com.viaversion.viaversion.api.type.types.version.Types1_20_3;
@@ -329,6 +330,17 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
                     return new StructuredItem(1, 1);
                 }
                 return item;
+            }
+
+            @Override
+            protected void handleIngredient(final PacketWrapper wrapper) {
+                // Needed to map between DataItem and StructuredItem types
+                final Item[] items = wrapper.read(itemArrayType());
+                final StructuredItem[] mappedItems = new StructuredItem[items.length];
+                for (int i = 0; i < items.length; i++) {
+                    mappedItems[i] = (StructuredItem) rewrite(wrapper.user(), items[i]);
+                }
+                wrapper.write(mappedItemArrayType(), mappedItems);
             }
         };
         protocol.registerClientbound(ClientboundPackets1_20_3.UPDATE_RECIPES, wrapper -> {

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/RecipeRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/RecipeRewriter.java
@@ -82,7 +82,7 @@ public class RecipeRewriter<C extends ClientboundPacketType> {
         protocol.registerClientbound(packetType, wrapper -> {
             int size = wrapper.passthrough(Types.VAR_INT);
             for (int i = 0; i < size; i++) {
-                wrapper.passthrough(Types.STRING);// Recipe Identifier
+                wrapper.passthrough(Types.STRING); // Recipe Identifier
 
                 final int typeId = wrapper.passthrough(Types.VAR_INT);
                 final String type = protocol.getMappingData().getRecipeSerializerMappings().identifier(typeId);


### PR DESCRIPTION
This is needed in the transition protocol between DataItem and StructuredItem because types of Item have changed and would throw ArrayStoreException otherwise.

Closes https://github.com/ViaVersion/ViaFabricPlus/issues/412 and can be tested on both servers mentioned there.