### PR TITLE
Allow base protocols to set client version

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/version/VersionProvider.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/version/VersionProvider.java
@@ -29,6 +29,17 @@ import com.viaversion.viaversion.api.platform.providers.Provider;
 public interface VersionProvider extends Provider {
 
     /**
+     * Optionally allows platforms to specify the client version of a user. This is needed when the platform supports
+     * connecting other version types then {@link VersionType#RELEASE} to the server.
+     *
+     * @param connection connection
+     * @return client protocol version, or null if handshake packet should be used
+     */
+    default ProtocolVersion getClientProtocol(UserConnection connection) {
+        return null;
+    }
+
+    /**
      * Returns the closest server protocol version to the user's protocol version.
      * On non-proxy servers, this returns the actual server version.
      *

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
@@ -61,13 +61,19 @@ public class BaseProtocol extends AbstractProtocol<BaseClientboundPacket, BaseCl
             wrapper.passthrough(Types.UNSIGNED_SHORT); // Server Port
             int state = wrapper.passthrough(Types.VAR_INT);
 
-            ProtocolInfo info = wrapper.user().getProtocolInfo();
-            info.setProtocolVersion(ProtocolVersion.getProtocol(protocolVersion));
-            // Ensure the server has a version provider
             VersionProvider versionProvider = Via.getManager().getProviders().get(VersionProvider.class);
+            // Ensure the server has a version provider
             if (versionProvider == null) {
                 wrapper.user().setActive(false);
                 return;
+            }
+
+            ProtocolInfo info = wrapper.user().getProtocolInfo();
+            ProtocolVersion clientVersion = versionProvider.getClientProtocol(wrapper.user());
+            if (clientVersion != null) {
+                info.setProtocolVersion(clientVersion);
+            } else {
+                info.setProtocolVersion(ProtocolVersion.getProtocol(protocolVersion));
             }
 
             // Choose the pipe


### PR DESCRIPTION
Adds VersionProvider#getClientProtocol which can be optionally implemented, this is needed for platforms like ViaProxy/ViaFabric which allow versions other than RELEASE (april fools) to join. Reason for this is that ProtocolVersion#getProtocol only supports RELEASE.