### PR TITLE
Deprecate StoredObject#getUser

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/connection/StoredObject.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/connection/StoredObject.java
@@ -29,6 +29,11 @@ public abstract class StoredObject implements StorableObject {
         this.user = user;
     }
 
+    public UserConnection user() {
+        return this.user;
+    }
+
+    @Deprecated
     public UserConnection getUser() {
         return user;
     }


### PR DESCRIPTION
Adds new method matching the name convention in PacketWrapper#user() and other places.