### PR TITLE
Restructure build-system to only publish important/usable modules

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -34,5 +34,3 @@ dependencies {
 java {
     withJavadocJar()
 }
-
-publishShadowJar()

--- a/build-logic/src/main/kotlin/extensions.kt
+++ b/build-logic/src/main/kotlin/extensions.kt
@@ -1,21 +1,7 @@
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.named
 import java.io.ByteArrayOutputStream
-
-fun Project.publishShadowJar() {
-    extensions.configure<PublishingExtension> {
-        publications.named<MavenPublication>("mavenJava") {
-            artifact(tasks["shadowJar"])
-            artifact(tasks["sourcesJar"])
-        }
-    }
-}
 
 fun Project.latestCommitHash(): String {
     return runGitCommand(listOf("rev-parse", "--short", "HEAD"))

--- a/build-logic/src/main/kotlin/extensions.kt
+++ b/build-logic/src/main/kotlin/extensions.kt
@@ -9,22 +9,10 @@ import org.gradle.kotlin.dsl.named
 import java.io.ByteArrayOutputStream
 
 fun Project.publishShadowJar() {
-    configurePublication {
-        artifact(tasks["shadowJar"])
-        artifact(tasks["sourcesJar"])
-    }
-}
-
-fun Project.publishJavaComponents() {
-    configurePublication {
-        from(components["java"])
-    }
-}
-
-private fun Project.configurePublication(configurer: MavenPublication.() -> Unit) {
     extensions.configure<PublishingExtension> {
         publications.named<MavenPublication>("mavenJava") {
-            apply(configurer)
+            artifact(tasks["shadowJar"])
+            artifact(tasks["sourcesJar"])
         }
     }
 }

--- a/build-logic/src/main/kotlin/via.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/via.base-conventions.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     `java-library`
-    `maven-publish`
 }
 
 tasks {
@@ -26,20 +25,4 @@ tasks {
 java {
     javaTarget(17)
     withSourcesJar()
-}
-
-publishing {
-    publications.create<MavenPublication>("mavenJava") {
-        groupId = rootProject.group as String
-        artifactId = project.name
-        version = rootProject.version as String
-    }
-    repositories.maven {
-        name = "Via"
-        url = uri("https://repo.viaversion.com/")
-        credentials(PasswordCredentials::class)
-        authentication {
-            create<BasicAuthentication>("basic")
-        }
-    }
 }

--- a/build-logic/src/main/kotlin/via.shadow-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/via.shadow-conventions.gradle.kts
@@ -27,6 +27,9 @@ publishing {
         groupId = rootProject.group as String
         artifactId = project.name
         version = rootProject.version as String
+
+        artifact(tasks["shadowJar"])
+        artifact(tasks["sourcesJar"])
     }
     repositories.maven {
         name = "Via"

--- a/build-logic/src/main/kotlin/via.shadow-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/via.shadow-conventions.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.jvm.tasks.Jar
 
 plugins {
     id("via.base-conventions")
+    id("maven-publish")
     id("com.github.johnrengelman.shadow")
 }
 
@@ -18,6 +19,22 @@ tasks {
     }
     named("build") {
         dependsOn(shadowJar)
+    }
+}
+
+publishing {
+    publications.create<MavenPublication>("mavenJava") {
+        groupId = rootProject.group as String
+        artifactId = project.name
+        version = rootProject.version as String
+    }
+    repositories.maven {
+        name = "Via"
+        url = uri("https://repo.viaversion.com/")
+        credentials(PasswordCredentials::class)
+        authentication {
+            create<BasicAuthentication>("basic")
+        }
     }
 }
 

--- a/build-logic/src/main/kotlin/via.standard-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/via.standard-conventions.gradle.kts
@@ -1,5 +1,0 @@
-plugins {
-    id("via.base-conventions")
-}
-
-publishJavaComponents()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,9 @@ val main = setOf(
     projects.viaversionFabric
 ).map { it.dependencyProject }
 
-// val special = setOf().map { it.dependencyProject }
-
 subprojects {
     when (this) {
         in main -> plugins.apply("via.shadow-conventions")
-        // in special -> plugins.apply("via.base-conventions")
-        else -> plugins.apply("via.standard-conventions")
+        else -> plugins.apply("via.base-conventions")
     }
 }

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -7,5 +7,3 @@ dependencies {
         exclude("javax.persistence", "persistence-api")
     }
 }
-
-publishShadowJar()

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -20,5 +20,3 @@ java {
 tasks.named<Jar>("sourcesJar") {
     from(project(":viaversion-api").sourceSets.main.get().allSource)
 }
-
-publishShadowJar()

--- a/universal/build.gradle.kts
+++ b/universal/build.gradle.kts
@@ -30,8 +30,6 @@ tasks {
     }
 }
 
-publishShadowJar()
-
 val branch = rootProject.branchName()
 val baseVersion = project.version as String
 val isRelease = !baseVersion.contains('-')

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -6,5 +6,3 @@ dependencies {
     }
     annotationProcessor(libs.velocity)
 }
-
-publishShadowJar()


### PR DESCRIPTION
There isn't really much a point to publishing either template or compat submodules to the repository server as they shouldn't be depended on anyway, I think we should also consider not publishing some of the platform impls as well, fabric/velocity, for example, can't and shouldn't be used at all. (Not sure about bukkit). I decided to come up with this because we now have platforms which are external (sponge/bungee) and changed artifacts, making it not really possible to publish them at all (At least not in the classic way with com.viaversion.viaversion-<name>).

Not sure if extensions#publishJavaComponents should be kept or not, can be removed if you want.

If we agree on something here, I'll open a PR to ViaBackwards as well and do the same for ViaRewind.