### PR TITLE
Rework unsupported config options in AbstractViaConfig

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaConfig.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaConfig.java
@@ -19,13 +19,11 @@ package com.viaversion.viaversion.bukkit.platform;
 
 import com.viaversion.viaversion.configuration.AbstractViaConfig;
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
 public class BukkitViaConfig extends AbstractViaConfig {
-    private static final List<String> UNSUPPORTED = Arrays.asList("velocity-ping-interval", "velocity-ping-save", "velocity-servers");
     private boolean quickMoveActionFix;
     private boolean hitboxFix1_9;
     private boolean hitboxFix1_14;
@@ -84,6 +82,6 @@ public class BukkitViaConfig extends AbstractViaConfig {
 
     @Override
     public List<String> getUnsupportedOptions() {
-        return UNSUPPORTED;
+        return VELOCITY_ONLY_OPTIONS;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -26,6 +26,7 @@ import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.protocol.BlockedProtocolVersionsImpl;
 import com.viaversion.viaversion.util.Config;
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,11 @@ import it.unimi.dsi.fastutil.objects.ObjectSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract class AbstractViaConfig extends Config implements ViaVersionConfig {
+    public static final List<String> BUKKIT_ONLY_OPTIONS = Arrays.asList("register-userconnections-on-join", "quick-move-action-fix",
+        "change-1_9-hitbox", "change-1_14-hitbox", "blockconnection-method", "armor-toggle-fix", "use-new-deathmessages",
+        "item-cache", "nms-player-ticking");
+
+    public static final List<String> VELOCITY_ONLY_OPTIONS = Arrays.asList("velocity-ping-interval", "velocity-ping-save", "velocity-servers");
 
     private boolean checkForUpdates;
     private boolean preventCollision;

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaConfig.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaConfig.java
@@ -20,7 +20,6 @@ package com.viaversion.viaversion.velocity.platform;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.configuration.AbstractViaConfig;
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,7 +27,6 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 public class VelocityViaConfig extends AbstractViaConfig {
-    private static final List<String> UNSUPPORTED = Arrays.asList("nms-player-ticking", "item-cache", "quick-move-action-fix", "blockconnection-method", "change-1_9-hitbox", "change-1_14-hitbox");
     private int velocityPingInterval;
     private boolean velocityPingSave;
     private Map<String, Integer> velocityServerProtocols;
@@ -85,7 +83,7 @@ public class VelocityViaConfig extends AbstractViaConfig {
 
     @Override
     public List<String> getUnsupportedOptions() {
-        return UNSUPPORTED;
+        return BUKKIT_ONLY_OPTIONS;
     }
 
     @Override


### PR DESCRIPTION
Adds globalized lists for unsupported options, so we don't have to update every platform once we add/change settings.