### PR TITLE
Add DataItem constructor without data short

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/DataItem.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/DataItem.java
@@ -38,6 +38,10 @@ public class DataItem implements Item {
     public DataItem() {
     }
 
+    public DataItem(int identifier, byte amount, @Nullable CompoundTag tag) {
+        this(identifier, amount, (short) 0, tag);
+    }
+
     public DataItem(int identifier, byte amount, short data, @Nullable CompoundTag tag) {
         this.identifier = identifier;
         this.amount = amount;


### PR DESCRIPTION
Most protocols don't have the data field, and in theory we should have a separate Item class for 1.13-1.20.4 but having a second constructor is probably fine.