### PR TITLE
Change Attack Speed for 1.8 -> 1.9

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
@@ -303,7 +303,7 @@ public class EntityPacketRewriter1_9 extends EntityRewriter<ClientboundPackets1_
                         properties.put(key, new Pair<>(value, modifiers));
                     }
                     
-                    properties.put("generic.attackSpeed", new Pair<>(23, ImmutableList.of( // Neutralize modifiers
+                    properties.put("generic.attackSpeed", new Pair<>(23.0, ImmutableList.of( // Neutralize modifiers
                         new Triple<>(UUID.fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3"), 0.0, (byte) 0), // Tool and weapon modifier
                         new Triple<>(UUID.fromString("AF8B6E3F-3328-4C0A-AA36-5BA2BB9DBEF3"), 0.0, (byte) 2), // Dig speed
                         new Triple<>(UUID.fromString("55FCED67-E92A-486E-9800-B47F202C4386"), 0.0, (byte) 2) // Dig slow down

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
@@ -303,7 +303,7 @@ public class EntityPacketRewriter1_9 extends EntityRewriter<ClientboundPackets1_
                         properties.put(key, new Pair<>(value, modifiers));
                     }
                     
-                    properties.put("generic.attackSpeed", new Pair<>(23.0, ImmutableList.of( // Neutralize modifiers
+                    properties.put("generic.attackSpeed", new Pair<>(20.0, ImmutableList.of( // Neutralize modifiers
                         new Triple<>(UUID.fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3"), 0.0, (byte) 0), // Tool and weapon modifier
                         new Triple<>(UUID.fromString("AF8B6E3F-3328-4C0A-AA36-5BA2BB9DBEF3"), 0.0, (byte) 2), // Dig speed
                         new Triple<>(UUID.fromString("55FCED67-E92A-486E-9800-B47F202C4386"), 0.0, (byte) 2) // Dig slow down

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
@@ -302,11 +302,8 @@ public class EntityPacketRewriter1_9 extends EntityRewriter<ClientboundPackets1_
                         }
                         properties.put(key, new Pair<>(value, modifiers));
                     }
-
-                    // == Why 15.9? ==
-                    // Higher values hides the cooldown but it bugs visual animation on hand
-                    // when removing item from hand with inventory gui
-                    properties.put("generic.attackSpeed", new Pair<>(15.9, ImmutableList.of( // Neutralize modifiers
+                    
+                    properties.put("generic.attackSpeed", new Pair<>(23, ImmutableList.of( // Neutralize modifiers
                         new Triple<>(UUID.fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3"), 0.0, (byte) 0), // Tool and weapon modifier
                         new Triple<>(UUID.fromString("AF8B6E3F-3328-4C0A-AA36-5BA2BB9DBEF3"), 0.0, (byte) 2), // Dig speed
                         new Triple<>(UUID.fromString("55FCED67-E92A-486E-9800-B47F202C4386"), 0.0, (byte) 2) // Dig slow down


### PR DESCRIPTION
The previous attack speed value would still show a slight cooldown, the new value removes the cooldown entirely.

The bug that was mentioned in the comment above the code doesn't seem to happen in modern version (1.21) from testing.
I wasn't able to reproduce the bug in 1.9 also.

The reason the value is 23 is because I tested ingame using a sword until the cooldown dissapeared.