### PR TITLE
Fix respawn "keep data" translation

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
@@ -24,6 +24,7 @@ import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_16;
 import com.viaversion.viaversion.api.minecraft.entitydata.EntityData;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.version.Types1_14;
 import com.viaversion.viaversion.api.type.types.version.Types1_16;
@@ -119,10 +120,13 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
                 handler(wrapper -> {
                     wrapper.write(Types.BYTE, (byte) -1); // Previous gamemode, set to none
 
+                    // <= 1.14.4 didn't keep attributes on respawn and 1.15.x always kept them
+                    final boolean keepAttributes = wrapper.user().getProtocolInfo().serverProtocolVersion().newerThanOrEqualTo(ProtocolVersion.v1_15);
+
                     String levelType = wrapper.read(Types.STRING);
                     wrapper.write(Types.BOOLEAN, false); // debug
                     wrapper.write(Types.BOOLEAN, levelType.equals("flat"));
-                    wrapper.write(Types.BOOLEAN, true); // keep all playerdata
+                    wrapper.write(Types.BOOLEAN, keepAttributes); // keep player attributes
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
@@ -26,8 +26,8 @@ import com.viaversion.nbt.tag.NumberTag;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.data.ParticleMappings;
 import com.viaversion.viaversion.api.data.entity.DimensionData;
-import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.minecraft.BlockPosition;
+import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19;
 import com.viaversion.viaversion.api.minecraft.entitydata.EntityData;
@@ -227,7 +227,7 @@ public final class EntityPacketRewriter1_19 extends EntityRewriter<ClientboundPa
                 map(Types.BYTE); // Previous gamemode
                 map(Types.BOOLEAN); // Debug
                 map(Types.BOOLEAN); // Flat
-                map(Types.BOOLEAN); // Keep player data
+                map(Types.BOOLEAN); // Keep player attributes
                 create(Types.OPTIONAL_GLOBAL_POSITION, null); // Last death location
                 handler(worldDataTrackerHandlerByKey());
             }


### PR DESCRIPTION
1.14.4 and below never kept player attributes when respawning and 1.15.x always kept them