### PR TITLE
Fix entity type defaults and handling of unknown entity types

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_10.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_10.java
@@ -38,7 +38,6 @@ public class EntityTypes1_10 {
         }
         if (type == null) {
             Via.getPlatform().getLogger().severe("Could not find 1.10 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_11.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_11.java
@@ -38,7 +38,6 @@ public class EntityTypes1_11 {
         }
         if (type == null) {
             Via.getPlatform().getLogger().severe("Could not find 1.11 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_12.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_12.java
@@ -38,7 +38,6 @@ public class EntityTypes1_12 {
         }
         if (type == null) {
             Via.getPlatform().getLogger().severe("Could not find 1.12 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_13.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_13.java
@@ -38,7 +38,6 @@ public class EntityTypes1_13 {
         }
         if (type == null) {
             Via.getPlatform().getLogger().severe("Could not find 1.13 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_14.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_14.java
@@ -245,7 +245,7 @@ public enum EntityTypes1_14 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_15.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_15.java
@@ -246,7 +246,7 @@ public enum EntityTypes1_15 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_16.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_16.java
@@ -250,7 +250,7 @@ public enum EntityTypes1_16 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_16_2.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_16_2.java
@@ -253,7 +253,7 @@ public enum EntityTypes1_16_2 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_17.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_17.java
@@ -259,7 +259,7 @@ public enum EntityTypes1_17 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19.java
@@ -264,7 +264,7 @@ public enum EntityTypes1_19 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19_3.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19_3.java
@@ -265,7 +265,7 @@ public enum EntityTypes1_19_3 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19_4.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19_4.java
@@ -272,7 +272,7 @@ public enum EntityTypes1_19_4 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_20_3.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_20_3.java
@@ -274,7 +274,7 @@ public enum EntityTypes1_20_3 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_20_5.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_20_5.java
@@ -280,7 +280,7 @@ public enum EntityTypes1_20_5 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, null);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_8.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_8.java
@@ -38,7 +38,6 @@ public class EntityTypes1_8 {
         }
         if (type == null) {
             Via.getPlatform().getLogger().severe("Could not find 1.8 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_9.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_9.java
@@ -38,7 +38,6 @@ public class EntityTypes1_9 {
         }
         if (type == null) {
             Via.getPlatform().getLogger().severe("Could not find 1.9 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
@@ -82,6 +82,8 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
                     int typeId = wrapper.get(Types.VAR_INT, 1);
 
                     EntityTypes1_13.EntityType type1_13 = EntityTypes1_13.getTypeFromId(typeId, true);
+                    if (type1_13 == null) return;
+
                     typeId = newEntityId(type1_13.getId());
                     EntityType type1_14 = EntityTypes1_14.getTypeFromId(typeId);
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/SpawnPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/SpawnPacketRewriter1_9.java
@@ -18,6 +18,7 @@
 package com.viaversion.viaversion.protocols.v1_8to1_9.rewriter;
 
 import com.viaversion.viaversion.api.data.entity.EntityTracker;
+import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_8;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_9;
 import com.viaversion.viaversion.api.minecraft.item.DataItem;
@@ -63,7 +64,10 @@ public class SpawnPacketRewriter1_9 {
                     int entityID = wrapper.get(Types.VAR_INT, 0);
                     int typeID = wrapper.get(Types.BYTE, 0);
                     EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
-                    tracker.addEntity(entityID, EntityTypes1_9.getTypeFromId(typeID, true));
+                    EntityType entityType = EntityTypes1_9.getTypeFromId(typeID, true);
+                    if (entityType != null) {
+                        tracker.addEntity(entityID, entityType);
+                    }
                 });
 
                 map(Types.INT, toNewDouble); // 3 - X - Needs to be divided by 32
@@ -176,7 +180,10 @@ public class SpawnPacketRewriter1_9 {
                     int entityID = wrapper.get(Types.VAR_INT, 0);
                     int typeID = wrapper.get(Types.UNSIGNED_BYTE, 0);
                     EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
-                    tracker.addEntity(entityID, EntityTypes1_9.getTypeFromId(typeID, false));
+                    EntityType type = EntityTypes1_9.getTypeFromId(typeID, false);
+                    if (type != null) {
+                        tracker.addEntity(entityID, type);
+                    }
                 });
 
                 map(Types.INT, toNewDouble); // 3 - X - Needs to be divided by 32

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -557,6 +557,9 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
             }
 
             EntityType entType = typeFromId(trackMappedType ? newType : type);
+            if (entType == null) {
+                return;
+            }
             // Register Type ID
             tracker(wrapper.user()).addEntity(entityId, entType);
 

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -589,6 +589,9 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
             byte type = wrapper.get(Types.BYTE, 0);
 
             EntityType entType = objectTypeFromId(type);
+            if (entType == null) {
+                return;
+            }
             // Register Type ID
             tracker(wrapper.user()).addEntity(entityId, entType);
         };


### PR DESCRIPTION
- Legacy versions (<=1.13) are skipping entities with invalid types silently.
- Versions 1.14-1.20.4 are defaulting to PIG when the entity type is unknown.