### PR TITLE
Add several fixes using item data components

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -27,7 +27,6 @@ import com.viaversion.nbt.tag.NumberTag;
 import com.viaversion.nbt.tag.StringTag;
 import com.viaversion.nbt.tag.Tag;
 import com.viaversion.viaversion.api.Via;
-import com.viaversion.viaversion.api.connection.ProtocolInfo;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.ParticleMappings;
 import com.viaversion.viaversion.api.minecraft.GameProfile;
@@ -614,14 +613,14 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
     }
 
     private void appendItemDataFixComponents(final UserConnection connection, final Item item) {
-        final ProtocolInfo protocolInfo = connection.getProtocolInfo();
-        if (protocolInfo.serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_17_1)) {
+        final ProtocolVersion serverVersion = connection.getProtocolInfo().serverProtocolVersion();
+        if (serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_17_1)) {
             if (item.identifier() == 1182) { // crossbow
                 // Change crossbow damage to value used in 1.17.1 and lower
                 item.dataContainer().set(StructuredDataKey.MAX_DAMAGE, 326);
             }
         }
-        if (protocolInfo.serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
+        if (serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_8)) {
             if (item.identifier() == 814 || item.identifier() == 819 || item.identifier() == 824 || item.identifier() == 829 || item.identifier() == 834) { // swords
                 // Make sword "eatable" to enable clientside instant blocking on 1.8. Consume time is set really high, so the eating animation doesn't play
                 item.dataContainer().set(StructuredDataKey.FOOD1_20_5, new FoodProperties(0, 0F, true, 3600, null, new FoodEffect[0]));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -613,6 +613,11 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
     }
 
     private void appendItemDataFixComponents(final UserConnection connection, final Item item) {
+        if (connection.getProtocolInfo().serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_17_1)) {
+            if (item.identifier() == 1182) { // crossbow
+                item.dataContainer().set(StructuredDataKey.MAX_DAMAGE, 326);
+            }
+        }
         if (connection.getProtocolInfo().serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
             if (item.identifier() == 814 || item.identifier() == 819 || item.identifier() == 824 || item.identifier() == 829 || item.identifier() == 834) { // swords
                 item.dataContainer().set(StructuredDataKey.FOOD1_20_5, new FoodProperties(0, 0F, true, 3600, null, new FoodEffect[0]));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -75,6 +75,7 @@ import com.viaversion.viaversion.api.minecraft.item.data.ToolProperties;
 import com.viaversion.viaversion.api.minecraft.item.data.ToolRule;
 import com.viaversion.viaversion.api.minecraft.item.data.Unbreakable;
 import com.viaversion.viaversion.api.minecraft.item.data.WrittenBook;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_20_2;
 import com.viaversion.viaversion.api.type.types.version.Types1_20_3;
@@ -384,6 +385,8 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
         }
 
         final Item structuredItem = toStructuredItem(connection, item);
+        // Add data components to fix issues in older protocols
+        appendItemDataFixComponents(connection, structuredItem);
 
         if (Via.getConfig().handleInvalidItemCount()) {
             // Server can send amounts which are higher than vanilla's default, and 1.20.4 will still accept them,
@@ -407,7 +410,7 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
     }
 
     public Item toOldItem(final UserConnection connection, final Item item, final StructuredDataConverter dataConverter) {
-        // Start out with custom data and add the rest on top, or short-curcuit with the original item
+        // Start out with custom data and add the rest on top, or short-circuit with the original item
         final StructuredDataContainer data = item.dataContainer();
         data.setIdLookup(protocol, true);
 
@@ -607,6 +610,14 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
 
         data.set(StructuredDataKey.CUSTOM_DATA, tag);
         return item;
+    }
+
+    private void appendItemDataFixComponents(final UserConnection connection, final Item item) {
+        if (connection.getProtocolInfo().serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
+            if (item.identifier() == 814 || item.identifier() == 819 || item.identifier() == 824 || item.identifier() == 829 || item.identifier() == 834) { // swords
+                item.dataContainer().set(StructuredDataKey.FOOD1_20_5, new FoodProperties(0, 0F, true, 3600, null, new FoodEffect[0]));
+            }
+        }
     }
 
     private int unmappedItemId(final String name) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -27,6 +27,7 @@ import com.viaversion.nbt.tag.NumberTag;
 import com.viaversion.nbt.tag.StringTag;
 import com.viaversion.nbt.tag.Tag;
 import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.connection.ProtocolInfo;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.ParticleMappings;
 import com.viaversion.viaversion.api.minecraft.GameProfile;
@@ -613,13 +614,16 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
     }
 
     private void appendItemDataFixComponents(final UserConnection connection, final Item item) {
-        if (connection.getProtocolInfo().serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_17_1)) {
+        final ProtocolInfo protocolInfo = connection.getProtocolInfo();
+        if (protocolInfo.serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_17_1)) {
             if (item.identifier() == 1182) { // crossbow
+                // Change crossbow damage to value used in 1.17.1 and lower
                 item.dataContainer().set(StructuredDataKey.MAX_DAMAGE, 326);
             }
         }
-        if (connection.getProtocolInfo().serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
+        if (protocolInfo.serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
             if (item.identifier() == 814 || item.identifier() == 819 || item.identifier() == 824 || item.identifier() == 829 || item.identifier() == 834) { // swords
+                // Make sword "eatable" to enable clientside instant blocking on 1.8. Consume time is set really high, so the eating animation doesn't play
                 item.dataContainer().set(StructuredDataKey.FOOD1_20_5, new FoodProperties(0, 0F, true, 3600, null, new FoodEffect[0]));
             }
         }


### PR DESCRIPTION
This PR adds several fixes for older protocols using the new item data components.

This first fix adds instant sword blocking on 1.8 servers (It doesn't rely on inventory tracking and thus always works and has zero delay). The consume time has been set to the same value a 1.8 client uses (3600 seconds). The fix has been tested on a 1.8 server and works with or without the old shield blocking fix.

The second fix changes the crossbow max damage on <= 1.17.1 servers to fix desynced visuals on newer clients.