### PR TITLE
Add missing conditions to 1.20.5 item type writing

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/item/ItemType1_20_5.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/item/ItemType1_20_5.java
@@ -82,7 +82,7 @@ public class ItemType1_20_5 extends Type<Item> {
 
     @Override
     public void write(final ByteBuf buffer, @Nullable final Item object) {
-        if (object == null) {
+        if (object == null || object.identifier() == 0 || object.amount() <= 0) {
             Types.VAR_INT.writePrimitive(buffer, 0);
             return;
         }


### PR DESCRIPTION
Minecraft's 1.20.5 item write code checks if the item is empty (item-type == null or air, count <= 0), so we also have to do this to not send broken items to the client. 

Closes https://github.com/ViaVersion/ViaVersion/issues/3881

1.20.5 logic:
<img width="434" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/757d95f1-2d96-4c4c-809b-27e2d39d25c8">
<img width="464" alt="image" src="https://github.com/ViaVersion/ViaVersion/assets/60033407/0e5dfd04-5512-451a-a549-f898218e0b0b">
