### PR TITLE
Add EntityRewriter#registerBlockStateHandler

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
@@ -260,9 +260,11 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
     protected void registerRewrites() {
         filter().mapDataType(Types1_14.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_14.ENTITY_DATA_TYPES.itemType, Types1_14.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_14.ENTITY_DATA_TYPES.particleType);
-        registerBlockStateHandler(EntityTypes1_14.ABSTRACT_MINECART, 10);
 
         filter().type(EntityTypes1_14.ENTITY).addIndex(6);
+
+        registerBlockStateHandler(EntityTypes1_14.ABSTRACT_MINECART, 10);
+
         filter().type(EntityTypes1_14.LIVING_ENTITY).addIndex(12);
 
         filter().type(EntityTypes1_14.LIVING_ENTITY).index(8).handler((event, meta) -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
@@ -260,7 +260,7 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
     protected void registerRewrites() {
         filter().mapDataType(Types1_14.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_14.ENTITY_DATA_TYPES.itemType, Types1_14.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_14.ENTITY_DATA_TYPES.particleType);
-        registerMinecartBlockStateHandler(EntityTypes1_14.ABSTRACT_MINECART, 10);
+        registerBlockStateHandler(EntityTypes1_14.ABSTRACT_MINECART, 10);
 
         filter().type(EntityTypes1_14.ENTITY).addIndex(6);
         filter().type(EntityTypes1_14.LIVING_ENTITY).addIndex(12);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
@@ -260,6 +260,7 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
     protected void registerRewrites() {
         filter().mapDataType(Types1_14.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_14.ENTITY_DATA_TYPES.itemType, Types1_14.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_14.ENTITY_DATA_TYPES.particleType);
+        registerMinecartBlockStateHandler(EntityTypes1_14.ABSTRACT_MINECART, 10);
 
         filter().type(EntityTypes1_14.ENTITY).addIndex(6);
         filter().type(EntityTypes1_14.LIVING_ENTITY).addIndex(12);
@@ -307,11 +308,6 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
             } else if (meta.id() > 16) {
                 meta.setId(meta.id() - 1);
             }
-        });
-
-        filter().type(EntityTypes1_14.ABSTRACT_MINECART).index(10).handler((event, meta) -> {
-            int data = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
         });
 
         filter().type(EntityTypes1_14.HORSE).index(18).handler((event, meta) -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13to1_13_1/rewriter/EntityPacketRewriter1_13_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13to1_13_1/rewriter/EntityPacketRewriter1_13_1.java
@@ -109,7 +109,7 @@ public class EntityPacketRewriter1_13_1 extends EntityRewriter<ClientboundPacket
     @Override
     protected void registerRewrites() {
         registerEntityDataTypeHandler(Types1_13.ENTITY_DATA_TYPES.itemType, Types1_13.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_13.ENTITY_DATA_TYPES.particleType);
-        registerMinecartBlockStateHandler(EntityTypes1_13.EntityType.ABSTRACT_MINECART, 9);
+        registerBlockStateHandler(EntityTypes1_13.EntityType.ABSTRACT_MINECART, 9);
 
         filter().type(EntityTypes1_13.EntityType.ABSTRACT_ARROW).addIndex(7); // Shooter UUID
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13to1_13_1/rewriter/EntityPacketRewriter1_13_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13to1_13_1/rewriter/EntityPacketRewriter1_13_1.java
@@ -109,10 +109,8 @@ public class EntityPacketRewriter1_13_1 extends EntityRewriter<ClientboundPacket
     @Override
     protected void registerRewrites() {
         registerEntityDataTypeHandler(Types1_13.ENTITY_DATA_TYPES.itemType, Types1_13.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_13.ENTITY_DATA_TYPES.particleType);
-        filter().type(EntityTypes1_13.EntityType.ABSTRACT_MINECART).index(9).handler((event, meta) -> {
-            int data = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
-        });
+        registerMinecartBlockStateHandler(EntityTypes1_13.EntityType.ABSTRACT_MINECART, 9);
+
         filter().type(EntityTypes1_13.EntityType.ABSTRACT_ARROW).addIndex(7); // Shooter UUID
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_14_4to1_15/rewriter/EntityPacketRewriter1_15.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_14_4to1_15/rewriter/EntityPacketRewriter1_15.java
@@ -115,10 +115,7 @@ public class EntityPacketRewriter1_15 extends EntityRewriter<ClientboundPackets1
     @Override
     protected void registerRewrites() {
         registerEntityDataTypeHandler(Types1_14.ENTITY_DATA_TYPES.itemType, Types1_14.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_14.ENTITY_DATA_TYPES.particleType);
-        filter().type(EntityTypes1_15.ABSTRACT_MINECART).index(10).handler((metadatas, meta) -> {
-            int data = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
-        });
+        registerMinecartBlockStateHandler(EntityTypes1_15.ABSTRACT_MINECART, 10);
 
         filter().type(EntityTypes1_15.LIVING_ENTITY).addIndex(12);
         filter().type(EntityTypes1_15.WOLF).removeIndex(18);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_14_4to1_15/rewriter/EntityPacketRewriter1_15.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_14_4to1_15/rewriter/EntityPacketRewriter1_15.java
@@ -115,7 +115,7 @@ public class EntityPacketRewriter1_15 extends EntityRewriter<ClientboundPackets1
     @Override
     protected void registerRewrites() {
         registerEntityDataTypeHandler(Types1_14.ENTITY_DATA_TYPES.itemType, Types1_14.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_14.ENTITY_DATA_TYPES.particleType);
-        registerMinecartBlockStateHandler(EntityTypes1_15.ABSTRACT_MINECART, 10);
+        registerBlockStateHandler(EntityTypes1_15.ABSTRACT_MINECART, 10);
 
         filter().type(EntityTypes1_15.LIVING_ENTITY).addIndex(12);
         filter().type(EntityTypes1_15.WOLF).removeIndex(18);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
@@ -208,7 +208,7 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
     protected void registerRewrites() {
         filter().mapDataType(Types1_16.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_16.ENTITY_DATA_TYPES.itemType, Types1_16.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_16.ENTITY_DATA_TYPES.particleType);
-        registerMinecartBlockStateHandler(EntityTypes1_16.ABSTRACT_MINECART, 10);
+        registerBlockStateHandler(EntityTypes1_16.ABSTRACT_MINECART, 10);
 
         filter().type(EntityTypes1_16.ABSTRACT_ARROW).removeIndex(8);
         filter().type(EntityTypes1_16.WOLF).index(16).handler((event, meta) -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
@@ -208,10 +208,8 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
     protected void registerRewrites() {
         filter().mapDataType(Types1_16.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_16.ENTITY_DATA_TYPES.itemType, Types1_16.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_16.ENTITY_DATA_TYPES.particleType);
-        filter().type(EntityTypes1_16.ABSTRACT_MINECART).index(10).handler((metadatas, meta) -> {
-            int data = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
-        });
+        registerMinecartBlockStateHandler(EntityTypes1_16.ABSTRACT_MINECART, 10);
+
         filter().type(EntityTypes1_16.ABSTRACT_ARROW).removeIndex(8);
         filter().type(EntityTypes1_16.WOLF).index(16).handler((event, meta) -> {
             byte mask = meta.value();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_1to1_16_2/rewriter/EntityPacketRewriter1_16_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_1to1_16_2/rewriter/EntityPacketRewriter1_16_2.java
@@ -78,7 +78,7 @@ public class EntityPacketRewriter1_16_2 extends EntityRewriter<ClientboundPacket
     @Override
     protected void registerRewrites() {
         registerEntityDataTypeHandler(Types1_16.ENTITY_DATA_TYPES.itemType, Types1_16.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_16.ENTITY_DATA_TYPES.particleType);
-        registerMinecartBlockStateHandler(EntityTypes1_16_2.ABSTRACT_MINECART, 10);
+        registerBlockStateHandler(EntityTypes1_16_2.ABSTRACT_MINECART, 10);
 
         filter().type(EntityTypes1_16_2.ABSTRACT_PIGLIN).handler((metadatas, meta) -> {
             if (meta.id() == 15) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_1to1_16_2/rewriter/EntityPacketRewriter1_16_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_1to1_16_2/rewriter/EntityPacketRewriter1_16_2.java
@@ -78,10 +78,8 @@ public class EntityPacketRewriter1_16_2 extends EntityRewriter<ClientboundPacket
     @Override
     protected void registerRewrites() {
         registerEntityDataTypeHandler(Types1_16.ENTITY_DATA_TYPES.itemType, Types1_16.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_16.ENTITY_DATA_TYPES.particleType);
-        filter().type(EntityTypes1_16_2.ABSTRACT_MINECART).index(10).handler((metadatas, meta) -> {
-            int data = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
-        });
+        registerMinecartBlockStateHandler(EntityTypes1_16_2.ABSTRACT_MINECART, 10);
+
         filter().type(EntityTypes1_16_2.ABSTRACT_PIGLIN).handler((metadatas, meta) -> {
             if (meta.id() == 15) {
                 meta.setId(16);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_4to1_17/rewriter/EntityPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_4to1_17/rewriter/EntityPacketRewriter1_17.java
@@ -144,10 +144,11 @@ public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPa
             }
         });
         registerEntityDataTypeHandler(Types1_17.ENTITY_DATA_TYPES.itemType, Types1_17.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_17.ENTITY_DATA_TYPES.particleType);
-        registerBlockStateHandler(EntityTypes1_17.ABSTRACT_MINECART, 11);
 
         // Ticks frozen added with id 7
         filter().type(EntityTypes1_17.ENTITY).addIndex(7);
+
+        registerBlockStateHandler(EntityTypes1_17.ABSTRACT_MINECART, 11);
 
         // Attachment position removed
         filter().type(EntityTypes1_17.SHULKER).removeIndex(17);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_4to1_17/rewriter/EntityPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_4to1_17/rewriter/EntityPacketRewriter1_17.java
@@ -144,15 +144,10 @@ public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPa
             }
         });
         registerEntityDataTypeHandler(Types1_17.ENTITY_DATA_TYPES.itemType, Types1_17.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_17.ENTITY_DATA_TYPES.particleType);
+        registerMinecartBlockStateHandler(EntityTypes1_17.ABSTRACT_MINECART);
 
         // Ticks frozen added with id 7
         filter().type(EntityTypes1_17.ENTITY).addIndex(7);
-
-        filter().type(EntityTypes1_17.ABSTRACT_MINECART).index(11).handler((event, meta) -> {
-            // Convert to new block id
-            int data = (int) meta.getValue();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
-        });
 
         // Attachment position removed
         filter().type(EntityTypes1_17.SHULKER).removeIndex(17);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_4to1_17/rewriter/EntityPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_4to1_17/rewriter/EntityPacketRewriter1_17.java
@@ -144,7 +144,7 @@ public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPa
             }
         });
         registerEntityDataTypeHandler(Types1_17.ENTITY_DATA_TYPES.itemType, Types1_17.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_17.ENTITY_DATA_TYPES.particleType);
-        registerMinecartBlockStateHandler(EntityTypes1_17.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_17.ABSTRACT_MINECART, 11);
 
         // Ticks frozen added with id 7
         filter().type(EntityTypes1_17.ENTITY).addIndex(7);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
@@ -335,12 +335,7 @@ public final class EntityPacketRewriter1_19 extends EntityRewriter<ClientboundPa
         });
 
         registerEntityDataTypeHandler(Types1_19.ENTITY_DATA_TYPES.itemType, Types1_19.ENTITY_DATA_TYPES.optionalBlockStateType, null);
-
-        filter().type(EntityTypes1_19.ABSTRACT_MINECART).index(11).handler((event, meta) -> {
-            // Convert to new block id
-            final int data = (int) meta.getValue();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
-        });
+        registerMinecartBlockStateHandler(EntityTypes1_19.ABSTRACT_MINECART);
 
         filter().type(EntityTypes1_19.CAT).index(19).mapDataType(typeId -> Types1_19.ENTITY_DATA_TYPES.catVariantType);
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
@@ -335,7 +335,7 @@ public final class EntityPacketRewriter1_19 extends EntityRewriter<ClientboundPa
         });
 
         registerEntityDataTypeHandler(Types1_19.ENTITY_DATA_TYPES.itemType, Types1_19.ENTITY_DATA_TYPES.optionalBlockStateType, null);
-        registerMinecartBlockStateHandler(EntityTypes1_19.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_19.ABSTRACT_MINECART, 11);
 
         filter().type(EntityTypes1_19.CAT).index(19).mapDataType(typeId -> Types1_19.ENTITY_DATA_TYPES.catVariantType);
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_1to1_19_3/rewriter/EntityPacketRewriter1_19_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_1to1_19_3/rewriter/EntityPacketRewriter1_19_3.java
@@ -153,6 +153,7 @@ public final class EntityPacketRewriter1_19_3 extends EntityRewriter<Clientbound
     protected void registerRewrites() {
         filter().mapDataType(typeId -> Types1_19_3.ENTITY_DATA_TYPES.byId(typeId >= 2 ? typeId + 1 : typeId)); // Long added
         registerEntityDataTypeHandler(Types1_19_3.ENTITY_DATA_TYPES.itemType, Types1_19_3.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_19_3.ENTITY_DATA_TYPES.particleType);
+        registerMinecartBlockStateHandler(EntityTypes1_19_3.ABSTRACT_MINECART);
 
         filter().type(EntityTypes1_19_3.ENTITY).index(6).handler((event, meta) -> {
             // Sitting pose added
@@ -160,11 +161,6 @@ public final class EntityPacketRewriter1_19_3 extends EntityRewriter<Clientbound
             if (pose >= 10) {
                 meta.setValue(pose + 1);
             }
-        });
-        filter().type(EntityTypes1_19_3.ABSTRACT_MINECART).index(11).handler((event, meta) -> {
-            // Convert to new block id
-            final int data = (int) meta.getValue();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
         });
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_1to1_19_3/rewriter/EntityPacketRewriter1_19_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_1to1_19_3/rewriter/EntityPacketRewriter1_19_3.java
@@ -153,7 +153,7 @@ public final class EntityPacketRewriter1_19_3 extends EntityRewriter<Clientbound
     protected void registerRewrites() {
         filter().mapDataType(typeId -> Types1_19_3.ENTITY_DATA_TYPES.byId(typeId >= 2 ? typeId + 1 : typeId)); // Long added
         registerEntityDataTypeHandler(Types1_19_3.ENTITY_DATA_TYPES.itemType, Types1_19_3.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_19_3.ENTITY_DATA_TYPES.particleType);
-        registerMinecartBlockStateHandler(EntityTypes1_19_3.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_19_3.ABSTRACT_MINECART, 11);
 
         filter().type(EntityTypes1_19_3.ENTITY).index(6).handler((event, meta) -> {
             // Sitting pose added

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/rewriter/EntityPacketRewriter1_19_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/rewriter/EntityPacketRewriter1_19_4.java
@@ -221,11 +221,7 @@ public final class EntityPacketRewriter1_19_4 extends EntityRewriter<Clientbound
     protected void registerRewrites() {
         filter().mapDataType(typeId -> Types1_19_4.ENTITY_DATA_TYPES.byId(typeId >= 14 ? typeId + 1 : typeId)); // Optional block state (and map block state=14 to optional block state)
         registerEntityDataTypeHandler(Types1_19_4.ENTITY_DATA_TYPES.itemType, Types1_19_4.ENTITY_DATA_TYPES.blockStateType, Types1_19_4.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_19_4.ENTITY_DATA_TYPES.particleType, null);
-
-        filter().type(EntityTypes1_19_4.ABSTRACT_MINECART).index(11).handler((event, meta) -> {
-            final int blockState = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(blockState));
-        });
+        registerMinecartBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART);
 
         filter().type(EntityTypes1_19_4.BOAT).index(11).handler((event, meta) -> {
             final int boatType = meta.value();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/rewriter/EntityPacketRewriter1_19_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/rewriter/EntityPacketRewriter1_19_4.java
@@ -221,7 +221,7 @@ public final class EntityPacketRewriter1_19_4 extends EntityRewriter<Clientbound
     protected void registerRewrites() {
         filter().mapDataType(typeId -> Types1_19_4.ENTITY_DATA_TYPES.byId(typeId >= 14 ? typeId + 1 : typeId)); // Optional block state (and map block state=14 to optional block state)
         registerEntityDataTypeHandler(Types1_19_4.ENTITY_DATA_TYPES.itemType, Types1_19_4.ENTITY_DATA_TYPES.blockStateType, Types1_19_4.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_19_4.ENTITY_DATA_TYPES.particleType, null);
-        registerMinecartBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART, 11);
 
         filter().type(EntityTypes1_19_4.BOAT).index(11).handler((event, meta) -> {
             final int boatType = meta.value();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_4to1_20/rewriter/EntityPacketRewriter1_20.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_4to1_20/rewriter/EntityPacketRewriter1_20.java
@@ -129,7 +129,7 @@ public final class EntityPacketRewriter1_20 extends EntityRewriter<ClientboundPa
     protected void registerRewrites() {
         filter().mapDataType(Types1_20.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_20.ENTITY_DATA_TYPES.itemType, Types1_20.ENTITY_DATA_TYPES.blockStateType, Types1_20.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_20.ENTITY_DATA_TYPES.particleType, null);
-        registerMinecartBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART, 11);
 
         // Rotate item display by 180 degrees around the Y axis
         filter().type(EntityTypes1_19_4.ITEM_DISPLAY).handler((event, meta) -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_4to1_20/rewriter/EntityPacketRewriter1_20.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_4to1_20/rewriter/EntityPacketRewriter1_20.java
@@ -129,6 +129,7 @@ public final class EntityPacketRewriter1_20 extends EntityRewriter<ClientboundPa
     protected void registerRewrites() {
         filter().mapDataType(Types1_20.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_20.ENTITY_DATA_TYPES.itemType, Types1_20.ENTITY_DATA_TYPES.blockStateType, Types1_20.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_20.ENTITY_DATA_TYPES.particleType, null);
+        registerMinecartBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART);
 
         // Rotate item display by 180 degrees around the Y axis
         filter().type(EntityTypes1_19_4.ITEM_DISPLAY).handler((event, meta) -> {
@@ -143,11 +144,6 @@ public final class EntityPacketRewriter1_20 extends EntityRewriter<ClientboundPa
         filter().type(EntityTypes1_19_4.ITEM_DISPLAY).index(12).handler((event, meta) -> {
             final Quaternion quaternion = meta.value();
             meta.setValue(rotateY180(quaternion));
-        });
-
-        filter().type(EntityTypes1_19_4.ABSTRACT_MINECART).index(11).handler((event, meta) -> {
-            final int blockState = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(blockState));
         });
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/EntityPacketRewriter1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/EntityPacketRewriter1_20_3.java
@@ -135,7 +135,7 @@ public final class EntityPacketRewriter1_20_3 extends EntityRewriter<Clientbound
             Types1_20_3.ENTITY_DATA_TYPES.optionalBlockStateType,
             Types1_20_3.ENTITY_DATA_TYPES.particleType,
             null);
-        registerMinecartBlockStateHandler(EntityTypes1_20_3.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_20_3.ABSTRACT_MINECART, 11);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/EntityPacketRewriter1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/EntityPacketRewriter1_20_3.java
@@ -135,11 +135,7 @@ public final class EntityPacketRewriter1_20_3 extends EntityRewriter<Clientbound
             Types1_20_3.ENTITY_DATA_TYPES.optionalBlockStateType,
             Types1_20_3.ENTITY_DATA_TYPES.particleType,
             null);
-
-        filter().type(EntityTypes1_20_3.ABSTRACT_MINECART).index(11).handler((event, meta) -> {
-            final int blockState = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(blockState));
-        });
+        registerMinecartBlockStateHandler(EntityTypes1_20_3.ABSTRACT_MINECART);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
@@ -413,7 +413,7 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
             Types1_20_5.ENTITY_DATA_TYPES.particleType,
             null
         );
-        registerMinecartBlockStateHandler(EntityTypes1_20_5.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_20_5.ABSTRACT_MINECART, 11);
 
         filter().dataType(Types1_20_5.ENTITY_DATA_TYPES.componentType).handler((event, meta) -> protocol.getComponentRewriter().processTag(event.user(), meta.value()));
         filter().dataType(Types1_20_5.ENTITY_DATA_TYPES.optionalComponentType).handler((event, meta) -> protocol.getComponentRewriter().processTag(event.user(), meta.value()));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
@@ -413,6 +413,8 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
             Types1_20_5.ENTITY_DATA_TYPES.particleType,
             null
         );
+        registerMinecartBlockStateHandler(EntityTypes1_20_5.ABSTRACT_MINECART);
+
         filter().dataType(Types1_20_5.ENTITY_DATA_TYPES.componentType).handler((event, meta) -> protocol.getComponentRewriter().processTag(event.user(), meta.value()));
         filter().dataType(Types1_20_5.ENTITY_DATA_TYPES.optionalComponentType).handler((event, meta) -> protocol.getComponentRewriter().processTag(event.user(), meta.value()));
 
@@ -478,11 +480,6 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
             if (color != -1) {
                 meta.setValue(withAlpha(color));
             }
-        });
-
-        filter().type(EntityTypes1_20_5.ABSTRACT_MINECART).index(11).handler((event, meta) -> {
-            final int blockState = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(blockState));
         });
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/rewriter/EntityPacketRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/rewriter/EntityPacketRewriter1_20_2.java
@@ -174,7 +174,7 @@ public final class EntityPacketRewriter1_20_2 extends EntityRewriter<Clientbound
     protected void registerRewrites() {
         filter().mapDataType(Types1_20_2.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_20_2.ENTITY_DATA_TYPES.itemType, Types1_20_2.ENTITY_DATA_TYPES.blockStateType, Types1_20_2.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_20_2.ENTITY_DATA_TYPES.particleType, null);
-        registerMinecartBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART, 11);
 
         filter().type(EntityTypes1_19_4.DISPLAY).addIndex(10);
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/rewriter/EntityPacketRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/rewriter/EntityPacketRewriter1_20_2.java
@@ -174,13 +174,9 @@ public final class EntityPacketRewriter1_20_2 extends EntityRewriter<Clientbound
     protected void registerRewrites() {
         filter().mapDataType(Types1_20_2.ENTITY_DATA_TYPES::byId);
         registerEntityDataTypeHandler(Types1_20_2.ENTITY_DATA_TYPES.itemType, Types1_20_2.ENTITY_DATA_TYPES.blockStateType, Types1_20_2.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_20_2.ENTITY_DATA_TYPES.particleType, null);
+        registerMinecartBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART);
 
         filter().type(EntityTypes1_19_4.DISPLAY).addIndex(10);
-
-        filter().type(EntityTypes1_19_4.ABSTRACT_MINECART).index(11).handler((event, meta) -> {
-            final int blockState = meta.value();
-            meta.setValue(protocol.getMappingData().getNewBlockStateId(blockState));
-        });
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -223,6 +223,17 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
         });
     }
 
+    public void registerMinecartBlockStateHandler(final EntityType entityType) {
+        registerMinecartBlockStateHandler(entityType, 11);
+    }
+
+    public void registerMinecartBlockStateHandler(final EntityType entityType, final int index) {
+        filter().type(entityType).index(index).handler((event, meta) -> {
+            final int data = (int) meta.getValue();
+            meta.setValue(protocol.getMappingData().getNewBlockStateId(data));
+        });
+    }
+
     public void registerTracker(C packetType) {
         protocol.registerClientbound(packetType, new PacketHandlers() {
             @Override

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -223,11 +223,7 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
         });
     }
 
-    public void registerMinecartBlockStateHandler(final EntityType entityType) {
-        registerMinecartBlockStateHandler(entityType, 11);
-    }
-
-    public void registerMinecartBlockStateHandler(final EntityType entityType, final int index) {
+    public void registerBlockStateHandler(final EntityType entityType, final int index) {
         filter().type(entityType).index(index).handler((event, meta) -> {
             final int data = (int) meta.getValue();
             meta.setValue(protocol.getMappingData().getNewBlockStateId(data));

--- a/template/src/main/java/com/viaversion/viaversion/template/protocols/rewriter/EntityPacketRewriter1_99.java
+++ b/template/src/main/java/com/viaversion/viaversion/template/protocols/rewriter/EntityPacketRewriter1_99.java
@@ -102,7 +102,7 @@ public final class EntityPacketRewriter1_99 extends EntityRewriter<ClientboundPa
             Types1_20_5.ENTITY_DATA_TYPES.particlesType
         );
         // Minecarts are special
-        registerMinecartBlockStateHandler(EntityTypes1_20_5.ABSTRACT_MINECART);
+        registerBlockStateHandler(EntityTypes1_20_5.ABSTRACT_MINECART, 11);
     }
 
     @Override

--- a/template/src/main/java/com/viaversion/viaversion/template/protocols/rewriter/EntityPacketRewriter1_99.java
+++ b/template/src/main/java/com/viaversion/viaversion/template/protocols/rewriter/EntityPacketRewriter1_99.java
@@ -101,12 +101,8 @@ public final class EntityPacketRewriter1_99 extends EntityRewriter<ClientboundPa
             Types1_20_5.ENTITY_DATA_TYPES.particleType,
             Types1_20_5.ENTITY_DATA_TYPES.particlesType
         );
-
         // Minecarts are special
-        filter().type(EntityTypes1_20_5.ABSTRACT_MINECART).index(11).handler((event, data) -> {
-            final int blockState = data.value();
-            data.setValue(protocol.getMappingData().getNewBlockStateId(blockState));
-        });
+        registerMinecartBlockStateHandler(EntityTypes1_20_5.ABSTRACT_MINECART);
     }
 
     @Override


### PR DESCRIPTION
Deduplicates some common code by moving out minecart block state rewriting into an own handler like other common metadata rewriters