### PR TITLE
Rename missing metadata references to entity data

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -67,9 +67,9 @@ public interface ViaVersionConfig extends Config {
     boolean isShowNewDeathMessages();
 
     /**
-     * Get if metadata errors will be suppressed
+     * Get if entity data errors will be suppressed
      *
-     * @return true if metadata errors suppression is enabled
+     * @return true if entity data errors suppression is enabled
      */
     boolean isSuppressMetadataErrors();
 

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_8.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_8.java
@@ -93,7 +93,7 @@ public class EntityTypes1_8 {
 
         LIVING_ENTITY_BASE(ENTITY),
         ARMOR_STAND(30, LIVING_ENTITY_BASE),
-        PLAYER(LIVING_ENTITY_BASE), // Needed for entity (un)tracking and metadata indexing
+        PLAYER(LIVING_ENTITY_BASE), // Needed for entity (un)tracking and entity data indexing
 
         // Living entities as a larger subclass
         LIVING_ENTITY(48, LIVING_ENTITY_BASE),

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entitydata/EntityData.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entitydata/EntityData.java
@@ -28,21 +28,21 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class EntityData {
     private int id;
-    private EntityDataType metaType;
+    private EntityDataType dataType;
     private Object value;
 
     /**
-     * Creates a new metadata instance.
+     * Creates a new entity data instance.
      *
-     * @param id       metadata index
-     * @param metaType metadata type
+     * @param id       data index
+     * @param dataType data type
      * @param value    value if present
-     * @throws IllegalArgumentException if the value and metaType are incompatible
+     * @throws IllegalArgumentException if the value and dataType are incompatible
      */
-    public EntityData(int id, EntityDataType metaType, @Nullable Object value) {
+    public EntityData(int id, EntityDataType dataType, @Nullable Object value) {
         this.id = id;
-        this.metaType = metaType;
-        this.value = checkValue(metaType, value);
+        this.dataType = dataType;
+        this.value = checkValue(dataType, value);
     }
 
     public int id() {
@@ -54,19 +54,19 @@ public final class EntityData {
     }
 
     public EntityDataType dataType() {
-        return metaType;
+        return dataType;
     }
 
     /**
-     * Sets the metadata type if compatible with the current value.
+     * Sets the entity data type if compatible with the current value.
      *
-     * @param metaType metadata type
-     * @throws IllegalArgumentException if the metadata type and current value are incompatible
+     * @param dataType entity data type
+     * @throws IllegalArgumentException if the entity data type and current value are incompatible
      * @see #setTypeAndValue(EntityDataType, Object)
      */
-    public void setDataType(EntityDataType metaType) {
-        checkValue(metaType, this.value);
-        this.metaType = metaType;
+    public void setDataType(EntityDataType dataType) {
+        checkValue(dataType, this.value);
+        this.dataType = dataType;
     }
 
     public @Nullable <T> T value() {
@@ -78,32 +78,32 @@ public final class EntityData {
     }
 
     /**
-     * Sets the metadata value if compatible with the current meta type.
+     * Sets the entity data value if compatible with the current data type.
      *
      * @param value value
-     * @throws IllegalArgumentException if the value and current metaType are incompatible
+     * @throws IllegalArgumentException if the value and current dataType are incompatible
      * @see #setTypeAndValue(EntityDataType, Object)
      */
     public void setValue(@Nullable Object value) {
-        this.value = checkValue(this.metaType, value);
+        this.value = checkValue(this.dataType, value);
     }
 
     /**
-     * Sets metadata type and value.
+     * Sets entity data type and value.
      *
-     * @param metaType metadata type
+     * @param dataType entity data type
      * @param value    value
-     * @throws IllegalArgumentException if the value and metaType are incompatible
+     * @throws IllegalArgumentException if the value and dataType are incompatible
      */
-    public void setTypeAndValue(EntityDataType metaType, @Nullable Object value) {
-        this.value = checkValue(metaType, value);
-        this.metaType = metaType;
+    public void setTypeAndValue(EntityDataType dataType, @Nullable Object value) {
+        this.value = checkValue(dataType, value);
+        this.dataType = dataType;
     }
 
-    private Object checkValue(EntityDataType metaType, @Nullable Object value) {
-        Preconditions.checkNotNull(metaType);
-        if (value != null && !metaType.type().getOutputClass().isAssignableFrom(value.getClass())) {
-            throw new IllegalArgumentException("Metadata value and metaType are incompatible. Type=" + metaType
+    private Object checkValue(EntityDataType dataType, @Nullable Object value) {
+        Preconditions.checkNotNull(dataType);
+        if (value != null && !dataType.type().getOutputClass().isAssignableFrom(value.getClass())) {
+            throw new IllegalArgumentException("Entity data value and dataType are incompatible. Type=" + dataType
                 + ", value=" + value + " (" + value.getClass().getSimpleName() + ")");
         }
         return value;
@@ -111,32 +111,32 @@ public final class EntityData {
 
     @Deprecated
     public void setDataTypeUnsafe(EntityDataType type) {
-        this.metaType = type;
+        this.dataType = type;
     }
 
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        EntityData metadata = (EntityData) o;
-        if (id != metadata.id) return false;
-        if (metaType != metadata.metaType) return false;
-        return Objects.equals(value, metadata.value);
+        EntityData entityData = (EntityData) o;
+        if (id != entityData.id) return false;
+        if (dataType != entityData.dataType) return false;
+        return Objects.equals(value, entityData.value);
     }
 
     @Override
     public int hashCode() {
         int result = id;
-        result = 31 * result + metaType.hashCode();
+        result = 31 * result + dataType.hashCode();
         result = 31 * result + (value != null ? value.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
-        return "Metadata{" +
+        return "EntityData{" +
             "id=" + id +
-            ", metaType=" + metaType +
+            ", dataType=" + dataType +
             ", value=" + value +
             '}';
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entitydata/EntityDataType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entitydata/EntityDataType.java
@@ -35,7 +35,7 @@ public interface EntityDataType {
     Type type();
 
     /**
-     * Get type id from the specific MetaDataType
+     * Get type id from the specific EntityDataType
      *
      * @return Type id as an integer
      */
@@ -77,9 +77,9 @@ public interface EntityDataType {
         public boolean equals(final Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            final EntityDataTypeImpl metaType = (EntityDataTypeImpl) o;
-            if (typeId != metaType.typeId) return false;
-            return type.equals(metaType.type);
+            final EntityDataTypeImpl dataType = (EntityDataTypeImpl) o;
+            if (typeId != dataType.typeId) return false;
+            return type.equals(dataType.type);
         }
 
         @Override

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entitydata/types/AbstractEntityDataTypes.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entitydata/types/AbstractEntityDataTypes.java
@@ -44,8 +44,8 @@ public abstract class AbstractEntityDataTypes implements EntityDataTypes {
     }
 
     protected EntityDataType add(final int typeId, final Type<?> type) {
-        final EntityDataType metaType = EntityDataType.create(typeId, type);
-        values[typeId] = metaType;
-        return metaType;
+        final EntityDataType dataType = EntityDataType.create(typeId, type);
+        values[typeId] = dataType;
+        return dataType;
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entitydata/types/EntityDataTypes.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entitydata/types/EntityDataTypes.java
@@ -27,18 +27,18 @@ import com.viaversion.viaversion.api.minecraft.entitydata.EntityDataType;
 public interface EntityDataTypes {
 
     /**
-     * Returns the meta type by the given id.
+     * Returns the data type by the given id.
      *
      * @param id type id
-     * @return meta type by id
+     * @return data type by id
      * @throws IndexOutOfBoundsException if id is out of bounds
      */
     EntityDataType byId(int id);
 
     /**
-     * Returns an array of meta types.
+     * Returns an array of data types.
      *
-     * @return array of meta types
+     * @return array of data types
      */
     EntityDataType[] values();
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/rewriter/EntityRewriter.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/rewriter/EntityRewriter.java
@@ -59,13 +59,13 @@ public interface EntityRewriter<T extends Protocol<?, ?, ?, ?>> extends Rewriter
     int newEntityId(int id);
 
     /**
-     * Handles and transforms metadata of an entity.
+     * Handles and transforms entity data of an entity.
      *
      * @param entityId     entity id
-     * @param metadataList full, mutable list of metadata
+     * @param dataList full, mutable list of entity data
      * @param connection   user connection
      */
-    void handleEntityData(int entityId, List<EntityData> metadataList, UserConnection connection);
+    void handleEntityData(int entityId, List<EntityData> dataList, UserConnection connection);
 
     /**
      * Returns the entity tracker for the current protocol.

--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/entitydata/EntityDataListType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/entitydata/EntityDataListType.java
@@ -40,20 +40,20 @@ public final class EntityDataListType extends EntityDataListTypeTemplate {
     @Override
     public List<EntityData> read(final ByteBuf buffer) {
         final List<EntityData> list = new ArrayList<>();
-        EntityData meta;
+        EntityData data;
         do {
-            meta = this.type.read(buffer);
-            if (meta != null) {
-                list.add(meta);
+            data = this.type.read(buffer);
+            if (data != null) {
+                list.add(data);
             }
-        } while (meta != null);
+        } while (data != null);
         return list;
     }
 
     @Override
     public void write(final ByteBuf buffer, final List<EntityData> object) {
-        for (final EntityData metadata : object) {
-            this.type.write(buffer, metadata);
+        for (final EntityData data : object) {
+            this.type.write(buffer, data);
         }
         this.type.write(buffer, null);
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/entitydata/EntityDataType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/entitydata/EntityDataType.java
@@ -26,14 +26,14 @@ import com.viaversion.viaversion.api.minecraft.entitydata.types.EntityDataTypes;
 
 public final class EntityDataType extends ModernEntityDataType {
 
-    private final EntityDataTypes metaTypes;
+    private final EntityDataTypes dataTypes;
 
-    public EntityDataType(final EntityDataTypes metaTypes) {
-        this.metaTypes = metaTypes;
+    public EntityDataType(final EntityDataTypes dataTypes) {
+        this.dataTypes = dataTypes;
     }
 
     @Override
     protected com.viaversion.viaversion.api.minecraft.entitydata.EntityDataType getType(final int index) {
-        return metaTypes.byId(index);
+        return dataTypes.byId(index);
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/entitydata/ModernEntityDataType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/entitydata/ModernEntityDataType.java
@@ -33,7 +33,7 @@ public abstract class ModernEntityDataType extends EntityDataTypeTemplate {
     @Override
     public EntityData read(final ByteBuf buffer) {
         final short index = buffer.readUnsignedByte();
-        if (index == END) return null; // End of metadata
+        if (index == END) return null; // End of data
         final EntityDataType type = this.getType(Types.VAR_INT.readPrimitive(buffer));
         return new EntityData(index, type, type.type().read(buffer));
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/entitydata/OldEntityDataType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/entitydata/OldEntityDataType.java
@@ -32,7 +32,7 @@ public abstract class OldEntityDataType extends EntityDataTypeTemplate {
     @Override
     public EntityData read(final ByteBuf buffer) {
         final byte index = buffer.readByte();
-        if (index == END) return null; // End of metadata
+        if (index == END) return null; // End of data
         final EntityDataType type = this.getType((index & 224) >> 5);
         return new EntityData(index & 31, type, type.type().read(buffer));
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/version/Types1_12.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/version/Types1_12.java
@@ -31,11 +31,11 @@ import java.util.List;
 public final class Types1_12 {
 
     /**
-     * Metadata type for 1.12
+     * Entity data type for 1.12
      */
     public static final Type<EntityData> ENTITY_DATA = new EntityDataType1_12();
     /**
-     * Metadata list type for 1.12
+     * Entity data list type for 1.12
      */
     public static final Type<List<EntityData>> ENTITY_DATA_LIST = new EntityDataListType(ENTITY_DATA);
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/version/Types1_8.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/version/Types1_8.java
@@ -33,11 +33,11 @@ import java.util.List;
 public final class Types1_8 {
 
     /**
-     * Metadata type for 1.8
+     * Entity data type for 1.8
      */
     public static final Type<EntityData> ENTITY_DATA = new EntityDataType1_8();
     /**
-     * Metadata list type for 1.8
+     * Entity data list type for 1.8
      */
     public static final Type<List<EntityData>> ENTITY_DATA_LIST = new EntityDataListType(ENTITY_DATA);
 

--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/version/Types1_9.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/version/Types1_9.java
@@ -32,11 +32,11 @@ import java.util.List;
 
 public final class Types1_9 {
     /**
-     * Metadata type for 1.9
+     * Entity data type for 1.9
      */
     public static final Type<EntityData> ENTITY_DATA = new EntityDataType1_9();
     /**
-     * Metadata list type for 1.9
+     * Entity data list type for 1.9
      */
     public static final Type<List<EntityData>> ENTITY_DATA_LIST = new EntityDataListType(ENTITY_DATA);
 

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/v1_14_4to1_15/EntityToggleGlideListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/v1_14_4to1_15/EntityToggleGlideListener.java
@@ -51,13 +51,13 @@ public class EntityToggleGlideListener extends ViaBukkitListener {
 
         if (!isOnPipe(player)) return;
 
-        // Cancelling can only be done by updating the player's metadata
+        // Cancelling can only be done by updating the player's entity data
         if (event.isGliding() && event.isCancelled()) {
             PacketWrapper packet = PacketWrapper.create(ClientboundPackets1_15.SET_ENTITY_DATA, null, getUserConnection(player));
             packet.write(Types.VAR_INT, player.getEntityId());
 
             byte bitmask = 0;
-            // Collect other metadata for the mitmask
+            // Collect other entity data for the mitmask
             if (player.getFireTicks() > 0) {
                 bitmask |= 0x01;
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/EntityPacketRewriter1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/EntityPacketRewriter1_11.java
@@ -230,7 +230,7 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
             }
         });
 
-        filter().type(EntityType.ARMOR_STAND).index(0).handler((event, meta) -> {
+        filter().type(EntityType.ARMOR_STAND).index(0).handler((event, data) -> {
             if (!Via.getConfig().isHologramPatch()) {
                 return;
             }
@@ -242,9 +242,9 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
                 return;
             }
 
-            byte data = meta.value();
+            byte value = data.value();
             // Check invisible | Check small | Check if custom name is empty | Check if custom name visible is true
-            if ((data & 0x20) == 0x20 && ((byte) flags.getValue() & 0x01) == 0x01
+            if ((value & 0x20) == 0x20 && ((byte) flags.getValue() & 0x01) == 0x01
                 && !((String) customName.getValue()).isEmpty() && (boolean) customNameVisible.getValue()) {
                 EntityTracker1_11 tracker = tracker(event.user());
                 int entityId = event.entityId();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/EntityPacketRewriter1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/EntityPacketRewriter1_11.java
@@ -87,7 +87,7 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
                 map(Types.SHORT); // 9 - Velocity X
                 map(Types.SHORT); // 10 - Velocity Y
                 map(Types.SHORT); // 11 - Velocity Z
-                map(Types1_9.ENTITY_DATA_LIST); // 12 - Metadata
+                map(Types1_9.ENTITY_DATA_LIST); // 12 - Entity data
 
                 handler(wrapper -> {
                     int entityId = wrapper.get(Types.VAR_INT, 0);
@@ -179,50 +179,50 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
 
     @Override
     protected void registerRewrites() {
-        filter().handler((event, meta) -> {
-            if (meta.getValue() instanceof DataItem) {
+        filter().handler((event, data) -> {
+            if (data.getValue() instanceof DataItem) {
                 // Apply rewrite
-                EntityMappings1_11.toClientItem(meta.value());
+                EntityMappings1_11.toClientItem(data.value());
             }
         });
 
-        filter().type(EntityType.GUARDIAN).index(12).handler((event, meta) -> {
-            boolean value = (((byte) meta.getValue()) & 0x02) == 0x02;
-            meta.setTypeAndValue(EntityDataTypes1_9.BOOLEAN, value);
+        filter().type(EntityType.GUARDIAN).index(12).handler((event, data) -> {
+            boolean value = (((byte) data.getValue()) & 0x02) == 0x02;
+            data.setTypeAndValue(EntityDataTypes1_9.BOOLEAN, value);
         });
 
         filter().type(EntityType.ABSTRACT_SKELETON).removeIndex(12);
 
-        filter().type(EntityType.ZOMBIE).handler((event, meta) -> {
-            if ((event.entityType() == EntityType.ZOMBIE || event.entityType() == EntityType.HUSK) && meta.id() == 14) {
+        filter().type(EntityType.ZOMBIE).handler((event, data) -> {
+            if ((event.entityType() == EntityType.ZOMBIE || event.entityType() == EntityType.HUSK) && data.id() == 14) {
                 event.cancel();
-            } else if (meta.id() == 15) {
-                meta.setId(14);
+            } else if (data.id() == 15) {
+                data.setId(14);
             }
         });
 
-        filter().type(EntityType.ABSTRACT_HORSE).handler((event, metadata) -> {
+        filter().type(EntityType.ABSTRACT_HORSE).handler((event, data) -> {
             final com.viaversion.viaversion.api.minecraft.entities.EntityType type = event.entityType();
-            int id = metadata.id();
+            int id = data.id();
             if (id == 14) { // Type
                 event.cancel();
                 return;
             }
 
             if (id == 16) { // Owner
-                metadata.setId(14);
+                data.setId(14);
             } else if (id == 17) { // Armor
-                metadata.setId(16);
+                data.setId(16);
             }
 
             // Process per type
-            if (!type.is(EntityType.HORSE) && metadata.id() == 15 || metadata.id() == 16) {
+            if (!type.is(EntityType.HORSE) && data.id() == 15 || data.id() == 16) {
                 event.cancel();
                 return;
             }
 
-            if ((type == EntityType.DONKEY || type == EntityType.MULE) && metadata.id() == 13) {
-                if ((((byte) metadata.getValue()) & 0x08) == 0x08) {
+            if ((type == EntityType.DONKEY || type == EntityType.MULE) && data.id() == 13) {
+                if ((((byte) data.getValue()) & 0x08) == 0x08) {
                     event.createExtraData(new EntityData(15, EntityDataTypes1_9.BOOLEAN, true));
                 } else {
                     event.createExtraData(new EntityData(15, EntityDataTypes1_9.BOOLEAN, false));
@@ -284,17 +284,17 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
         return EntityTypes1_11.getTypeFromId(type, true);
     }
 
-    public EntityType rewriteEntityType(int numType, List<EntityData> metadata) {
+    public EntityType rewriteEntityType(int numType, List<EntityData> entityData) {
         EntityType type = EntityType.findById(numType);
         if (type == null) {
-            Via.getManager().getPlatform().getLogger().severe("Error: could not find Entity type " + numType + " with metadata: " + metadata);
+            Via.getManager().getPlatform().getLogger().severe("Error: could not find Entity type " + numType + " with entity data: " + entityData);
             return null;
         }
 
         try {
             if (type.is(EntityType.GUARDIAN)) {
                 // ElderGuardian - 4
-                Optional<EntityData> options = getById(metadata, 12);
+                Optional<EntityData> options = getById(entityData, 12);
                 if (options.isPresent()) {
                     if ((((byte) options.get().getValue()) & 0x04) == 0x04) {
                         return EntityType.ELDER_GUARDIAN;
@@ -304,7 +304,7 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
             if (type.is(EntityType.SKELETON)) {
                 // WitherSkeleton - 5
                 // Stray - 6
-                Optional<EntityData> options = getById(metadata, 12);
+                Optional<EntityData> options = getById(entityData, 12);
                 if (options.isPresent()) {
                     if (((int) options.get().getValue()) == 1) {
                         return EntityType.WITHER_SKELETON;
@@ -317,11 +317,11 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
             if (type.is(EntityType.ZOMBIE)) {
                 // ZombieVillager - 27
                 // Husk - 23
-                Optional<EntityData> options = getById(metadata, 13);
+                Optional<EntityData> options = getById(entityData, 13);
                 if (options.isPresent()) {
                     int value = (int) options.get().getValue();
                     if (value > 0 && value < 6) {
-                        metadata.add(new EntityData(16, EntityDataTypes1_9.VAR_INT, value - 1)); // Add profession type to new metadata
+                        entityData.add(new EntityData(16, EntityDataTypes1_9.VAR_INT, value - 1)); // Add profession type to new entity data
                         return EntityType.ZOMBIE_VILLAGER;
                     }
                     if (value == 6) {
@@ -334,7 +334,7 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
                 // ZombieHorse - 29
                 // Donkey - 31
                 // Mule - 32
-                Optional<EntityData> options = getById(metadata, 14);
+                Optional<EntityData> options = getById(entityData, 14);
                 if (options.isPresent()) {
                     if (((int) options.get().getValue()) == 0) {
                         return EntityType.HORSE;
@@ -356,7 +356,7 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
         } catch (Exception e) {
             if (!Via.getConfig().isSuppressMetadataErrors() || Via.getManager().isDebug()) {
                 protocol.getLogger().warning("An error occurred with entity type rewriter");
-                protocol.getLogger().warning("Metadata: " + metadata);
+                protocol.getLogger().warning("Entity data: " + entityData);
                 protocol.getLogger().log(Level.WARNING, "Error: ", e);
             }
         }
@@ -364,9 +364,9 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
         return type;
     }
 
-    public Optional<EntityData> getById(List<EntityData> metadatas, int id) {
-        for (EntityData metadata : metadatas) {
-            if (metadata.id() == id) return Optional.of(metadata);
+    public Optional<EntityData> getById(List<EntityData> entityData, int id) {
+        for (EntityData data : entityData) {
+            if (data.id() == id) return Optional.of(data);
         }
         return Optional.empty();
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_11_1to1_12/rewriter/EntityPacketRewriter1_12.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_11_1to1_12/rewriter/EntityPacketRewriter1_12.java
@@ -62,9 +62,9 @@ public class EntityPacketRewriter1_12 extends EntityRewriter<ClientboundPackets1
                 map(Types.SHORT); // 9 - Velocity X
                 map(Types.SHORT); // 10 - Velocity Y
                 map(Types.SHORT); // 11 - Velocity Z
-                map(Types1_12.ENTITY_DATA_LIST); // 12 - Metadata
+                map(Types1_12.ENTITY_DATA_LIST); // 12 - Entity data
 
-                // Track mob and rewrite metadata
+                // Track mob and rewrite entity data
                 handler(trackerAndRewriterHandler(Types1_12.ENTITY_DATA_LIST));
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_11_1to1_12/rewriter/EntityPacketRewriter1_12.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_11_1to1_12/rewriter/EntityPacketRewriter1_12.java
@@ -75,9 +75,9 @@ public class EntityPacketRewriter1_12 extends EntityRewriter<ClientboundPackets1
 
     @Override
     protected void registerRewrites() {
-        filter().handler((event, meta) -> {
-            if (meta.getValue() instanceof Item) {
-                meta.setValue(protocol.getItemRewriter().handleItemToClient(event.user(), meta.value()));
+        filter().handler((event, data) -> {
+            if (data.getValue() instanceof Item) {
+                data.setValue(protocol.getItemRewriter().handleItemToClient(event.user(), data.value()));
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/EntityPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/EntityPacketRewriter1_13.java
@@ -102,7 +102,7 @@ public class EntityPacketRewriter1_13 extends EntityRewriter<ClientboundPackets1
                 map(Types.SHORT); // 9 - Velocity X
                 map(Types.SHORT); // 10 - Velocity Y
                 map(Types.SHORT); // 11 - Velocity Z
-                map(Types1_12.ENTITY_DATA_LIST, Types1_13.ENTITY_DATA_LIST); // 12 - Metadata
+                map(Types1_12.ENTITY_DATA_LIST, Types1_13.ENTITY_DATA_LIST); // 12 - Entity data
 
                 handler(trackerAndRewriterHandler(Types1_13.ENTITY_DATA_LIST));
             }
@@ -118,7 +118,7 @@ public class EntityPacketRewriter1_13 extends EntityRewriter<ClientboundPackets1
                 map(Types.DOUBLE); // 4 - Z
                 map(Types.BYTE); // 5 - Yaw
                 map(Types.BYTE); // 6 - Pitch
-                map(Types1_12.ENTITY_DATA_LIST, Types1_13.ENTITY_DATA_LIST); // 7 - Metadata
+                map(Types1_12.ENTITY_DATA_LIST, Types1_13.ENTITY_DATA_LIST); // 7 - Entity data
 
                 handler(trackerAndRewriterHandler(Types1_13.ENTITY_DATA_LIST, EntityTypes1_13.EntityType.PLAYER));
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/EntityPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/EntityPacketRewriter1_13.java
@@ -167,55 +167,55 @@ public class EntityPacketRewriter1_13 extends EntityRewriter<ClientboundPackets1
     @Override
     protected void registerRewrites() {
         filter().mapDataType(typeId -> Types1_13.ENTITY_DATA_TYPES.byId(typeId > 4 ? typeId + 1 : typeId));
-        filter().dataType(Types1_13.ENTITY_DATA_TYPES.itemType).handler(((event, meta) -> protocol.getItemRewriter().handleItemToClient(event.user(), meta.value())));
-        filter().dataType(Types1_13.ENTITY_DATA_TYPES.optionalBlockStateType).handler(((event, meta) -> {
-            final int oldId = meta.value();
+        filter().dataType(Types1_13.ENTITY_DATA_TYPES.itemType).handler(((event, data) -> protocol.getItemRewriter().handleItemToClient(event.user(), data.value())));
+        filter().dataType(Types1_13.ENTITY_DATA_TYPES.optionalBlockStateType).handler(((event, data) -> {
+            final int oldId = data.value();
             if (oldId != 0) {
                 final int combined = (((oldId & 4095) << 4) | (oldId >> 12 & 15));
                 final int newId = WorldPacketRewriter1_13.toNewId(combined);
-                meta.setValue(newId);
+                data.setValue(newId);
             }
         }));
 
         // Previously unused, now swimming
-        filter().index(0).handler((event, meta) -> meta.setValue((byte) ((byte) meta.getValue() & ~0x10)));
+        filter().index(0).handler((event, data) -> data.setValue((byte) ((byte) data.getValue() & ~0x10)));
 
-        filter().index(2).handler(((event, meta) -> {
-            if (meta.getValue() != null && !((String) meta.getValue()).isEmpty()) {
-                meta.setTypeAndValue(Types1_13.ENTITY_DATA_TYPES.optionalComponentType, ComponentUtil.legacyToJson((String) meta.getValue()));
+        filter().index(2).handler(((event, data) -> {
+            if (data.getValue() != null && !((String) data.getValue()).isEmpty()) {
+                data.setTypeAndValue(Types1_13.ENTITY_DATA_TYPES.optionalComponentType, ComponentUtil.legacyToJson((String) data.getValue()));
             } else {
-                meta.setTypeAndValue(Types1_13.ENTITY_DATA_TYPES.optionalComponentType, null);
+                data.setTypeAndValue(Types1_13.ENTITY_DATA_TYPES.optionalComponentType, null);
             }
         }));
 
-        filter().type(EntityTypes1_13.EntityType.WOLF).index(17).handler((event, meta) -> {
+        filter().type(EntityTypes1_13.EntityType.WOLF).index(17).handler((event, data) -> {
             // Handle new colors
-            meta.setValue(15 - (int) meta.getValue());
+            data.setValue(15 - (int) data.getValue());
         });
 
         filter().type(EntityTypes1_13.EntityType.ZOMBIE).addIndex(15); // Shaking
 
-        filter().type(EntityTypes1_13.EntityType.ABSTRACT_MINECART).index(9).handler((event, meta) -> {
-            final int oldId = meta.value();
+        filter().type(EntityTypes1_13.EntityType.ABSTRACT_MINECART).index(9).handler((event, data) -> {
+            final int oldId = data.value();
             final int combined = (((oldId & 4095) << 4) | (oldId >> 12 & 15));
             final int newId = WorldPacketRewriter1_13.toNewId(combined);
-            meta.setValue(newId);
+            data.setValue(newId);
         });
 
-        filter().type(EntityTypes1_13.EntityType.AREA_EFFECT_CLOUD).handler((event, meta) -> {
-            if (meta.id() == 9) {
-                int particleId = meta.value();
-                EntityData parameter1Meta = event.dataAtIndex(10);
-                EntityData parameter2Meta = event.dataAtIndex(11);
-                int parameter1 = parameter1Meta != null ? parameter1Meta.value() : 0;
-                int parameter2 = parameter2Meta != null ? parameter2Meta.value() : 0;
+        filter().type(EntityTypes1_13.EntityType.AREA_EFFECT_CLOUD).handler((event, data) -> {
+            if (data.id() == 9) {
+                int particleId = data.value();
+                EntityData parameter1Data = event.dataAtIndex(10);
+                EntityData parameter2Data = event.dataAtIndex(11);
+                int parameter1 = parameter1Data != null ? parameter1Data.value() : 0;
+                int parameter2 = parameter2Data != null ? parameter2Data.value() : 0;
 
                 Particle particle = ParticleIdMappings1_13.rewriteParticle(particleId, new Integer[]{parameter1, parameter2});
                 if (particle != null && particle.id() != -1) {
                     event.createExtraData(new EntityData(9, Types1_13.ENTITY_DATA_TYPES.particleType, particle));
                 }
             }
-            if (meta.id() >= 9) {
+            if (data.id() >= 9) {
                 event.cancel();
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_1to1_13_2/rewriter/EntityPacketRewriter1_13_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_1to1_13_2/rewriter/EntityPacketRewriter1_13_2.java
@@ -29,9 +29,9 @@ import com.viaversion.viaversion.protocols.v1_13_1to1_13_2.Protocol1_13_1To1_13_
 public class EntityPacketRewriter1_13_2 {
 
     public static void register(Protocol1_13_1To1_13_2 protocol) {
-        final PacketHandler metaTypeHandler = wrapper -> {
-            for (EntityData metadata : wrapper.get(Types1_13_2.ENTITY_DATA_LIST, 0)) {
-                metadata.setDataType(Types1_13_2.ENTITY_DATA_TYPES.byId(metadata.dataType().typeId()));
+        final PacketHandler dataTypeHandler = wrapper -> {
+            for (EntityData data : wrapper.get(Types1_13_2.ENTITY_DATA_LIST, 0)) {
+                data.setDataType(Types1_13_2.ENTITY_DATA_TYPES.byId(data.dataType().typeId()));
             }
         };
 
@@ -50,9 +50,9 @@ public class EntityPacketRewriter1_13_2 {
                 map(Types.SHORT); // 9 - Velocity X
                 map(Types.SHORT); // 10 - Velocity Y
                 map(Types.SHORT); // 11 - Velocity Z
-                map(Types1_13.ENTITY_DATA_LIST, Types1_13_2.ENTITY_DATA_LIST); // 12 - Metadata
+                map(Types1_13.ENTITY_DATA_LIST, Types1_13_2.ENTITY_DATA_LIST); // 12 - Entity data
 
-                handler(metaTypeHandler);
+                handler(dataTypeHandler);
             }
         });
 
@@ -66,9 +66,9 @@ public class EntityPacketRewriter1_13_2 {
                 map(Types.DOUBLE); // 4 - Z
                 map(Types.BYTE); // 5 - Yaw
                 map(Types.BYTE); // 6 - Pitch
-                map(Types1_13.ENTITY_DATA_LIST, Types1_13_2.ENTITY_DATA_LIST); // 7 - Metadata
+                map(Types1_13.ENTITY_DATA_LIST, Types1_13_2.ENTITY_DATA_LIST); // 7 - Entity data
 
-                handler(metaTypeHandler);
+                handler(dataTypeHandler);
             }
         });
 
@@ -76,9 +76,9 @@ public class EntityPacketRewriter1_13_2 {
             @Override
             public void register() {
                 map(Types.VAR_INT); // 0 - Entity ID
-                map(Types1_13.ENTITY_DATA_LIST, Types1_13_2.ENTITY_DATA_LIST); // 1 - Metadata list
+                map(Types1_13.ENTITY_DATA_LIST, Types1_13_2.ENTITY_DATA_LIST); // 1 - Entity data list
 
-                handler(metaTypeHandler);
+                handler(dataTypeHandler);
             }
         });
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
@@ -267,10 +267,10 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
 
         filter().type(EntityTypes1_14.LIVING_ENTITY).addIndex(12);
 
-        filter().type(EntityTypes1_14.LIVING_ENTITY).index(8).handler((event, meta) -> {
-            float value = ((Number) meta.getValue()).floatValue();
+        filter().type(EntityTypes1_14.LIVING_ENTITY).index(8).handler((event, data) -> {
+            float value = ((Number) data.getValue()).floatValue();
             if (Float.isNaN(value) && Via.getConfig().is1_14HealthNaNFix()) {
-                meta.setValue(1F);
+                data.setValue(1F);
             }
         });
 
@@ -299,23 +299,23 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
             }
         });
 
-        filter().type(EntityTypes1_14.ZOMBIE).handler((event, meta) -> {
-            if (meta.id() == 16) {
+        filter().type(EntityTypes1_14.ZOMBIE).handler((event, data) -> {
+            if (data.id() == 16) {
                 EntityTracker1_14 tracker = tracker(event.user());
                 int entityId = event.entityId();
                 tracker.setInsentientData(entityId, (byte) ((tracker.getInsentientData(entityId) & ~0x4)
-                    | ((boolean) meta.getValue() ? 0x4 : 0))); // New attacking
+                    | ((boolean) data.getValue() ? 0x4 : 0))); // New attacking
                 event.createExtraData(new EntityData(13, Types1_14.ENTITY_DATA_TYPES.byteType, tracker.getInsentientData(entityId)));
                 event.cancel(); // "Are hands held up"
-            } else if (meta.id() > 16) {
-                meta.setId(meta.id() - 1);
+            } else if (data.id() > 16) {
+                data.setId(data.id() - 1);
             }
         });
 
-        filter().type(EntityTypes1_14.HORSE).index(18).handler((event, meta) -> {
+        filter().type(EntityTypes1_14.HORSE).index(18).handler((event, data) -> {
             event.cancel();
 
-            int armorType = meta.value();
+            int armorType = data.value();
             Item armorItem = null;
             if (armorType == 1) {  //iron armor
                 armorItem = new DataItem(protocol.getMappingData().getNewItemId(727), (byte) 1, null);
@@ -336,42 +336,42 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
             }
         });
 
-        filter().type(EntityTypes1_14.VILLAGER).index(15).handler((event, meta) -> {
-            meta.setTypeAndValue(Types1_14.ENTITY_DATA_TYPES.villagerDatatType, new VillagerData(2, getNewProfessionId(meta.value()), 0));
+        filter().type(EntityTypes1_14.VILLAGER).index(15).handler((event, data) -> {
+            data.setTypeAndValue(Types1_14.ENTITY_DATA_TYPES.villagerDatatType, new VillagerData(2, getNewProfessionId(data.value()), 0));
         });
 
-        filter().type(EntityTypes1_14.ZOMBIE_VILLAGER).index(18).handler((event, meta) -> {
-            meta.setTypeAndValue(Types1_14.ENTITY_DATA_TYPES.villagerDatatType, new VillagerData(2, getNewProfessionId(meta.value()), 0));
+        filter().type(EntityTypes1_14.ZOMBIE_VILLAGER).index(18).handler((event, data) -> {
+            data.setTypeAndValue(Types1_14.ENTITY_DATA_TYPES.villagerDatatType, new VillagerData(2, getNewProfessionId(data.value()), 0));
         });
 
         filter().type(EntityTypes1_14.ABSTRACT_ARROW).addIndex(9); // Piercing level added
 
-        filter().type(EntityTypes1_14.FIREWORK_ROCKET).index(8).handler((event, meta) -> {
-            meta.setDataType(Types1_14.ENTITY_DATA_TYPES.optionalVarIntType);
-            if (meta.getValue().equals(0)) {
-                meta.setValue(null); // https://bugs.mojang.com/browse/MC-111480
+        filter().type(EntityTypes1_14.FIREWORK_ROCKET).index(8).handler((event, data) -> {
+            data.setDataType(Types1_14.ENTITY_DATA_TYPES.optionalVarIntType);
+            if (data.getValue().equals(0)) {
+                data.setValue(null); // https://bugs.mojang.com/browse/MC-111480
             }
         });
 
-        filter().type(EntityTypes1_14.ABSTRACT_SKELETON).index(14).handler((event, meta) -> {
+        filter().type(EntityTypes1_14.ABSTRACT_SKELETON).index(14).handler((event, data) -> {
             EntityTracker1_14 tracker = tracker(event.user());
             int entityId = event.entityId();
             tracker.setInsentientData(entityId, (byte) ((tracker.getInsentientData(entityId) & ~0x4)
-                | ((boolean) meta.getValue() ? 0x4 : 0))); // New attacking
+                | ((boolean) data.getValue() ? 0x4 : 0))); // New attacking
             event.createExtraData(new EntityData(13, Types1_14.ENTITY_DATA_TYPES.byteType, tracker.getInsentientData(entityId)));
             event.cancel();  // "Is swinging arms"
         });
 
-        filter().type(EntityTypes1_14.ABSTRACT_ILLAGER).handler((event, meta) -> {
+        filter().type(EntityTypes1_14.ABSTRACT_ILLAGER).handler((event, data) -> {
             if (event.index() == 14) {
                 EntityTracker1_14 tracker = tracker(event.user());
                 int entityId = event.entityId();
                 tracker.setInsentientData(entityId, (byte) ((tracker.getInsentientData(entityId) & ~0x4)
-                    | (((Number) meta.getValue()).byteValue() != 0 ? 0x4 : 0))); // New attacking
+                    | (((Number) data.getValue()).byteValue() != 0 ? 0x4 : 0))); // New attacking
                 event.createExtraData(new EntityData(13, Types1_14.ENTITY_DATA_TYPES.byteType, tracker.getInsentientData(entityId)));
                 event.cancel(); // "Has target (aggressive state)"
             } else if (event.index() > 14) {
-                meta.setId(meta.id() - 1);
+                data.setId(data.id() - 1);
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13to1_13_1/rewriter/EntityPacketRewriter1_13_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13to1_13_1/rewriter/EntityPacketRewriter1_13_1.java
@@ -80,7 +80,7 @@ public class EntityPacketRewriter1_13_1 extends EntityRewriter<ClientboundPacket
                 map(Types.SHORT); // 9 - Velocity X
                 map(Types.SHORT); // 10 - Velocity Y
                 map(Types.SHORT); // 11 - Velocity Z
-                map(Types1_13.ENTITY_DATA_LIST); // 12 - Metadata
+                map(Types1_13.ENTITY_DATA_LIST); // 12 - Entity data
 
                 handler(trackerAndRewriterHandler(Types1_13.ENTITY_DATA_LIST));
             }
@@ -96,7 +96,7 @@ public class EntityPacketRewriter1_13_1 extends EntityRewriter<ClientboundPacket
                 map(Types.DOUBLE); // 4 - Z
                 map(Types.BYTE); // 5 - Yaw
                 map(Types.BYTE); // 6 - Pitch
-                map(Types1_13.ENTITY_DATA_LIST); // 7 - Metadata
+                map(Types1_13.ENTITY_DATA_LIST); // 7 - Entity data
 
                 handler(trackerAndRewriterHandler(Types1_13.ENTITY_DATA_LIST, EntityTypes1_13.EntityType.PLAYER));
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_14_4to1_15/rewriter/EntityPacketRewriter1_15.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_14_4to1_15/rewriter/EntityPacketRewriter1_15.java
@@ -123,7 +123,7 @@ public class EntityPacketRewriter1_15 extends EntityRewriter<ClientboundPackets1
 
 
     private void sendEntityDataPacket(PacketWrapper wrapper, int entityId) {
-        // Meta is no longer included in the spawn packets, but sent separately
+        // Data is no longer included in the spawn packets, but sent separately
         List<EntityData> entityData = wrapper.read(Types1_14.ENTITY_DATA_LIST);
         if (entityData.isEmpty()) {
             return;
@@ -133,7 +133,7 @@ public class EntityPacketRewriter1_15 extends EntityRewriter<ClientboundPackets1
         wrapper.send(Protocol1_14_4To1_15.class);
         wrapper.cancel();
 
-        // Handle meta
+        // Handle data
         handleEntityData(entityId, entityData, wrapper.user());
 
         PacketWrapper entityDataPacket = PacketWrapper.create(ClientboundPackets1_15.SET_ENTITY_DATA, wrapper.user());

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_14_4to1_15/rewriter/EntityPacketRewriter1_15.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_14_4to1_15/rewriter/EntityPacketRewriter1_15.java
@@ -58,7 +58,7 @@ public class EntityPacketRewriter1_15 extends EntityRewriter<ClientboundPackets1
                 map(Types.SHORT); // 11 - Velocity Z
 
                 handler(trackerHandler());
-                handler(wrapper -> sendMetadataPacket(wrapper, wrapper.get(Types.VAR_INT, 0)));
+                handler(wrapper -> sendEntityDataPacket(wrapper, wrapper.get(Types.VAR_INT, 0)));
             }
         });
 
@@ -77,7 +77,7 @@ public class EntityPacketRewriter1_15 extends EntityRewriter<ClientboundPackets1
                     int entityId = wrapper.get(Types.VAR_INT, 0);
                     wrapper.user().getEntityTracker(Protocol1_14_4To1_15.class).addEntity(entityId, EntityTypes1_15.PLAYER);
 
-                    sendMetadataPacket(wrapper, entityId);
+                    sendEntityDataPacket(wrapper, entityId);
                 });
             }
         });
@@ -122,10 +122,10 @@ public class EntityPacketRewriter1_15 extends EntityRewriter<ClientboundPackets1
     }
 
 
-    private void sendMetadataPacket(PacketWrapper wrapper, int entityId) {
+    private void sendEntityDataPacket(PacketWrapper wrapper, int entityId) {
         // Meta is no longer included in the spawn packets, but sent separately
-        List<EntityData> metadata = wrapper.read(Types1_14.ENTITY_DATA_LIST);
-        if (metadata.isEmpty()) {
+        List<EntityData> entityData = wrapper.read(Types1_14.ENTITY_DATA_LIST);
+        if (entityData.isEmpty()) {
             return;
         }
 
@@ -134,12 +134,12 @@ public class EntityPacketRewriter1_15 extends EntityRewriter<ClientboundPackets1
         wrapper.cancel();
 
         // Handle meta
-        handleEntityData(entityId, metadata, wrapper.user());
+        handleEntityData(entityId, entityData, wrapper.user());
 
-        PacketWrapper metadataPacket = PacketWrapper.create(ClientboundPackets1_15.SET_ENTITY_DATA, wrapper.user());
-        metadataPacket.write(Types.VAR_INT, entityId);
-        metadataPacket.write(Types1_14.ENTITY_DATA_LIST, metadata);
-        metadataPacket.send(Protocol1_14_4To1_15.class);
+        PacketWrapper entityDataPacket = PacketWrapper.create(ClientboundPackets1_15.SET_ENTITY_DATA, wrapper.user());
+        entityDataPacket.write(Types.VAR_INT, entityId);
+        entityDataPacket.write(Types1_14.ENTITY_DATA_LIST, entityData);
+        entityDataPacket.send(Protocol1_14_4To1_15.class);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_14to1_14_1/rewriter/EntityPacketRewriter1_14_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_14to1_14_1/rewriter/EntityPacketRewriter1_14_1.java
@@ -49,7 +49,7 @@ public class EntityPacketRewriter1_14_1 extends EntityRewriter<ClientboundPacket
                 map(Types.SHORT); // 9 - Velocity X
                 map(Types.SHORT); // 10 - Velocity Y
                 map(Types.SHORT); // 11 - Velocity Z
-                map(Types1_14.ENTITY_DATA_LIST); // 12 - Metadata
+                map(Types1_14.ENTITY_DATA_LIST); // 12 - Entity data
 
                 handler(trackerAndRewriterHandler(Types1_14.ENTITY_DATA_LIST));
             }
@@ -67,7 +67,7 @@ public class EntityPacketRewriter1_14_1 extends EntityRewriter<ClientboundPacket
                 map(Types.DOUBLE); // 4 - Z
                 map(Types.BYTE); // 5 - Yaw
                 map(Types.BYTE); // 6 - Pitch
-                map(Types1_14.ENTITY_DATA_LIST); // 7 - Metadata
+                map(Types1_14.ENTITY_DATA_LIST); // 7 - Entity data
 
                 handler(trackerAndRewriterHandler(Types1_14.ENTITY_DATA_LIST, EntityTypes1_14.PLAYER));
             }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
@@ -211,8 +211,8 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
         registerBlockStateHandler(EntityTypes1_16.ABSTRACT_MINECART, 10);
 
         filter().type(EntityTypes1_16.ABSTRACT_ARROW).removeIndex(8);
-        filter().type(EntityTypes1_16.WOLF).index(16).handler((event, meta) -> {
-            byte mask = meta.value();
+        filter().type(EntityTypes1_16.WOLF).index(16).handler((event, data) -> {
+            byte mask = data.value();
             int angerTime = (mask & 0x02) != 0 ? Integer.MAX_VALUE : 0;
             event.createExtraData(new EntityData(20, Types1_16.ENTITY_DATA_TYPES.varIntType, angerTime));
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_1to1_16_2/rewriter/EntityPacketRewriter1_16_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_1to1_16_2/rewriter/EntityPacketRewriter1_16_2.java
@@ -80,11 +80,11 @@ public class EntityPacketRewriter1_16_2 extends EntityRewriter<ClientboundPacket
         registerEntityDataTypeHandler(Types1_16.ENTITY_DATA_TYPES.itemType, Types1_16.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_16.ENTITY_DATA_TYPES.particleType);
         registerBlockStateHandler(EntityTypes1_16_2.ABSTRACT_MINECART, 10);
 
-        filter().type(EntityTypes1_16_2.ABSTRACT_PIGLIN).handler((metadatas, meta) -> {
-            if (meta.id() == 15) {
-                meta.setId(16);
-            } else if (meta.id() == 16) {
-                meta.setId(15);
+        filter().type(EntityTypes1_16_2.ABSTRACT_PIGLIN).handler((event, data) -> {
+            if (data.id() == 15) {
+                data.setId(16);
+            } else if (data.id() == 16) {
+                data.setId(15);
             }
         });
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_4to1_17/rewriter/EntityPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_16_4to1_17/rewriter/EntityPacketRewriter1_17.java
@@ -136,11 +136,11 @@ public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPa
     @Override
     protected void registerRewrites() {
         filter().mapDataType(Types1_17.ENTITY_DATA_TYPES::byId);
-        filter().dataType(Types1_17.ENTITY_DATA_TYPES.poseType).handler((event, meta) -> {
-            int pose = meta.value();
+        filter().dataType(Types1_17.ENTITY_DATA_TYPES.poseType).handler((event, data) -> {
+            int pose = data.value();
             if (pose > 5) {
                 // Added LONG_JUMP at 6
-                meta.setValue(pose + 1);
+                data.setValue(pose + 1);
             }
         });
         registerEntityDataTypeHandler(Types1_17.ENTITY_DATA_TYPES.itemType, Types1_17.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_17.ENTITY_DATA_TYPES.particleType);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_17_1to1_18/rewriter/EntityPacketRewriter1_18.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_17_1to1_18/rewriter/EntityPacketRewriter1_18.java
@@ -82,8 +82,8 @@ public final class EntityPacketRewriter1_18 extends EntityRewriter<ClientboundPa
     @Override
     protected void registerRewrites() {
         filter().mapDataType(Types1_18.ENTITY_DATA_TYPES::byId);
-        filter().dataType(Types1_18.ENTITY_DATA_TYPES.particleType).handler((event, meta) -> {
-            final Particle particle = (Particle) meta.getValue();
+        filter().dataType(Types1_18.ENTITY_DATA_TYPES.particleType).handler((event, data) -> {
+            final Particle particle = (Particle) data.getValue();
             if (particle.id() == 2) { // Barrier
                 particle.setId(3); // Block marker
                 particle.add(Types.VAR_INT, 7754); // Barrier state

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
@@ -115,13 +115,13 @@ public final class EntityPacketRewriter1_19 extends EntityRewriter<ClientboundPa
                     wrapper.send(Protocol1_18_2To1_19.class);
                     wrapper.cancel();
 
-                    // Send motive in metadata
-                    final PacketWrapper metaPacket = wrapper.create(ClientboundPackets1_19.SET_ENTITY_DATA);
-                    metaPacket.write(Types.VAR_INT, wrapper.get(Types.VAR_INT, 0)); // Entity id
-                    final List<EntityData> metadata = new ArrayList<>();
-                    metadata.add(new EntityData(8, Types1_19.ENTITY_DATA_TYPES.paintingVariantType, protocol.getMappingData().getPaintingMappings().getNewIdOrDefault(motive, 0)));
-                    metaPacket.write(Types1_19.ENTITY_DATA_LIST, metadata);
-                    metaPacket.send(Protocol1_18_2To1_19.class);
+                    // Send motive in entity data
+                    final PacketWrapper entityDataPacket = wrapper.create(ClientboundPackets1_19.SET_ENTITY_DATA);
+                    entityDataPacket.write(Types.VAR_INT, wrapper.get(Types.VAR_INT, 0)); // Entity id
+                    final List<EntityData> entityData = new ArrayList<>();
+                    entityData.add(new EntityData(8, Types1_19.ENTITY_DATA_TYPES.paintingVariantType, protocol.getMappingData().getPaintingMappings().getNewIdOrDefault(motive, 0)));
+                    entityDataPacket.write(Types1_19.ENTITY_DATA_LIST, entityData);
+                    entityDataPacket.send(Protocol1_18_2To1_19.class);
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
@@ -317,8 +317,8 @@ public final class EntityPacketRewriter1_19 extends EntityRewriter<ClientboundPa
     @Override
     protected void registerRewrites() {
         filter().mapDataType(Types1_19.ENTITY_DATA_TYPES::byId);
-        filter().dataType(Types1_19.ENTITY_DATA_TYPES.particleType).handler((event, meta) -> {
-            final Particle particle = (Particle) meta.getValue();
+        filter().dataType(Types1_19.ENTITY_DATA_TYPES.particleType).handler((event, data) -> {
+            final Particle particle = (Particle) data.getValue();
             final ParticleMappings particleMappings = protocol.getMappingData().getParticleMappings();
             if (particle.id() == particleMappings.id("vibration")) {
                 // Remove the position

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_1to1_19_3/rewriter/EntityPacketRewriter1_19_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_1to1_19_3/rewriter/EntityPacketRewriter1_19_3.java
@@ -155,11 +155,11 @@ public final class EntityPacketRewriter1_19_3 extends EntityRewriter<Clientbound
         registerEntityDataTypeHandler(Types1_19_3.ENTITY_DATA_TYPES.itemType, Types1_19_3.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_19_3.ENTITY_DATA_TYPES.particleType);
         registerBlockStateHandler(EntityTypes1_19_3.ABSTRACT_MINECART, 11);
 
-        filter().type(EntityTypes1_19_3.ENTITY).index(6).handler((event, meta) -> {
+        filter().type(EntityTypes1_19_3.ENTITY).index(6).handler((event, data) -> {
             // Sitting pose added
-            final int pose = meta.value();
+            final int pose = data.value();
             if (pose >= 10) {
-                meta.setValue(pose + 1);
+                data.setValue(pose + 1);
             }
         });
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/rewriter/EntityPacketRewriter1_19_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/rewriter/EntityPacketRewriter1_19_4.java
@@ -223,10 +223,10 @@ public final class EntityPacketRewriter1_19_4 extends EntityRewriter<Clientbound
         registerEntityDataTypeHandler(Types1_19_4.ENTITY_DATA_TYPES.itemType, Types1_19_4.ENTITY_DATA_TYPES.blockStateType, Types1_19_4.ENTITY_DATA_TYPES.optionalBlockStateType, Types1_19_4.ENTITY_DATA_TYPES.particleType, null);
         registerBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART, 11);
 
-        filter().type(EntityTypes1_19_4.BOAT).index(11).handler((event, meta) -> {
-            final int boatType = meta.value();
+        filter().type(EntityTypes1_19_4.BOAT).index(11).handler((event, data) -> {
+            final int boatType = data.value();
             if (boatType > 4) { // Cherry added
-                meta.setValue(boatType + 1);
+                data.setValue(boatType + 1);
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_4to1_20/rewriter/EntityPacketRewriter1_20.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_4to1_20/rewriter/EntityPacketRewriter1_20.java
@@ -132,7 +132,7 @@ public final class EntityPacketRewriter1_20 extends EntityRewriter<ClientboundPa
         registerBlockStateHandler(EntityTypes1_19_4.ABSTRACT_MINECART, 11);
 
         // Rotate item display by 180 degrees around the Y axis
-        filter().type(EntityTypes1_19_4.ITEM_DISPLAY).handler((event, meta) -> {
+        filter().type(EntityTypes1_19_4.ITEM_DISPLAY).handler((event, data) -> {
             if (event.trackedEntity().hasSentEntityData() || event.hasExtraData()) {
                 return;
             }
@@ -141,9 +141,9 @@ public final class EntityPacketRewriter1_20 extends EntityRewriter<ClientboundPa
                 event.createExtraData(new EntityData(12, Types1_20.ENTITY_DATA_TYPES.quaternionType, Y_FLIPPED_ROTATION));
             }
         });
-        filter().type(EntityTypes1_19_4.ITEM_DISPLAY).index(12).handler((event, meta) -> {
-            final Quaternion quaternion = meta.value();
-            meta.setValue(rotateY180(quaternion));
+        filter().type(EntityTypes1_19_4.ITEM_DISPLAY).index(12).handler((event, data) -> {
+            final Quaternion quaternion = data.value();
+            data.setValue(rotateY180(quaternion));
         });
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/EntityPacketRewriter1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/EntityPacketRewriter1_20_3.java
@@ -103,14 +103,14 @@ public final class EntityPacketRewriter1_20_3 extends EntityRewriter<Clientbound
 
     @Override
     protected void registerRewrites() {
-        filter().handler((event, meta) -> {
-            final EntityDataType type = meta.dataType();
+        filter().handler((event, data) -> {
+            final EntityDataType type = data.dataType();
             if (type == Types1_20_2.ENTITY_DATA_TYPES.componentType) {
-                meta.setTypeAndValue(Types1_20_3.ENTITY_DATA_TYPES.componentType, ComponentUtil.jsonToTag(meta.value()));
+                data.setTypeAndValue(Types1_20_3.ENTITY_DATA_TYPES.componentType, ComponentUtil.jsonToTag(data.value()));
             } else if (type == Types1_20_2.ENTITY_DATA_TYPES.optionalComponentType) {
-                meta.setTypeAndValue(Types1_20_3.ENTITY_DATA_TYPES.optionalComponentType, ComponentUtil.jsonToTag(meta.value()));
+                data.setTypeAndValue(Types1_20_3.ENTITY_DATA_TYPES.optionalComponentType, ComponentUtil.jsonToTag(data.value()));
             } else {
-                meta.setDataType(Types1_20_3.ENTITY_DATA_TYPES.byId(type.typeId()));
+                data.setDataType(Types1_20_3.ENTITY_DATA_TYPES.byId(type.typeId()));
             }
         });
         filter().dataType(Types1_20_3.ENTITY_DATA_TYPES.particleType).handler((event, meta) -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/EntityPacketRewriter1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/EntityPacketRewriter1_20_3.java
@@ -113,8 +113,8 @@ public final class EntityPacketRewriter1_20_3 extends EntityRewriter<Clientbound
                 data.setDataType(Types1_20_3.ENTITY_DATA_TYPES.byId(type.typeId()));
             }
         });
-        filter().dataType(Types1_20_3.ENTITY_DATA_TYPES.particleType).handler((event, meta) -> {
-            final Particle particle = meta.value();
+        filter().dataType(Types1_20_3.ENTITY_DATA_TYPES.particleType).handler((event, data) -> {
+            final Particle particle = data.value();
             final ParticleMappings particleMappings = protocol.getMappingData().getParticleMappings();
             if (particle.id() == particleMappings.id("vibration")) {
                 // Change the type of the resource key argument

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
@@ -432,13 +432,13 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
         });
 
         filter().type(EntityTypes1_20_5.LLAMA).removeIndex(20); // Carpet color
-        filter().type(EntityTypes1_20_5.AREA_EFFECT_CLOUD).handler((event, meta) -> {
+        filter().type(EntityTypes1_20_5.AREA_EFFECT_CLOUD).handler((event, data) -> {
             // Color removed - Now put into the actual particle
-            final int metaIndex = event.index();
-            if (metaIndex == 9) {
+            final int dataIndex = event.index();
+            if (dataIndex == 9) {
                 // If the color is found first
                 final EntityData particleData = event.dataAtIndex(11);
-                final int color = meta.value();
+                final int color = data.value();
                 if (particleData == null) {
                     if (color != 0) {
                         // Add default particle with data
@@ -454,23 +454,23 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
                 return;
             }
 
-            if (metaIndex > 9) {
-                event.setIndex(metaIndex - 1);
+            if (dataIndex > 9) {
+                event.setIndex(dataIndex - 1);
             }
 
-            if (metaIndex == 11) {
+            if (dataIndex == 11) {
                 // If the particle is found first
                 final EntityData colorData = event.dataAtIndex(9);
                 if (colorData != null && colorData.dataType() == Types1_20_5.ENTITY_DATA_TYPES.varIntType) {
-                    addColor(meta, colorData.value());
+                    addColor(data, colorData.value());
                 }
             }
         });
 
-        filter().type(EntityTypes1_20_5.ARROW).index(10).handler((event, meta) -> {
-            final int color = meta.value();
+        filter().type(EntityTypes1_20_5.ARROW).index(10).handler((event, data) -> {
+            final int color = data.value();
             if (color != -1) {
-                meta.setValue(withAlpha(color));
+                data.setValue(withAlpha(color));
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
@@ -418,17 +418,17 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
         );
         registerBlockStateHandler(EntityTypes1_20_5.ABSTRACT_MINECART, 11);
 
-        filter().type(EntityTypes1_20_5.LIVING_ENTITY).index(10).handler((event, meta) -> {
-            final int effectColor = meta.value();
+        filter().type(EntityTypes1_20_5.LIVING_ENTITY).index(10).handler((event, data) -> {
+            final int effectColor = data.value();
             if (effectColor == 0) {
                 // No effect
-                meta.setTypeAndValue(Types1_20_5.ENTITY_DATA_TYPES.particlesType, new Particle[0]);
+                data.setTypeAndValue(Types1_20_5.ENTITY_DATA_TYPES.particlesType, new Particle[0]);
                 return;
             }
 
             final Particle particle = new Particle(protocol.getMappingData().getParticleMappings().mappedId("entity_effect"));
             particle.add(Types.INT, withAlpha(effectColor));
-            meta.setTypeAndValue(Types1_20_5.ENTITY_DATA_TYPES.particlesType, new Particle[]{particle});
+            data.setTypeAndValue(Types1_20_5.ENTITY_DATA_TYPES.particlesType, new Particle[]{particle});
         });
 
         filter().type(EntityTypes1_20_5.LLAMA).removeIndex(20); // Carpet color

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/EntityDataIndex1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/EntityDataIndex1_9.java
@@ -255,10 +255,10 @@ public enum EntityDataIndex1_9 {
     public static EntityDataIndex1_9 searchIndex(EntityType type, int index) {
         EntityType currentType = type;
         do {
-            Optional<EntityDataIndex1_9> optMeta = getIndex(currentType, index);
+            Optional<EntityDataIndex1_9> optData = getIndex(currentType, index);
 
-            if (optMeta.isPresent()) {
-                return optMeta.get();
+            if (optData.isPresent()) {
+                return optData.get();
             }
 
             currentType = currentType.getParent();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/EntityDataIndex1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/data/EntityDataIndex1_9.java
@@ -189,11 +189,11 @@ public enum EntityDataIndex1_9 {
     // Ender dragon
     ENDER_DRAGON_PHASE(ENDER_DRAGON, 11, EntityDataTypes1_9.VAR_INT);
 
-    private static final HashMap<Pair<EntityTypes1_9.EntityType, Integer>, EntityDataIndex1_9> metadataRewrites = new HashMap<>();
+    private static final HashMap<Pair<EntityTypes1_9.EntityType, Integer>, EntityDataIndex1_9> entityDataRewriters = new HashMap<>();
 
     static {
         for (EntityDataIndex1_9 index : EntityDataIndex1_9.values()) {
-            metadataRewrites.put(new Pair<>(index.clazz, index.index), index);
+            entityDataRewriters.put(new Pair<>(index.clazz, index.index), index);
         }
     }
 
@@ -249,7 +249,7 @@ public enum EntityDataIndex1_9 {
 
     private static Optional<EntityDataIndex1_9> getIndex(EntityType type, int index) {
         Pair pair = new Pair<>(type, index);
-        return Optional.ofNullable(metadataRewrites.get(pair));
+        return Optional.ofNullable(entityDataRewriters.get(pair));
     }
 
     public static EntityDataIndex1_9 searchIndex(EntityType type, int index) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/EntityPacketRewriter1_9.java
@@ -222,7 +222,7 @@ public class EntityPacketRewriter1_9 extends EntityRewriter<ClientboundPackets1_
                     }
                 });
 
-                // Handler for meta data
+                // Handler for entity data
                 handler(wrapper -> {
                     List<EntityData> entityDataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
                     int entityID = wrapper.get(Types.VAR_INT, 0);
@@ -425,8 +425,8 @@ public class EntityPacketRewriter1_9 extends EntityRewriter<ClientboundPackets1_
                         val = 1;
                     }
                     int newIndex = EntityDataIndex1_9.PLAYER_HAND.getNewIndex();
-                    EntityDataType metaType = EntityDataIndex1_9.PLAYER_HAND.getNewType();
-                    event.createExtraData(new EntityData(newIndex, metaType, val));
+                    EntityDataType dataType = EntityDataIndex1_9.PLAYER_HAND.getNewType();
+                    event.createExtraData(new EntityData(newIndex, dataType, val));
                 }
                 break;
             case OPTIONAL_UUID:

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/SpawnPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/SpawnPacketRewriter1_9.java
@@ -203,7 +203,7 @@ public class SpawnPacketRewriter1_9 {
                         entityDataList.clear();
                     }
                 });
-                // Handler for meta data
+                // Handler for entity data
                 handler(wrapper -> {
                     List<EntityData> entityDataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
                     int entityID = wrapper.get(Types.VAR_INT, 0);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/SpawnPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/SpawnPacketRewriter1_9.java
@@ -100,20 +100,20 @@ public class SpawnPacketRewriter1_9 {
 
                     int typeID = wrapper.get(Types.BYTE, 0);
                     if (EntityTypes1_8.getTypeFromId(typeID, true) == EntityTypes1_8.EntityType.POTION) {
-                        // Convert this to meta data, woo!
-                        PacketWrapper metaPacket = wrapper.create(ClientboundPackets1_9.SET_ENTITY_DATA, wrapper1 -> {
+                        // Convert this to entity data, woo!
+                        PacketWrapper entityDataPacket = wrapper.create(ClientboundPackets1_9.SET_ENTITY_DATA, wrapper1 -> {
                             wrapper1.write(Types.VAR_INT, entityID);
-                            List<EntityData> meta = new ArrayList<>();
+                            List<EntityData> entityData = new ArrayList<>();
                             Item item = new DataItem(373, (byte) 1, (short) data, null); // Potion
                             protocol.getItemRewriter().handleItemToClient(wrapper.user(), item); // Rewrite so that it gets the right nbt
                             // TEMP FIX FOR POTIONS UNTIL WE FIGURE OUT HOW TO TRANSFORM SENT PACKETS
                             EntityData potion = new EntityData(5, EntityDataTypes1_9.ITEM, item);
-                            meta.add(potion);
-                            wrapper1.write(Types1_9.ENTITY_DATA_LIST, meta);
+                            entityData.add(potion);
+                            wrapper1.write(Types1_9.ENTITY_DATA_LIST, entityData);
                         });
                         // Fix packet order
                         wrapper.send(Protocol1_8To1_9.class);
-                        metaPacket.send(Protocol1_8To1_9.class);
+                        entityDataPacket.send(Protocol1_8To1_9.class);
                         wrapper.cancel();
                     }
                 });
@@ -193,22 +193,22 @@ public class SpawnPacketRewriter1_9 {
 
                 map(Types1_8.ENTITY_DATA_LIST, Types1_9.ENTITY_DATA_LIST);
                 handler(wrapper -> {
-                    List<EntityData> metadataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
+                    List<EntityData> entityDataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
                     int entityId = wrapper.get(Types.VAR_INT, 0);
                     EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
                     if (tracker.hasEntity(entityId)) {
-                        protocol.getEntityRewriter().handleEntityData(entityId, metadataList, wrapper.user());
+                        protocol.getEntityRewriter().handleEntityData(entityId, entityDataList, wrapper.user());
                     } else {
-                        protocol.getLogger().warning("Unable to find entity for metadata, entity ID: " + entityId);
-                        metadataList.clear();
+                        protocol.getLogger().warning("Unable to find entity for entity data, entity ID: " + entityId);
+                        entityDataList.clear();
                     }
                 });
                 // Handler for meta data
                 handler(wrapper -> {
-                    List<EntityData> metadataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
+                    List<EntityData> entityDataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
                     int entityID = wrapper.get(Types.VAR_INT, 0);
                     EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
-                    tracker.handleMetadata(entityID, metadataList);
+                    tracker.handleEntityData(entityID, entityDataList);
                 });
             }
         });
@@ -271,23 +271,23 @@ public class SpawnPacketRewriter1_9 {
                 map(Types1_8.ENTITY_DATA_LIST, Types1_9.ENTITY_DATA_LIST);
 
                 handler(wrapper -> {
-                    List<EntityData> metadataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
+                    List<EntityData> entityDataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
                     int entityId = wrapper.get(Types.VAR_INT, 0);
                     EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
                     if (tracker.hasEntity(entityId)) {
-                        protocol.getEntityRewriter().handleEntityData(entityId, metadataList, wrapper.user());
+                        protocol.getEntityRewriter().handleEntityData(entityId, entityDataList, wrapper.user());
                     } else {
-                        protocol.getLogger().warning("Unable to find entity for metadata, entity ID: " + entityId);
-                        metadataList.clear();
+                        protocol.getLogger().warning("Unable to find entity for entity data, entity ID: " + entityId);
+                        entityDataList.clear();
                     }
                 });
 
-                // Handler for meta data
+                // Handler for entity data
                 handler(wrapper -> {
-                    List<EntityData> metadataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
+                    List<EntityData> entityDataList = wrapper.get(Types1_9.ENTITY_DATA_LIST, 0);
                     int entityID = wrapper.get(Types.VAR_INT, 0);
                     EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
-                    tracker.handleMetadata(entityID, metadataList);
+                    tracker.handleEntityData(entityID, entityDataList);
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
@@ -164,7 +164,7 @@ public class EntityTracker1_9 extends EntityTrackerBase {
 
         for (EntityData entityData : new ArrayList<>(entityDataList)) {
             if (type == EntityType.SKELETON) {
-                if ((getMetaByIndex(entityDataList, 12)) == null) {
+                if ((getDataByIndex(entityDataList, 12)) == null) {
                     entityDataList.add(new EntityData(12, EntityDataTypes1_9.BOOLEAN, true));
                 }
             }
@@ -204,15 +204,15 @@ public class EntityTracker1_9 extends EntityTrackerBase {
                 }
             }
             if (type == EntityType.ARMOR_STAND && Via.getConfig().isHologramPatch()) {
-                if (entityData.id() == 0 && getMetaByIndex(entityDataList, 10) != null) {
-                    EntityData meta = getMetaByIndex(entityDataList, 10); //Only happens if the armorstand is small
-                    byte data = (byte) entityData.getValue();
+                if (entityData.id() == 0 && getDataByIndex(entityDataList, 10) != null) {
+                    EntityData data = getDataByIndex(entityDataList, 10); //Only happens if the armorstand is small
+                    byte value = (byte) entityData.getValue();
                     // Check invisible | Check small | Check if custom name is empty | Check if custom name visible is true
                     EntityData displayName;
                     EntityData displayNameVisible;
-                    if ((data & 0x20) == 0x20 && ((byte) meta.getValue() & 0x01) == 0x01
-                        && (displayName = getMetaByIndex(entityDataList, 2)) != null && !((String) displayName.getValue()).isEmpty()
-                        && (displayNameVisible = getMetaByIndex(entityDataList, 3)) != null && (boolean) displayNameVisible.getValue()) {
+                    if ((value & 0x20) == 0x20 && ((byte) data.getValue() & 0x01) == 0x01
+                        && (displayName = getDataByIndex(entityDataList, 2)) != null && !((String) displayName.getValue()).isEmpty()
+                        && (displayNameVisible = getDataByIndex(entityDataList, 3)) != null && (boolean) displayNameVisible.getValue()) {
                         if (!knownHolograms.contains(entityId)) {
                             knownHolograms.add(entityId);
                             // Send movement
@@ -267,10 +267,10 @@ public class EntityTracker1_9 extends EntityTrackerBase {
         }
     }
 
-    public EntityData getMetaByIndex(List<EntityData> list, int index) {
-        for (EntityData meta : list)
-            if (index == meta.id()) {
-                return meta;
+    public EntityData getDataByIndex(List<EntityData> list, int index) {
+        for (EntityData data : list)
+            if (index == data.id()) {
+                return data;
             }
         return null;
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
@@ -156,32 +156,32 @@ public class EntityTracker1_9 extends EntityTrackerBase {
         blockInteractions.add(p);
     }
 
-    public void handleMetadata(int entityId, List<EntityData> metadataList) {
+    public void handleEntityData(int entityId, List<EntityData> entityDataList) {
         com.viaversion.viaversion.api.minecraft.entities.EntityType type = entityType(entityId);
         if (type == null) {
             return;
         }
 
-        for (EntityData metadata : new ArrayList<>(metadataList)) {
+        for (EntityData entityData : new ArrayList<>(entityDataList)) {
             if (type == EntityType.SKELETON) {
-                if ((getMetaByIndex(metadataList, 12)) == null) {
-                    metadataList.add(new EntityData(12, EntityDataTypes1_9.BOOLEAN, true));
+                if ((getMetaByIndex(entityDataList, 12)) == null) {
+                    entityDataList.add(new EntityData(12, EntityDataTypes1_9.BOOLEAN, true));
                 }
             }
 
             // 1.8 can handle out of range values and will just not show any armor, 1.9+ clients will get
             // exceptions and won't render the entity at all
-            if (type == EntityType.HORSE && metadata.id() == 16) {
-                final int value = metadata.value();
+            if (type == EntityType.HORSE && entityData.id() == 16) {
+                final int value = entityData.value();
                 if (value < 0 || value > 3) { // no armor, iron armor, gold armor and diamond armor
-                    metadata.setValue(0);
+                    entityData.setValue(0);
                 }
             }
 
             if (type == EntityType.PLAYER) {
-                if (metadata.id() == 0) {
+                if (entityData.id() == 0) {
                     // Byte
-                    byte data = (byte) metadata.getValue();
+                    byte data = (byte) entityData.getValue();
                     if (entityId != getProvidedEntityId() && Via.getConfig().isShieldBlocking()) {
                         if ((data & 0x10) == 0x10) {
                             if (validBlocking.contains(entityId)) {
@@ -195,24 +195,24 @@ public class EntityTracker1_9 extends EntityTrackerBase {
                         }
                     }
                 }
-                if (metadata.id() == 12 && Via.getConfig().isLeftHandedHandling()) { // Player model
-                    metadataList.add(new EntityData(
+                if (entityData.id() == 12 && Via.getConfig().isLeftHandedHandling()) { // Player model
+                    entityDataList.add(new EntityData(
                         13, // Main hand
                         EntityDataTypes1_9.BYTE,
-                        (byte) (((((byte) metadata.getValue()) & 0x80) != 0) ? 0 : 1)
+                        (byte) (((((byte) entityData.getValue()) & 0x80) != 0) ? 0 : 1)
                     ));
                 }
             }
             if (type == EntityType.ARMOR_STAND && Via.getConfig().isHologramPatch()) {
-                if (metadata.id() == 0 && getMetaByIndex(metadataList, 10) != null) {
-                    EntityData meta = getMetaByIndex(metadataList, 10); //Only happens if the armorstand is small
-                    byte data = (byte) metadata.getValue();
+                if (entityData.id() == 0 && getMetaByIndex(entityDataList, 10) != null) {
+                    EntityData meta = getMetaByIndex(entityDataList, 10); //Only happens if the armorstand is small
+                    byte data = (byte) entityData.getValue();
                     // Check invisible | Check small | Check if custom name is empty | Check if custom name visible is true
                     EntityData displayName;
                     EntityData displayNameVisible;
                     if ((data & 0x20) == 0x20 && ((byte) meta.getValue() & 0x01) == 0x01
-                        && (displayName = getMetaByIndex(metadataList, 2)) != null && !((String) displayName.getValue()).isEmpty()
-                        && (displayNameVisible = getMetaByIndex(metadataList, 3)) != null && (boolean) displayNameVisible.getValue()) {
+                        && (displayName = getMetaByIndex(entityDataList, 2)) != null && !((String) displayName.getValue()).isEmpty()
+                        && (displayNameVisible = getMetaByIndex(entityDataList, 3)) != null && (boolean) displayNameVisible.getValue()) {
                         if (!knownHolograms.contains(entityId)) {
                             knownHolograms.add(entityId);
                             // Send movement
@@ -230,9 +230,9 @@ public class EntityTracker1_9 extends EntityTrackerBase {
             // Boss bar
             if (Via.getConfig().isBossbarPatch()) {
                 if (type == EntityType.ENDER_DRAGON || type == EntityType.WITHER) {
-                    if (metadata.id() == 2) {
+                    if (entityData.id() == 2) {
                         BossBar bar = bossBarMap.get(entityId);
-                        String title = (String) metadata.getValue();
+                        String title = (String) entityData.getValue();
                         title = title.isEmpty() ? (type == EntityType.ENDER_DRAGON ? DRAGON_TRANSLATABLE : WITHER_TRANSLATABLE) : title;
                         if (bar == null) {
                             bar = Via.getAPI().legacyAPI().createLegacyBossBar(title, BossColor.PINK, BossStyle.SOLID);
@@ -245,11 +245,11 @@ public class EntityTracker1_9 extends EntityTrackerBase {
                         } else {
                             bar.setTitle(title);
                         }
-                    } else if (metadata.id() == 6 && !Via.getConfig().isBossbarAntiflicker()) { // If anti flicker is enabled, don't update health
+                    } else if (entityData.id() == 6 && !Via.getConfig().isBossbarAntiflicker()) { // If anti flicker is enabled, don't update health
                         BossBar bar = bossBarMap.get(entityId);
                         // Make health range between 0 and 1
                         float maxHealth = type == EntityType.ENDER_DRAGON ? 200.0f : 300.0f;
-                        float health = Math.max(0.0f, Math.min(((float) metadata.getValue()) / maxHealth, 1.0f));
+                        float health = Math.max(0.0f, Math.min(((float) entityData.getValue()) / maxHealth, 1.0f));
                         if (bar == null) {
                             String title = type == EntityType.ENDER_DRAGON ? DRAGON_TRANSLATABLE : WITHER_TRANSLATABLE;
                             bar = Via.getAPI().legacyAPI().createLegacyBossBar(title, health, BossColor.PINK, BossStyle.SOLID);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_9_3to1_10/Protocol1_9_3To1_10.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_9_3to1_10/Protocol1_9_3To1_10.java
@@ -46,15 +46,15 @@ public class Protocol1_9_3To1_10 extends AbstractProtocol<ClientboundPackets1_9_
             return inputValue / 63.0F;
         }
     };
-    public static final ValueTransformer<List<EntityData>, List<EntityData>> TRANSFORM_METADATA = new ValueTransformer<>(Types1_9.ENTITY_DATA_LIST) {
+    public static final ValueTransformer<List<EntityData>, List<EntityData>> TRANSFORM_ENTITY_DATA = new ValueTransformer<>(Types1_9.ENTITY_DATA_LIST) {
         @Override
         public List<EntityData> transform(PacketWrapper wrapper, List<EntityData> inputValue) {
-            List<EntityData> metaList = new CopyOnWriteArrayList<>(inputValue);
-            for (EntityData m : metaList) {
-                if (m.id() >= 5)
-                    m.setId(m.id() + 1);
+            List<EntityData> dataList = new CopyOnWriteArrayList<>(inputValue);
+            for (EntityData data : dataList) {
+                if (data.id() >= 5)
+                    data.setId(data.id() + 1);
             }
-            return metaList;
+            return dataList;
         }
     };
     private final ItemPacketRewriter1_10 itemRewriter = new ItemPacketRewriter1_10(this);
@@ -100,12 +100,12 @@ public class Protocol1_9_3To1_10 extends AbstractProtocol<ClientboundPackets1_9_
             }
         });
 
-        // Metadata packet
+        // Entity data packet
         registerClientbound(ClientboundPackets1_9_3.SET_ENTITY_DATA, new PacketHandlers() {
             @Override
             public void register() {
                 map(Types.VAR_INT); // 0 - Entity ID
-                map(Types1_9.ENTITY_DATA_LIST, TRANSFORM_METADATA); // 1 - Metadata list
+                map(Types1_9.ENTITY_DATA_LIST, TRANSFORM_ENTITY_DATA); // 1 - Entity data list
             }
         });
 
@@ -125,7 +125,7 @@ public class Protocol1_9_3To1_10 extends AbstractProtocol<ClientboundPackets1_9_
                 map(Types.SHORT); // 9 - Velocity X
                 map(Types.SHORT); // 10 - Velocity Y
                 map(Types.SHORT); // 11 - Velocity Z
-                map(Types1_9.ENTITY_DATA_LIST, TRANSFORM_METADATA); // 12 - Metadata
+                map(Types1_9.ENTITY_DATA_LIST, TRANSFORM_ENTITY_DATA); // 12 - Entity data
             }
         });
 
@@ -140,7 +140,7 @@ public class Protocol1_9_3To1_10 extends AbstractProtocol<ClientboundPackets1_9_
                 map(Types.DOUBLE); // 4 - Z
                 map(Types.BYTE); // 5 - Yaw
                 map(Types.BYTE); // 6 - Pitch
-                map(Types1_9.ENTITY_DATA_LIST, TRANSFORM_METADATA); // 7 - Metadata list
+                map(Types1_9.ENTITY_DATA_LIST, TRANSFORM_ENTITY_DATA); // 7 - Entity data list
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataFilter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataFilter.java
@@ -31,7 +31,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
                                @Nullable EntityDataType dataType, int index, EntityDataHandler handler) {
 
     public EntityDataFilter {
-        Preconditions.checkNotNull(handler, "MetaHandler cannot be null");
+        Preconditions.checkNotNull(handler, "EntityDataHandler cannot be null");
     }
 
     /**
@@ -84,7 +84,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
      *
      * @param type     entity type
      * @param entityData entityData
-     * @return whether the meta should be filtered
+     * @return whether the data should be filtered
      */
     public boolean isFiltered(@Nullable EntityType type, EntityData entityData) {
         // Check if no specific index is filtered or the indexes are equal
@@ -212,10 +212,10 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
         }
 
         public void mapDataType(Int2ObjectFunction<EntityDataType> updateFunction) {
-            handler((event, meta) -> {
-                EntityDataType mappedType = updateFunction.apply(meta.dataType().typeId());
+            handler((event, data) -> {
+                EntityDataType mappedType = updateFunction.apply(data.dataType().typeId());
                 if (mappedType != null) {
-                    meta.setDataType(mappedType);
+                    data.setDataType(mappedType);
                 } else {
                     event.cancel();
                 }
@@ -230,7 +230,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
          */
         public void cancel(int index) {
             this.index = index;
-            handler((event, meta) -> event.cancel());
+            handler((event, data) -> event.cancel());
         }
 
         /**
@@ -242,7 +242,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
          */
         public void toIndex(int newIndex) {
             Preconditions.checkArgument(this.index != -1);
-            handler((event, meta) -> event.setIndex(newIndex));
+            handler((event, data) -> event.setIndex(newIndex));
         }
 
         /**
@@ -254,7 +254,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
          */
         public void addIndex(int index) {
             Preconditions.checkArgument(this.index == -1);
-            handler((event, meta) -> {
+            handler((event, data) -> {
                 if (event.index() >= index) {
                     event.setIndex(event.index() + 1);
                 }
@@ -270,18 +270,18 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
          */
         public void removeIndex(int index) {
             Preconditions.checkArgument(this.index == -1);
-            handler((event, meta) -> {
-                int metaIndex = event.index();
-                if (metaIndex == index) {
+            handler((event, data) -> {
+                int dataIndex = event.index();
+                if (dataIndex == index) {
                     event.cancel();
-                } else if (metaIndex > index) {
-                    event.setIndex(metaIndex - 1);
+                } else if (dataIndex > index) {
+                    event.setIndex(dataIndex - 1);
                 }
             });
         }
 
         /**
-         * Creates and registers the created MetaFilter in the linked {@link EntityRewriter} instance.
+         * Creates and registers the created EntityDataFilter in the linked {@link EntityRewriter} instance.
          */
         public void register() {
             rewriter.registerFilter(build());

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataFilter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataFilter.java
@@ -35,9 +35,9 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
     }
 
     /**
-     * Returns the metadata index to filter, or -1.
+     * Returns the entity data index to filter, or -1.
      *
-     * @return metadata index, or -1 if unset
+     * @return entity data index, or -1 if unset
      */
     public int index() {
         return index;
@@ -62,9 +62,9 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
     }
 
     /**
-     * Returns the metadata handler.
+     * Returns the entity data handler.
      *
-     * @return metadata handler
+     * @return entity data handler
      */
     public EntityDataHandler handler() {
         return handler;
@@ -80,18 +80,18 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
     }
 
     /**
-     * Returns whether if the metadata should be handled by this filter.
+     * Returns whether if the entity data should be handled by this filter.
      *
      * @param type     entity type
-     * @param metadata metadata
+     * @param entityData entityData
      * @return whether the meta should be filtered
      */
-    public boolean isFiltered(@Nullable EntityType type, EntityData metadata) {
+    public boolean isFiltered(@Nullable EntityType type, EntityData entityData) {
         // Check if no specific index is filtered or the indexes are equal
         // Then check if the filter has no entity type or the type is equal to or part of the filtered parent type
-        return (this.index == -1 || metadata.id() == this.index)
+        return (this.index == -1 || entityData.id() == this.index)
             && (this.type == null || matchesType(type))
-            && (this.dataType == null || metadata.dataType() == this.dataType);
+            && (this.dataType == null || entityData.dataType() == this.dataType);
     }
 
     private boolean matchesType(EntityType type) {
@@ -156,7 +156,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
          * Sets the type to filter, including subtypes.
          * <p>
          * You should always register a type when accessing specific indexes,
-         * even if it is the base entity type, to avoid metadata from unregistered
+         * even if it is the base entity type, to avoid entity data from unregistered
          * entities causing issues.
          *
          * @param type entity type to filter
@@ -173,7 +173,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
          * Sets the type to filter, not including subtypes.
          * <p>
          * You should always register a type when accessing specific indexes,
-         * even if it is the base entity type, to avoid metadata from unregistered
+         * even if it is the base entity type, to avoid entity data from unregistered
          * entities causing issues.
          *
          * @param type exact entity type to filter
@@ -199,10 +199,10 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
         }
 
         /**
-         * Sets the metadata handler and registers the metadata filter.
+         * Sets the entity data handler and registers the entity data filter.
          * Should always be called last.
          *
-         * @param handler metadata handler
+         * @param handler entity data handler
          * @throws IllegalArgumentException if a handler has already been set
          */
         public void handler(EntityDataHandler handler) {
@@ -223,7 +223,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
         }
 
         /**
-         * Sets a handler to remove metadata at the given index without affecting any other indexes and registers the filter.
+         * Sets a handler to remove entity data at the given index without affecting any other indexes and registers the filter.
          * Should always be called last.
          *
          * @param index index to cancel
@@ -262,7 +262,7 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
         }
 
         /**
-         * Sets a handler to remove metadata at the given index, decrementing every index above it and registers the filter.
+         * Sets a handler to remove entity data at the given index, decrementing every index above it and registers the filter.
          * Should always be called last.
          *
          * @param index index to remove
@@ -288,9 +288,9 @@ public record EntityDataFilter(@Nullable EntityType type, boolean filterFamily,
         }
 
         /**
-         * Returns a new metadata filter without registering it.
+         * Returns a new entity data filter without registering it.
          *
-         * @return created meta filter
+         * @return created data filter
          */
         public EntityDataFilter build() {
             return new EntityDataFilter(type, filterFamily, dataType, index, handler);

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataHandlerEvent.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataHandlerEvent.java
@@ -27,7 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public interface EntityDataHandlerEvent {
 
     /**
-     * Returns the user connection the metadata is sent to.
+     * Returns the user connection the entity data is sent to.
      *
      * @return user connection
      */

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataHandlerEventImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataHandlerEventImpl.java
@@ -30,17 +30,17 @@ public class EntityDataHandlerEventImpl implements EntityDataHandlerEvent {
     private final UserConnection connection;
     private final TrackedEntity trackedEntity;
     private final int entityId;
-    private final List<EntityData> metadataList;
+    private final List<EntityData> dataList;
     private final EntityData meta;
     private List<EntityData> extraData;
     private boolean cancel;
 
-    public EntityDataHandlerEventImpl(UserConnection connection, @Nullable TrackedEntity trackedEntity, int entityId, EntityData meta, List<EntityData> metadataList) {
+    public EntityDataHandlerEventImpl(UserConnection connection, @Nullable TrackedEntity trackedEntity, int entityId, EntityData meta, List<EntityData> dataList) {
         this.connection = connection;
         this.trackedEntity = trackedEntity;
         this.entityId = entityId;
         this.meta = meta;
-        this.metadataList = metadataList;
+        this.dataList = dataList;
     }
 
     @Override
@@ -75,7 +75,7 @@ public class EntityDataHandlerEventImpl implements EntityDataHandlerEvent {
 
     @Override
     public @Nullable EntityData dataAtIndex(int index) {
-        for (EntityData meta : metadataList) {
+        for (EntityData meta : dataList) {
             if (index == meta.id()) {
                 return meta;
             }
@@ -85,7 +85,7 @@ public class EntityDataHandlerEventImpl implements EntityDataHandlerEvent {
 
     @Override
     public List<EntityData> dataList() {
-        return Collections.unmodifiableList(metadataList);
+        return Collections.unmodifiableList(dataList);
     }
 
     @Override
@@ -94,11 +94,11 @@ public class EntityDataHandlerEventImpl implements EntityDataHandlerEvent {
     }
 
     @Override
-    public void createExtraData(EntityData metadata) {
+    public void createExtraData(EntityData entityData) {
         if (extraData == null) {
             extraData = new ArrayList<>();
         }
 
-        extraData.add(metadata);
+        extraData.add(entityData);
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataHandlerEventImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/entitydata/EntityDataHandlerEventImpl.java
@@ -31,15 +31,15 @@ public class EntityDataHandlerEventImpl implements EntityDataHandlerEvent {
     private final TrackedEntity trackedEntity;
     private final int entityId;
     private final List<EntityData> dataList;
-    private final EntityData meta;
+    private final EntityData data;
     private List<EntityData> extraData;
     private boolean cancel;
 
-    public EntityDataHandlerEventImpl(UserConnection connection, @Nullable TrackedEntity trackedEntity, int entityId, EntityData meta, List<EntityData> dataList) {
+    public EntityDataHandlerEventImpl(UserConnection connection, @Nullable TrackedEntity trackedEntity, int entityId, EntityData data, List<EntityData> dataList) {
         this.connection = connection;
         this.trackedEntity = trackedEntity;
         this.entityId = entityId;
-        this.meta = meta;
+        this.data = data;
         this.dataList = dataList;
     }
 
@@ -60,7 +60,7 @@ public class EntityDataHandlerEventImpl implements EntityDataHandlerEvent {
 
     @Override
     public EntityData data() {
-        return meta;
+        return data;
     }
 
     @Override
@@ -75,9 +75,9 @@ public class EntityDataHandlerEventImpl implements EntityDataHandlerEvent {
 
     @Override
     public @Nullable EntityData dataAtIndex(int index) {
-        for (EntityData meta : dataList) {
-            if (index == meta.id()) {
-                return meta;
+        for (EntityData data : dataList) {
+            if (index == data.id()) {
+                return data;
             }
         }
         return null;

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -173,7 +173,7 @@ handle-invalid-item-count: false
 prevent-collision: true
 # If the above is true, should we automatically team players until you do?
 auto-team: true
-# When enabled if certain metadata can't be read, we won't tell you about it
+# When enabled if certain entity data can't be read, we won't tell you about it
 suppress-metadata-errors: false
 # When enabled, 1.9+ will be able to block by using shields
 shield-blocking: true


### PR DESCRIPTION
Fixes wrong field/method names in old protocols as well as javadoc. I skipped the config option for now because renaming it would be quite a breaking change.