### PR TITLE
Handle attribute_modifiers inside container components in 1.20.5->1.21

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/util/TagUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/TagUtil.java
@@ -64,6 +64,11 @@ public final class TagUtil {
         return compoundTag != null ? compoundTag : tag.getCompoundTag(Key.stripMinecraftNamespace(key));
     }
 
+    public static @Nullable ListTag<CompoundTag> getNamespacedCompoundTagList(final CompoundTag tag, final String key) {
+        final ListTag<CompoundTag> listTag = tag.getListTag(Key.namespaced(key), CompoundTag.class);
+        return listTag != null ? listTag : tag.getListTag(Key.stripMinecraftNamespace(key), CompoundTag.class);
+    }
+
     public static Tag handleDeep(final Tag tag, final TagUpdater consumer) {
         return handleDeep(null, tag, consumer);
     }


### PR DESCRIPTION
Since items inside the container component can also contain attribute modifiers, we need to handle them as well since the client would get kicked otherwise for the missing id nbt. While this works for now, we should rewrite our 1.21+ component rewriters to fully parse the item as soon as the ComponentRewriter1_20_5 is finished.

Closes https://github.com/ViaVersion/ViaVersion/issues/3968