### PR TITLE
[ci skip] Advertise ViaLoader in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ dependencies {
 If you need access to the existing protocol or platform implementations, use the parent artifact `viaversion`.
 Please note the [differences in licensing](#license).
 
+Note: If you want to make your own platform implementation of ViaVersion (and additional addons),
+you can use the [ViaLoader](https://github.com/ViaVersion/ViaLoader) project.
 
 Building
 --------


### PR DESCRIPTION
We sometimes had people asking in the discord for this, and since ViaLoader covers most use cases for an own platform implementation, it would make sense to advertise it below the API section.