### PR TITLE
Add method to remove sub commands from command handler

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/command/ViaVersionCommand.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/command/ViaVersionCommand.java
@@ -35,11 +35,11 @@ public interface ViaVersionCommand {
     void registerSubCommand(ViaSubCommand command);
 
     /**
-     * Removes a subcommand by class, can be used to unload default subcommands which are not supported
+     * Removes a subcommand by name, can be used to unload default subcommands which are not supported
      * on the platform.
-     * @param commandClass Subcommand class
+     * @param name Subcommand name
      */
-    void removeSubCommand(Class<? extends ViaSubCommand> commandClass);
+    void removeSubCommand(String name);
 
     /**
      * Check if a subcommand is registered.

--- a/api/src/main/java/com/viaversion/viaversion/api/command/ViaVersionCommand.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/command/ViaVersionCommand.java
@@ -35,6 +35,13 @@ public interface ViaVersionCommand {
     void registerSubCommand(ViaSubCommand command);
 
     /**
+     * Removes a subcommand by class, can be used to unload default subcommands which are not supported
+     * on the platform.
+     * @param commandClass Subcommand class
+     */
+    void removeSubCommand(Class<? extends ViaSubCommand> commandClass);
+
+    /**
      * Check if a subcommand is registered.
      *
      * @param name Subcommand name

--- a/common/src/main/java/com/viaversion/viaversion/commands/ViaCommandHandler.java
+++ b/common/src/main/java/com/viaversion/viaversion/commands/ViaCommandHandler.java
@@ -58,6 +58,11 @@ public abstract class ViaCommandHandler implements ViaVersionCommand {
     }
 
     @Override
+    public void removeSubCommand(final Class<? extends ViaSubCommand> commandClass) {
+        commandMap.values().removeIf(commandClass::isInstance);
+    }
+
+    @Override
     public boolean hasSubCommand(String name) {
         return commandMap.containsKey(name.toLowerCase(Locale.ROOT));
     }

--- a/common/src/main/java/com/viaversion/viaversion/commands/ViaCommandHandler.java
+++ b/common/src/main/java/com/viaversion/viaversion/commands/ViaCommandHandler.java
@@ -58,8 +58,8 @@ public abstract class ViaCommandHandler implements ViaVersionCommand {
     }
 
     @Override
-    public void removeSubCommand(final Class<? extends ViaSubCommand> commandClass) {
-        commandMap.values().removeIf(commandClass::isInstance);
+    public void removeSubCommand(final String name) {
+        commandMap.remove(name.toLowerCase(Locale.ROOT));
     }
 
     @Override


### PR DESCRIPTION
Adds API so ViaLoader and ViaFabricPlus can properly unload sub commands which are not supported or working.