### PR TITLE
Remove version type from dump

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/dump/VersionInfo.java
+++ b/common/src/main/java/com/viaversion/viaversion/dump/VersionInfo.java
@@ -17,7 +17,6 @@
  */
 package com.viaversion.viaversion.dump;
 
-import com.viaversion.viaversion.api.protocol.version.VersionType;
 import java.util.Set;
 
 public record VersionInfo(String javaVersion, String operatingSystem,

--- a/common/src/main/java/com/viaversion/viaversion/dump/VersionInfo.java
+++ b/common/src/main/java/com/viaversion/viaversion/dump/VersionInfo.java
@@ -20,7 +20,7 @@ package com.viaversion.viaversion.dump;
 import com.viaversion.viaversion.api.protocol.version.VersionType;
 import java.util.Set;
 
-public record VersionInfo(String javaVersion, String operatingSystem, VersionType versionType,
+public record VersionInfo(String javaVersion, String operatingSystem,
                           int serverProtocol, String serverVersion,
                           Set<String> enabledProtocols, String platformName,
                           String platformVersion, String pluginVersion,

--- a/common/src/main/java/com/viaversion/viaversion/util/DumpUtil.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/DumpUtil.java
@@ -62,7 +62,6 @@ public final class DumpUtil {
         final VersionInfo version = new VersionInfo(
             System.getProperty("java.version"),
             System.getProperty("os.name"),
-            protocolVersion.getVersionType(),
             protocolVersion.getVersion(),
             protocolVersion.getName(),
             Via.getManager().getProtocolManager().getSupportedVersions().stream().map(ProtocolVersion::toString).collect(Collectors.toCollection(LinkedHashSet::new)),


### PR DESCRIPTION
VV can only load on RELEASE servers and since it was listed above server protocol/version it could be confused with the ViaVersion version type.