### PR TITLE
Backup original book pages for creative mode clients in 1.8->1.9

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -1075,13 +1075,13 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
         data.set(StructuredDataKey.SUSPICIOUS_STEW_EFFECTS, suspiciousStewEffects);
     }
 
-    private void updateLodestoneTracker(final boolean tracked, final CompoundTag lodestonePosTag, final String lodestoneDimensionTag, final StructuredDataContainer data) {
+    private void updateLodestoneTracker(final boolean tracked, final CompoundTag lodestonePosTag, final String lodestoneDimension, final StructuredDataContainer data) {
         GlobalBlockPosition position = null;
-        if (lodestonePosTag != null && lodestoneDimensionTag != null) {
+        if (lodestonePosTag != null && lodestoneDimension != null) {
             final int x = lodestonePosTag.getInt("X");
             final int y = lodestonePosTag.getInt("Y");
             final int z = lodestonePosTag.getInt("Z");
-            position = new GlobalBlockPosition(lodestoneDimensionTag, x, y, z);
+            position = new GlobalBlockPosition(lodestoneDimension, x, y, z);
         }
         data.set(StructuredDataKey.LODESTONE_TRACKER, new LodestoneTracker(position, tracked));
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
@@ -486,10 +486,13 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
         if (item.identifier() == 387) { // WRITTEN_BOOK
             CompoundTag tag = item.tag();
             if (tag != null) {
-                ListTag<StringTag> pages = tag.getListTag(nbtTagName("pages"), StringTag.class);
-                if (pages != null && !pages.isEmpty()) {
-                    tag.put("pages", pages);
-                    tag.remove(nbtTagName("pages"));
+                ListTag<StringTag> pages = tag.removeUnchecked(nbtTagName("pages"));
+                if (pages != null) {
+                    if (!pages.isEmpty()) {
+                        tag.put("pages", pages);
+                    } else {
+                        tag.remove("pages");
+                    }
                     if (tag.isEmpty()) {
                         item.setTag(null);
                     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
@@ -486,15 +486,23 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
         if (item.identifier() == 387) { // WRITTEN_BOOK
             CompoundTag tag = item.tag();
             if (tag != null) {
-                ListTag<StringTag> pages = tag.removeUnchecked(nbtTagName("pages"));
-                if (pages != null) {
-                    if (!pages.isEmpty()) {
-                        tag.put("pages", pages);
+                // Prefer saved pages since they are more likely to be accurate
+                ListTag<StringTag> backup = tag.removeUnchecked(nbtTagName("pages"));
+                if (backup != null) {
+                    if (!backup.isEmpty()) {
+                        tag.put("pages", backup);
                     } else {
                         tag.remove("pages");
+                        if (tag.isEmpty()) {
+                            item.setTag(null);
+                        }
                     }
-                    if (tag.isEmpty()) {
-                        item.setTag(null);
+                } else {
+                    // Fallback to normal pages tag
+                    ListTag<StringTag> pages = tag.getListTag("pages", StringTag.class);
+                    for (int i = 0; i < pages.size(); i++) {
+                        final StringTag page = pages.get(i);
+                        page.setValue(ComponentUtil.convertJsonOrEmpty(page.getValue(), SerializerVersion.V1_9, SerializerVersion.V1_8).toString());
                     }
                 }
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
@@ -418,6 +418,8 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
             }
 
             ListTag<StringTag> pages = tag.getListTag("pages", StringTag.class);
+            tag.put(nbtTagName("pages"), pages == null ? new ListTag<>(StringTag.class) : pages);
+
             if (pages == null) {
                 pages = new ListTag<>(Collections.singletonList(new StringTag(ComponentUtil.emptyJsonComponent().toString())));
                 tag.put("pages", pages);
@@ -480,6 +482,19 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
             }
             item.setTag(tag);
             item.setData((short) data);
+        }
+        if (item.identifier() == 387) { // WRITTEN_BOOK
+            CompoundTag tag = item.tag();
+            if (tag != null) {
+                ListTag<StringTag> pages = tag.getListTag(nbtTagName("pages"), StringTag.class);
+                if (pages != null && !pages.isEmpty()) {
+                    tag.put("pages", pages);
+                    tag.remove(nbtTagName("pages"));
+                    if (tag.isEmpty()) {
+                        item.setTag(null);
+                    }
+                }
+            }
         }
 
         boolean newItem = item.identifier() >= 198 && item.identifier() <= 212;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
@@ -418,7 +418,7 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
             }
 
             ListTag<StringTag> pages = tag.getListTag("pages", StringTag.class);
-            tag.put(nbtTagName("pages"), pages == null ? new ListTag<>(StringTag.class) : pages);
+            tag.put(nbtTagName("pages"), pages == null ? new ListTag<>(StringTag.class) : pages.copy());
 
             if (pages == null) {
                 pages = new ListTag<>(Collections.singletonList(new StringTag(ComponentUtil.emptyJsonComponent().toString())));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
@@ -500,9 +500,11 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
                 } else {
                     // Fallback to normal pages tag
                     ListTag<StringTag> pages = tag.getListTag("pages", StringTag.class);
-                    for (int i = 0; i < pages.size(); i++) {
-                        final StringTag page = pages.get(i);
-                        page.setValue(ComponentUtil.convertJsonOrEmpty(page.getValue(), SerializerVersion.V1_9, SerializerVersion.V1_8).toString());
+                    if (pages != null) {
+                        for (int i = 0; i < pages.size(); i++) {
+                            final StringTag page = pages.get(i);
+                            page.setValue(ComponentUtil.convertJsonOrEmpty(page.getValue(), SerializerVersion.V1_9, SerializerVersion.V1_8).toString());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Can be tested by giving a written_book using give which will show "Invalid book tag" when openend, after getting in creative mode those line will disappear because VV puts a dummy pages tage inside the book, this PR fixes it.