### PR TITLE
Allow protocols to handle client intention packet

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
@@ -129,8 +129,7 @@ public class InitialBaseProtocol extends AbstractProtocol<BaseClientboundPacket,
                 protocols.remove(this);
                 wrapper.apply(Direction.SERVERBOUND, State.HANDSHAKE, protocols);
             } catch (CancelException e) {
-                wrapper.user().setActive(false);
-                return;
+                throw new RuntimeException("Cancelling the client intention packet is not allowed", e);
             }
 
             if (Via.getManager().isDebug()) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
@@ -123,6 +123,16 @@ public class InitialBaseProtocol extends AbstractProtocol<BaseClientboundPacket,
                 wrapper.set(Types.VAR_INT, 0, serverProtocol.getOriginalVersion());
             }
 
+            // Send client intention into the pipeline in case protocols down the line need to transform it
+            try {
+                final List<Protocol> protocols = new ArrayList<>(pipeline.pipes());
+                protocols.remove(this);
+                wrapper.apply(Direction.SERVERBOUND, State.HANDSHAKE, protocols);
+            } catch (CancelException e) {
+                wrapper.user().setActive(false);
+                return;
+            }
+
             if (Via.getManager().isDebug()) {
                 Via.getPlatform().getLogger().info("User connected with protocol: " + info.protocolVersion() + " and serverProtocol: " + info.serverProtocolVersion());
                 Via.getPlatform().getLogger().info("Protocol pipeline: " + pipeline.pipes());


### PR DESCRIPTION
This is currently not possible without manually added base protocols which is the case in both ViaLegacy/ViaBedrock. This way we can get rid of it completely: https://github.com/ViaVersion/ViaLegacy/blob/main/src/main/java/net/raphimc/vialegacy/api/protocol/PreNettyBaseProtocol.java