### PR TITLE
Update legacy Minecraft version warning

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
@@ -150,7 +150,7 @@ public class ViaManagerImpl implements ViaManager {
                 platform.getLogger().warning("and if you're still unsure, feel free to join our Discord-Server for further assistance.");
             } else if (protocolVersion.highestSupportedProtocolVersion().olderThan(ProtocolVersion.v1_13)) {
                 platform.getLogger().warning("This version of Minecraft is extremely outdated and support for it has reached its end of life. "
-                    + "You will still be able to run Via on this Minecraft version, but we are unlikely to provide any further fixes or help with problems specific to legacy Minecraft versions. "
+                    + "You will still be able to run Via on this Minecraft version, but we will prioritize issues with legacy Minecraft versions lower. "
                     + "Please consider updating to give your players a better experience and to avoid issues that have long been fixed.");
             }
         }

--- a/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
@@ -150,7 +150,7 @@ public class ViaManagerImpl implements ViaManager {
                 platform.getLogger().warning("and if you're still unsure, feel free to join our Discord-Server for further assistance.");
             } else if (protocolVersion.highestSupportedProtocolVersion().olderThan(ProtocolVersion.v1_13)) {
                 platform.getLogger().warning("This version of Minecraft is extremely outdated and support for it has reached its end of life. "
-                    + "You will still be able to run Via on this Minecraft version, but we will prioritize issues with legacy Minecraft versions lower. "
+                    + "You will still be able to run Via on this Minecraft version, but we will prioritize issues with legacy Minecraft versions less. "
                     + "Please consider updating to give your players a better experience and to avoid issues that have long been fixed.");
             }
         }


### PR DESCRIPTION
RK and I have opened several pull requests in the last months and took care of legacy versions, while we should still mark them as legacy issues on GH, I don't want to scare people from reporting them since I still maintain legacy protocols and fix issues.

My pull requests:
https://github.com/ViaVersion/ViaVersion/pull/3981 
https://github.com/ViaVersion/ViaVersion/pull/3952 
https://github.com/ViaVersion/ViaVersion/pull/3947 
https://github.com/ViaVersion/ViaVersion/pull/3939
https://github.com/ViaVersion/ViaVersion/pull/3921 
https://github.com/ViaVersion/ViaVersion/pull/3920 
https://github.com/ViaVersion/ViaVersion/pull/3886 
https://github.com/ViaVersion/ViaVersion/pull/3868 
https://github.com/ViaVersion/ViaVersion/pull/3834 
https://github.com/ViaVersion/ViaVersion/pull/3821 
https://github.com/ViaVersion/ViaVersion/pull/3841
https://github.com/ViaVersion/ViaVersion/pull/3842 
https://github.com/ViaVersion/ViaVersion/pull/3801 
https://github.com/ViaVersion/ViaVersion/pull/3794 
https://github.com/ViaVersion/ViaVersion/pull/3791 
https://github.com/ViaVersion/ViaVersion/pull/3790 
https://github.com/ViaVersion/ViaVersion/pull/3775 
https://github.com/ViaVersion/ViaVersion/pull/3774

RK's pull requests:
https://github.com/ViaVersion/ViaVersion/pull/3859 
https://github.com/ViaVersion/ViaVersion/pull/3781

Note that those are only newer ones since we are part of the team.