### PR TITLE
Add missing item types to item rewriter implementations

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_11to1_11_1/rewriter/ItemPacketRewriter1_11_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_11to1_11_1/rewriter/ItemPacketRewriter1_11_1.java
@@ -28,7 +28,7 @@ import com.viaversion.viaversion.rewriter.ItemRewriter;
 public class ItemPacketRewriter1_11_1 extends ItemRewriter<ClientboundPackets1_9_3, ServerboundPackets1_9_3, Protocol1_11To1_11_1> {
 
     public ItemPacketRewriter1_11_1(Protocol1_11To1_11_1 protocol) {
-        super(protocol, Types.ITEM1_8, null);
+        super(protocol, Types.ITEM1_8, Types.ITEM1_8_SHORT_ARRAY);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/ItemPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/ItemPacketRewriter1_13.java
@@ -51,7 +51,7 @@ import java.util.Optional;
 public class ItemPacketRewriter1_13 extends ItemRewriter<ClientboundPackets1_12_1, ServerboundPackets1_13, Protocol1_12_2To1_13> {
 
     public ItemPacketRewriter1_13(Protocol1_12_2To1_13 protocol) {
-        super(protocol, Types.ITEM1_8, null, Types.ITEM1_13, null);
+        super(protocol, Types.ITEM1_8, Types.ITEM1_8_SHORT_ARRAY, Types.ITEM1_13, Types.ITEM1_13_SHORT_ARRAY);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
@@ -43,7 +43,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, ServerboundPackets1_9, Protocol1_8To1_9> {
 
     public ItemPacketRewriter1_9(final Protocol1_8To1_9 protocol) {
-        super(protocol, Types.ITEM1_8, null);
+        super(protocol, Types.ITEM1_8, Types.ITEM1_8_SHORT_ARRAY);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_9_3to1_10/rewriter/ItemPacketRewriter1_10.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_9_3to1_10/rewriter/ItemPacketRewriter1_10.java
@@ -28,7 +28,7 @@ import com.viaversion.viaversion.rewriter.ItemRewriter;
 public class ItemPacketRewriter1_10 extends ItemRewriter<ClientboundPackets1_9_3, ServerboundPackets1_9_3, Protocol1_9_3To1_10> {
 
     public ItemPacketRewriter1_10(Protocol1_9_3To1_10 protocol) {
-        super(protocol, Types.ITEM1_8, null);
+        super(protocol, Types.ITEM1_8, Types.ITEM1_8_SHORT_ARRAY);
     }
 
     @Override


### PR DESCRIPTION
Makes the API more consistent since those types are exposed via the api module and the ItemRewriter interface.