### PR TITLE
Improve block break/place detection in 1.8->1.9

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
@@ -143,8 +143,13 @@ public class EntityTracker1_9 extends EntityTrackerBase {
         }
     }
 
-    public boolean interactedBlockRecently(int x, int y, int z) {
-        return blockInteractions.contains(new BlockPosition(x, y, z));
+    public boolean interactedBlockRecently(final int x, final int y, final int z) {
+        for (final BlockPosition position : blockInteractions) {
+            if (Math.abs(position.x() - x) <= 1 && Math.abs(position.y() - y) <= 1 && Math.abs(position.z() - z) <= 1) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void addBlockInteraction(BlockPosition p) {


### PR DESCRIPTION
Servers can send sound packets where the positions have a slight offset. This PR aims to improve the detection to account for that.

Closes https://github.com/ViaVersion/ViaFabricPlus/issues/333