### PR TITLE
Handle edge cases when converting legacy components

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ComponentUtil.java
@@ -155,16 +155,14 @@ public final class ComponentUtil {
 
     public static String legacyToJsonString(final String message, final boolean itemData) {
         final ATextComponent component = LegacyStringDeserializer.parse(message, true);
-        if (itemData && hasStyle(component)) {
-            component.setParentStyle(new Style().setItalic(false));
+        if (itemData) {
+            TextUtils.iterateAll(component, c -> {
+                if (!c.getStyle().isEmpty()) {
+                    c.setParentStyle(new Style().setItalic(false));
+                }
+            });
         }
         return SerializerVersion.V1_12.toString(component);
-    }
-
-    public static boolean hasStyle(final ATextComponent component) {
-        final boolean[] hasStyle = {false};
-        TextUtils.iterateAll(component, c -> hasStyle[0] |= !c.getStyle().isEmpty());
-        return hasStyle[0];
     }
 
     public static String jsonToLegacy(final String value) {


### PR DESCRIPTION
MC will keep parts of the component italic if they don't have any formatting, checking for every part of the component instead of just setting everything to italic once one part of the component hasn't any formatting.

Can be tested with the following item:
{display:{Name:"{\"text\":\"§4Test\"}"}}