### PR TITLE
Add config option for truncating 1.11+ chat messages

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -464,4 +464,11 @@ public interface ViaVersionConfig extends Config {
      * @return true if enabled
      */
     boolean cancelBlockSounds();
+
+    /**
+     * Truncate chat messages longer than 100 characters from 1.11+ clients on sub 1.11 servers
+     *
+     * @return true if enabled
+     */
+    boolean truncate1_11ChatMessages();
 }

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -94,6 +94,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private boolean enforceSecureChat;
     private boolean handleInvalidItemCount;
     private boolean cancelBlockSounds;
+    private boolean truncate1_11ChatMessages;
 
     protected AbstractViaConfig(final File configFile, final Logger logger) {
         super(configFile, logger);
@@ -161,6 +162,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         enforceSecureChat = getBoolean("enforce-secure-chat", false);
         handleInvalidItemCount = getBoolean("handle-invalid-item-count", false);
         cancelBlockSounds = getBoolean("cancel-block-sounds", true);
+        truncate1_11ChatMessages = getBoolean("truncate-1_11-chat-messages", true);
     }
 
     private BlockedProtocolVersions loadBlockedProtocolVersions() {
@@ -541,5 +543,10 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public boolean cancelBlockSounds() {
         return cancelBlockSounds;
+    }
+
+    @Override
+    public boolean truncate1_11ChatMessages() {
+        return truncate1_11ChatMessages;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/Protocol1_10To1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/Protocol1_10To1_11.java
@@ -198,7 +198,7 @@ public class Protocol1_10To1_11 extends AbstractProtocol<ClientboundPackets1_9_3
                 handler(wrapper -> {
                     // 100-character limit on older servers
                     String msg = wrapper.get(Types.STRING, 0);
-                    if (msg.length() > 100) {
+                    if (msg.length() > 100 && Via.getConfig().truncate1_11ChatMessages()) {
                         wrapper.set(Types.STRING, 0, msg.substring(0, 100));
                     }
                 });

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -209,3 +209,5 @@ chunk-border-fix: false
 left-handed-handling: true
 # Tries to cancel block break/place sounds sent by 1.8 servers to 1.9+ clients to prevent them from playing twice
 cancel-block-sounds: true
+# Truncate chat messages longer than 100 characters from 1.11+ clients on sub 1.11 servers
+truncate-1_11-chat-messages: true


### PR DESCRIPTION
This PR adds a config option for truncating 1.11+ chat. 

With this option disabled, 1.11+ clients can send longer chat messages on legacy servers which modify `PacketPlayInChat`, without needing to use ViaChatFixer.