### PR TITLE
Properly handle block change acknowledgements in 1.18.2 -> 1.19

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitAckSequenceProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitAckSequenceProvider.java
@@ -19,6 +19,7 @@ package com.viaversion.viaversion.bukkit.providers;
 
 import com.viaversion.viaversion.ViaVersionPlugin;
 import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.minecraft.BlockPosition;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.bukkit.tasks.v1_18_2to1_19.AckSequenceTask;
 import com.viaversion.viaversion.protocols.v1_18_2to1_19.provider.AckSequenceProvider;
@@ -33,7 +34,9 @@ public final class BukkitAckSequenceProvider extends AckSequenceProvider {
     }
 
     @Override
-    public void handleSequence(final UserConnection connection, final int sequence) {
+    public void handleSequence(final UserConnection connection, final BlockPosition position, final int sequence) {
+        if (sequence <= 0) return; // Does not need to be acked
+
         final SequenceStorage sequenceStorage = connection.get(SequenceStorage.class);
         final int previousSequence = sequenceStorage.setSequenceId(sequence);
         if (previousSequence == -1) {
@@ -45,4 +48,10 @@ public final class BukkitAckSequenceProvider extends AckSequenceProvider {
             }
         }
     }
+
+    @Override
+    public void handleBlockChange(final UserConnection connection, final BlockPosition position) {
+        // no op on bukkit
+    }
+
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/rewriter/EntityPacketRewriter1_19.java
@@ -26,6 +26,7 @@ import com.viaversion.nbt.tag.NumberTag;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.data.ParticleMappings;
 import com.viaversion.viaversion.api.data.entity.DimensionData;
+import com.viaversion.viaversion.api.data.entity.EntityTracker;
 import com.viaversion.viaversion.api.minecraft.BlockPosition;
 import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
@@ -41,6 +42,7 @@ import com.viaversion.viaversion.protocols.v1_17_1to1_18.packet.ClientboundPacke
 import com.viaversion.viaversion.protocols.v1_18_2to1_19.Protocol1_18_2To1_19;
 import com.viaversion.viaversion.protocols.v1_18_2to1_19.packet.ClientboundPackets1_19;
 import com.viaversion.viaversion.protocols.v1_18_2to1_19.storage.DimensionRegistryStorage;
+import com.viaversion.viaversion.protocols.v1_18_2to1_19.storage.SequenceStorage;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.util.Key;
 import com.viaversion.viaversion.util.Pair;
@@ -229,6 +231,13 @@ public final class EntityPacketRewriter1_19 extends EntityRewriter<ClientboundPa
                 map(Types.BOOLEAN); // Flat
                 map(Types.BOOLEAN); // Keep player attributes
                 create(Types.OPTIONAL_GLOBAL_POSITION, null); // Last death location
+                handler(wrapper -> {
+                    final String world = wrapper.get(Types.STRING, 1);
+                    final EntityTracker tracker = tracker(wrapper.user());
+                    if (tracker.currentWorld() != null && !tracker.currentWorld().equals(world)) {
+                        wrapper.user().get(SequenceStorage.class).clearPendingBlockChanges();
+                    }
+                });
                 handler(worldDataTrackerHandlerByKey());
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/storage/SequenceStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/storage/SequenceStorage.java
@@ -18,17 +18,18 @@
 package com.viaversion.viaversion.protocols.v1_18_2to1_19.storage;
 
 import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.minecraft.BlockPosition;
+import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntSortedMap;
 
 public final class SequenceStorage implements StorableObject {
 
+    // Bukkit fix
     private final Object lock = new Object();
     private int sequenceId = -1;
 
-    public int sequenceId() {
-        synchronized (lock) {
-            return sequenceId;
-        }
-    }
+    // Protocol level fix
+    private final Object2IntSortedMap<BlockPosition> pendingBlockChanges = new Object2IntLinkedOpenHashMap<>();
 
     public int setSequenceId(final int sequenceId) {
         synchronized (lock) {
@@ -37,4 +38,28 @@ public final class SequenceStorage implements StorableObject {
             return previousSequence;
         }
     }
+
+    public void addPendingBlockChange(final BlockPosition position, final int id) {
+        final int lastSequence = this.pendingBlockChanges.isEmpty() ? 0 : this.pendingBlockChanges.getInt(this.pendingBlockChanges.lastKey());
+        if (id > 0 && id >= lastSequence && !this.pendingBlockChanges.containsKey(position)) {
+            // Store the last 200 pending block changes. Some may never get acked, so we need to limit the size.
+            while (this.pendingBlockChanges.size() > 200) {
+                this.pendingBlockChanges.removeInt(this.pendingBlockChanges.firstKey());
+            }
+            this.pendingBlockChanges.put(position, id);
+        }
+    }
+
+    public int removePendingBlockChange(final BlockPosition position) {
+        final int ackedSequence = this.pendingBlockChanges.getInt(position); // 0 if not found
+        if (ackedSequence > 0) {
+            this.pendingBlockChanges.values().removeIf(sequence -> sequence <= ackedSequence); // Remove all previous pending changes
+        }
+        return ackedSequence;
+    }
+
+    public void clearPendingBlockChanges() {
+        this.pendingBlockChanges.clear();
+    }
+
 }


### PR DESCRIPTION
Recoded block change acknowledgement handling to fix block placement and block breaking lag issues.

Comparison video with 1 second simulated ping: https://upload.raphimc.net/file/0ZtebB8Se2NJrSQN/adx9mAEt2pcj7ytc/idea64_ZBLOxYOdHa.mp4
Left is with my patch and right is without my patch (Both running connected to a 1.8 server over ViaProxy)

I left the bukkit code mostly untouched. Might be worth to consider removing the bukkit code because the protocol level fix is almost perfect and the bukkit code has its own issues (#3643)