### PR TITLE
Validate index when reading structured data type

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/item/StructuredDataType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/item/StructuredDataType.java
@@ -50,7 +50,7 @@ public class StructuredDataType extends Type<StructuredData<?>> {
     public StructuredData<?> read(final ByteBuf buffer) {
         Preconditions.checkNotNull(types, "StructuredDataType has not been initialized");
         final int id = Types.VAR_INT.readPrimitive(buffer);
-        final StructuredDataKey<?> key = this.types[id];
+        final StructuredDataKey<?> key = key(id);
         if (key == null) {
             throw new IllegalArgumentException("No data component serializer found for id " + id);
         }


### PR DESCRIPTION
Ensures the proper exception is thrown when the server sends an out-of-bounds value, MC performs the same logic.