### PR TITLE
Add more API for base protocols and skip manually added ones.

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocol/RedirectProtocolVersion.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/RedirectProtocolVersion.java
@@ -24,9 +24,10 @@ import java.util.Comparator;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * A {@link ProtocolVersion} with the version type {@link VersionType#SPECIAL} that compares equal to the given
- * origin version. The origin version will also be used in {@link com.viaversion.viaversion.protocols.base.InitialBaseProtocol}
- * to determine the correct base protocol.
+ * Intended API class for protocol versions with the version type {@link VersionType#SPECIAL}.
+ * <p>
+ * Compares equal to the given origin version and allows base protocol determination via {@link #getBaseProtocolVersion()}
+ * which can be null for special cases where there is no base protocol.
  */
 public class RedirectProtocolVersion extends ProtocolVersion {
 
@@ -54,6 +55,13 @@ public class RedirectProtocolVersion extends ProtocolVersion {
     }
 
     public ProtocolVersion getOrigin() {
+        return origin;
+    }
+
+    /**
+     * @return the protocol version used to determine the base protocol, null in case there is no base protocol.
+     */
+    public @Nullable ProtocolVersion getBaseProtocolVersion() {
         return origin;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
@@ -99,14 +99,16 @@ public class InitialBaseProtocol extends AbstractProtocol<BaseClientboundPacket,
             // Add Base Protocol
             ProtocolPipeline pipeline = info.getPipeline();
 
-            // Special versions might compare equal to normal versions and would break this getter,
-            // platforms either need to use the RedirectProtocolVersion API or add the base protocols manually
+            // Special versions might compare equal to normal versions and would the normal lookup,
+            // platforms can use the RedirectProtocolVersion API or need to manually handle their base protocols.
+            ProtocolVersion baseProtocolVersion = null;
             if (serverProtocol.getVersionType() != VersionType.SPECIAL) {
-                for (final Protocol protocol : protocolManager.getBaseProtocols(serverProtocol)) {
-                    pipeline.add(protocol);
-                }
+                baseProtocolVersion = serverProtocol;
             } else if (serverProtocol instanceof RedirectProtocolVersion version) {
-                for (final Protocol protocol : protocolManager.getBaseProtocols(version.getOrigin())) {
+                baseProtocolVersion = version.getBaseProtocolVersion();
+            }
+            if (baseProtocolVersion != null) {
+                for (final Protocol protocol : protocolManager.getBaseProtocols(baseProtocolVersion)) {
                     pipeline.add(protocol);
                 }
             }


### PR DESCRIPTION
ViaBedrock has its own base protocol and needs to be excluded from the detection.