### PR TITLE
Handle negative items correctly in 1.10->1.11

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/data/EntityMappings1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/data/EntityMappings1_11.java
@@ -144,7 +144,6 @@ public class EntityMappings1_11 {
         if (hasEntityTag(item)) {
             toClient(item.tag().getCompoundTag("EntityTag"), backwards);
         }
-        if (item != null && item.amount() <= 0) item.setAmount(1);
     }
 
     public static void toServerItem(Item item) {


### PR DESCRIPTION
Moves out handling to the actual item rewriter to prevent the code being executed in ViaBackwards, also adding the missing toServer logic.