### PR TITLE
[ci skip] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The base ViaVersion jar runs on Paper and Velocity. We also have projects integr
 on Fabric, Forge, Bungee, Sponge, or as a standalone proxy to join from basically any client version on
 any server version from the past decade. **See [HERE](https://github.com/ViaVersion) for an overview of the different Via\* projects.**
 
-Note that ViaVersion will be able to **run best on either Paper servers or Fabric clients** due to having
+Note that ViaVersion will be able to **run best on either Paper servers or through [ViaFabricPlus](https://github.com/ViaVersion/ViaFabricPlus?tab=readme-ov-file#viafabricplus)** due to having
 direct access to client/server state and more extensive API.
 
 Supported Versions:
@@ -83,7 +83,7 @@ You need JDK 17 or newer to build ViaVersion.
 
 Mapping Files
 --------------
-Mapping files are generated and managed in our [Mappings repository](https://github.com/ViaVersion/Mappings).
+Mapping files are generated and managed in our [Mappings repository](https://github.com/ViaVersion/Mappings). The generated mapping output is stored [here](./common/src/main/resources/assets/viaversion).
 
 
 Resources
@@ -96,7 +96,7 @@ Resources
 
 License
 --------
-The entirety of the [API directory](api) (including the legacy API directory) is licensed under the MIT License;
+The entirety of the [API directory](api) is licensed under the MIT License;
 see [licenses/MIT.md](licenses/MIT.md) for
 details.
 


### PR DESCRIPTION
- Removes reference to legacy-api directory which got removed.
- Mentions ViaFabricPlus more specific since normal ViaFabric doesn't support work any better than other platforms in terms of gameplay.