### PR TITLE
Only print broken json in component type when debug mode is enabled

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/ComponentType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/ComponentType.java
@@ -44,7 +44,9 @@ public class ComponentType extends Type<JsonElement> {
         try {
             return JsonParser.parseString(s);
         } catch (JsonSyntaxException e) {
-            Via.getPlatform().getLogger().severe("Error when trying to parse json: " + s);
+            if (Via.getManager().isDebug()) {
+                Via.getPlatform().getLogger().severe("Error when trying to parse json: " + s);
+            }
             throw e;
         }
     }


### PR DESCRIPTION
Matches the ComponentRewriter, we mostly can't do anything with the json anyway.