### PR TITLE
Return generic Item array in StructuredItem#emptyArray

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/StructuredItem.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/StructuredItem.java
@@ -46,8 +46,8 @@ public class StructuredItem implements Item {
         return new StructuredItem(0, 0);
     }
 
-    public static StructuredItem[] emptyArray(final int size) {
-        final StructuredItem[] items = new StructuredItem[size];
+    public static Item[] emptyArray(final int size) {
+        final Item[] items = new Item[size];
         for (int i = 0; i < items.length; i++) {
             items[i] = empty();
         }


### PR DESCRIPTION
Returns a generic Item[] instead of a StructuredItem[] in order to avoid issues when the array content is converted to DataItem's