### PR TITLE
Apply required changes for ViaAprilFools

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/BaseProtocol.java
@@ -69,11 +69,11 @@ public class BaseProtocol extends AbstractProtocol<BaseClientboundPacket, BaseCl
             }
 
             ProtocolInfo info = wrapper.user().getProtocolInfo();
+            info.setProtocolVersion(ProtocolVersion.getProtocol(protocolVersion));
+
             ProtocolVersion clientVersion = versionProvider.getClientProtocol(wrapper.user());
             if (clientVersion != null) {
                 info.setProtocolVersion(clientVersion);
-            } else {
-                info.setProtocolVersion(ProtocolVersion.getProtocol(protocolVersion));
             }
 
             // Choose the pipe

--- a/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
@@ -106,7 +106,7 @@ public class VelocityPlugin implements ViaServerProxyPlatform<Player> {
         conf.reload();
     }
 
-    @Subscribe(order = PostOrder.LAST)
+    @Subscribe(order = PostOrder.LATE)
     public void onProxyLateInit(ProxyInitializeEvent e) {
         final ViaManagerImpl manager = (ViaManagerImpl) Via.getManager();
         manager.init();

--- a/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
@@ -106,7 +106,7 @@ public class VelocityPlugin implements ViaServerProxyPlatform<Player> {
         conf.reload();
     }
 
-    @Subscribe(order = PostOrder.LATE)
+    @Subscribe(order = PostOrder.LAST)
     public void onProxyLateInit(ProxyInitializeEvent e) {
         final ViaManagerImpl manager = (ViaManagerImpl) Via.getManager();
         manager.init();

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaLoader.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaLoader.java
@@ -21,8 +21,10 @@ import com.velocitypowered.api.plugin.PluginContainer;
 import com.viaversion.viaversion.VelocityPlugin;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
+import com.viaversion.viaversion.api.platform.providers.ViaProviders;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
+import com.viaversion.viaversion.protocol.version.BaseVersionProvider;
 import com.viaversion.viaversion.protocols.v1_8to1_9.provider.BossBarProvider;
 import com.viaversion.viaversion.velocity.listeners.UpdateListener;
 import com.viaversion.viaversion.velocity.providers.VelocityBossBarProvider;
@@ -35,12 +37,17 @@ public class VelocityViaLoader implements ViaPlatformLoader {
         Object plugin = VelocityPlugin.PROXY.getPluginManager()
             .getPlugin("viaversion").flatMap(PluginContainer::getInstance).get();
 
+        final ViaProviders providers = Via.getManager().getProviders();
+
         final ProtocolVersion protocolVersion = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
         if (protocolVersion.olderThan(ProtocolVersion.v1_9)) {
-            Via.getManager().getProviders().use(BossBarProvider.class, new VelocityBossBarProvider());
+            providers.use(BossBarProvider.class, new VelocityBossBarProvider());
         }
 
-        Via.getManager().getProviders().use(VersionProvider.class, new VelocityVersionProvider());
+        // Allow platforms to override the version provider
+        if (providers.get(VersionProvider.class) instanceof BaseVersionProvider) {
+            providers.use(VersionProvider.class, new VelocityVersionProvider());
+        }
         // We probably don't need a EntityIdProvider because velocity sends a Join packet on server change
         // We don't need main hand patch because Join Game packet makes client send hand data again
 


### PR DESCRIPTION
1. Allows the version provider to get the client version sent through the handshake packet
2. Change ViaVersions loading order in Velocity to LATE so plugins can inject after VV using LAST