### PR TITLE
Remove bungee options from config.yml

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaConfig.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaConfig.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 public class BukkitViaConfig extends AbstractViaConfig {
-    private static final List<String> UNSUPPORTED = Arrays.asList("bungee-ping-interval", "bungee-ping-save", "bungee-servers", "velocity-ping-interval", "velocity-ping-save", "velocity-servers");
+    private static final List<String> UNSUPPORTED = Arrays.asList("velocity-ping-interval", "velocity-ping-save", "velocity-servers");
     private boolean quickMoveActionFix;
     private boolean hitboxFix1_9;
     private boolean hitboxFix1_14;

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -29,28 +29,6 @@ reload-disconnect-msg: "Server reload, please rejoin!"
 suppress-conversion-warnings: false
 #
 #----------------------------------------------------------#
-#                     BUNGEE OPTIONS                       #
-#----------------------------------------------------------#
-#
-# BungeeCord allows you to have different server versions inside.
-# Instead of you entering all the versions of these servers, we can ping them.
-#
-# What interval would you like us to ping at? (in seconds)
-# Use -1 to disable.
-bungee-ping-interval: 60
-# If the above is enabled, should we save the info to the config (in the section below)
-bungee-ping-save: true
-# To get a server's protocol, ViaVersion will do the following:
-# Look for the server in the following section, then look for the last ping if bungee-ping is enabled
-# otherwise use default.
-#
-# The format for the following is:
-#  servername: protocolversion
-# You can find protocol ids on https://wiki.vg/Protocol_version_numbers
-# It will use the default option if none found.
-bungee-servers: {}
-#
-#----------------------------------------------------------#
 #                    VELOCITY OPTIONS                      #
 #----------------------------------------------------------#
 #

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaConfig.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaConfig.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 public class VelocityViaConfig extends AbstractViaConfig {
-    private static final List<String> UNSUPPORTED = Arrays.asList("nms-player-ticking", "item-cache", "quick-move-action-fix", "bungee-ping-interval", "bungee-ping-save", "bungee-servers", "blockconnection-method", "change-1_9-hitbox", "change-1_14-hitbox");
+    private static final List<String> UNSUPPORTED = Arrays.asList("nms-player-ticking", "item-cache", "quick-move-action-fix", "blockconnection-method", "change-1_9-hitbox", "change-1_14-hitbox");
     private int velocityPingInterval;
     private boolean velocityPingSave;
     private Map<String, Integer> velocityServerProtocols;


### PR DESCRIPTION
Another pull request will add them into ViaBungee to prevent bloating the config.yml with platform settings which aren't considered as mainly supported anymore.