### PR TITLE
Add VersionProvider#getServerProtocol

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/version/VersionProvider.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/version/VersionProvider.java
@@ -40,6 +40,20 @@ public interface VersionProvider extends Provider {
     }
 
     /**
+     * Calls {@link #getClosestServerProtocol(UserConnection)} and catches any exceptions by returning null.
+     *
+     * @param connection connection
+     * @return closest server protocol version to the user's protocol version
+     */
+    default ProtocolVersion getServerProtocol(UserConnection connection) {
+        try {
+            return getClosestServerProtocol(connection);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
      * Returns the closest server protocol version to the user's protocol version.
      * On non-proxy servers, this returns the actual server version.
      *


### PR DESCRIPTION
Most platforms won't ever throw an error and usually ViaVersion shouldn't even load when the server version can't be found. Therefore, I added this bouncer function, so I don't need to try catch my code in ViaLoader/VFP where an exception is never thrown