### PR TITLE
Add handleMenuType function to ItemRewriter

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
@@ -112,12 +112,12 @@ public class ItemRewriter<C extends ClientboundPacketType, S extends Serverbound
             @Override
             public void register() {
                 map(Types.VAR_INT); // Container id
-                handler(wrapper -> handleWindowType(wrapper));
+                handler(wrapper -> handleMenuType(wrapper));
             }
         });
     }
 
-    public void handleWindowType(final PacketWrapper wrapper) {
+    public void handleMenuType(final PacketWrapper wrapper) {
         final int windowType = wrapper.read(Types.VAR_INT);
         final int mappedId = protocol.getMappingData().getMenuMappings().getNewId(windowType);
         if (mappedId == -1) {

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
@@ -112,18 +112,20 @@ public class ItemRewriter<C extends ClientboundPacketType, S extends Serverbound
             @Override
             public void register() {
                 map(Types.VAR_INT); // Container id
-                handler(wrapper -> {
-                    final int windowType = wrapper.read(Types.VAR_INT);
-                    final int mappedId = protocol.getMappingData().getMenuMappings().getNewId(windowType);
-                    if (mappedId == -1) {
-                        wrapper.cancel();
-                        return;
-                    }
-
-                    wrapper.write(Types.VAR_INT, mappedId);
-                });
+                handler(wrapper -> handleWindowType(wrapper));
             }
         });
+    }
+
+    public void handleWindowType(final PacketWrapper wrapper) {
+        final int windowType = wrapper.read(Types.VAR_INT);
+        final int mappedId = protocol.getMappingData().getMenuMappings().getNewId(windowType);
+        if (mappedId == -1) {
+            wrapper.cancel();
+            return;
+        }
+
+        wrapper.write(Types.VAR_INT, mappedId);
     }
 
     public void registerSetSlot(C packetType) {


### PR DESCRIPTION
Allows VB (and other protocols in the future) to rewrite both window title and type at the same time.