### PR TITLE
Use RedirectProtocolVersion#getOrigin in InitialBaseProtocol if possible

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocol/RedirectProtocolVersion.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/RedirectProtocolVersion.java
@@ -24,8 +24,9 @@ import java.util.Comparator;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Special protocol version that compares to another version. This can be used for e.g. April Fool versions which are depending
- * on vanilla game versions.
+ * A {@link ProtocolVersion} with the version type {@link VersionType#SPECIAL} that compares equal to the given
+ * origin version. The origin version will also be used in {@link com.viaversion.viaversion.protocols.base.InitialBaseProtocol}
+ * to determine the correct base protocol.
  */
 public class RedirectProtocolVersion extends ProtocolVersion {
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
@@ -35,6 +35,7 @@ import com.viaversion.viaversion.api.protocol.version.VersionType;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.exception.CancelException;
 import com.viaversion.viaversion.exception.InformativeException;
+import com.viaversion.viaversion.protocol.RedirectProtocolVersion;
 import com.viaversion.viaversion.protocol.version.BaseVersionProvider;
 import com.viaversion.viaversion.protocols.base.packet.BaseClientboundPacket;
 import com.viaversion.viaversion.protocols.base.packet.BasePacketTypesProvider;
@@ -99,9 +100,13 @@ public class InitialBaseProtocol extends AbstractProtocol<BaseClientboundPacket,
             ProtocolPipeline pipeline = info.getPipeline();
 
             // Special versions might compare equal to normal versions and would break this getter,
-            // platforms need to add the base protocols manually in this case
+            // platforms either need to use the RedirectProtocolVersion API or add the base protocols manually
             if (serverProtocol.getVersionType() != VersionType.SPECIAL) {
                 for (final Protocol protocol : protocolManager.getBaseProtocols(serverProtocol)) {
+                    pipeline.add(protocol);
+                }
+            } else if (serverProtocol instanceof RedirectProtocolVersion version) {
+                for (final Protocol protocol : protocolManager.getBaseProtocols(version.getOrigin())) {
                     pipeline.add(protocol);
                 }
             }


### PR DESCRIPTION
This way, we should be able to get rid of manually adding the base protocol in projects like ViaAprilFools: https://github.com/ViaVersion/ViaAprilFools/blob/main/common/src/main/java/net/raphimc/viaaprilfools/protocol/s3d_sharewaretov1_14/Protocol3D_SharewareTo1_14.java#L87