### PR TITLE
Only rewrite entity data if entity is present

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -373,6 +373,10 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
                 }
                 handler(wrapper -> {
                     int entityId = wrapper.get(Types.VAR_INT, 0);
+                    if (!tracker(wrapper.user()).hasEntity(entityId)) {
+                        wrapper.cancel();
+                        return;
+                    }
                     List<EntityData> entityData = wrapper.get(mappedDataType, 0);
                     handleEntityData(entityId, entityData, wrapper.user());
                 });


### PR DESCRIPTION
Minecraft 1.8-1.21 checks if the entity exists when handling the entity data packet, this causes Via to rewrite entity data for non-existing entities where the entity type is null.

Proper fix for https://github.com/ViaVersion/ViaRewind/issues/527