### PR TITLE
Split base protocols list

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/ProtocolManager.java
@@ -25,6 +25,7 @@ package com.viaversion.viaversion.api.protocol;
 import com.google.common.collect.Range;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
+import com.viaversion.viaversion.api.protocol.packet.Direction;
 import com.viaversion.viaversion.api.protocol.packet.PacketType;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.packet.ServerboundPacketType;
@@ -73,13 +74,14 @@ public interface ProtocolManager {
     Protocol getBaseProtocol();
 
     /**
-     * Returns the base protocols for a specific server protocol version.
+     * Returns the base protocols for a specific server and client protocol version.
      * The standard base protocols deal with status and login packets for userconnection initialization.
      *
+     * @param clientVersion client protocol version
      * @param serverVersion server protocol version
-     * @return base protocols for the given server protocol version if present, else null
+     * @return base protocols for the given server and client protocol version
      */
-    List<Protocol> getBaseProtocols(ProtocolVersion serverVersion);
+    List<Protocol> getBaseProtocols(@Nullable ProtocolVersion clientVersion, @Nullable ProtocolVersion serverVersion);
 
     /**
      * Returns an immutable collection of registered protocols.
@@ -120,11 +122,12 @@ public interface ProtocolManager {
      * Registers and initializes a base protocol. Base Protocols registered later have higher priority.
      * Only base protocol will always be added to pipeline.
      *
+     * @param direction          direction of the base protocol
      * @param baseProtocol       base protocol to register
      * @param supportedProtocols protocol versions supported by the base protocol
      * @throws IllegalArgumentException if the protocol is not a base protocol as given by {@link Protocol#isBaseProtocol()}
      */
-    void registerBaseProtocol(Protocol baseProtocol, Range<ProtocolVersion> supportedProtocols);
+    void registerBaseProtocol(Direction direction, Protocol baseProtocol, Range<ProtocolVersion> supportedProtocols);
 
     /**
      * Calculates and returns the protocol path from a client protocol version to server protocol version.

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
@@ -40,7 +40,6 @@ import com.viaversion.viaversion.protocol.version.BaseVersionProvider;
 import com.viaversion.viaversion.protocols.base.packet.BaseClientboundPacket;
 import com.viaversion.viaversion.protocols.base.packet.BasePacketTypesProvider;
 import com.viaversion.viaversion.protocols.base.packet.BaseServerboundPacket;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -103,17 +102,15 @@ public class InitialBaseProtocol extends AbstractProtocol<BaseClientboundPacket,
 
             // Special versions might compare equal to normal versions and would the normal lookup,
             // platforms can use the RedirectProtocolVersion API or need to manually handle their base protocols.
-            ProtocolVersion baseProtocolVersion = null;
+            ProtocolVersion clientboundBaseProtocolVersion = null;
             if (serverProtocol.getVersionType() != VersionType.SPECIAL) {
-                baseProtocolVersion = serverProtocol;
+                clientboundBaseProtocolVersion = serverProtocol;
             } else if (serverProtocol instanceof RedirectProtocolVersion version) {
-                baseProtocolVersion = version.getBaseProtocolVersion();
+                clientboundBaseProtocolVersion = version.getBaseProtocolVersion();
             }
-            if (baseProtocolVersion != null) {
-                // Add base protocols
-                for (final Protocol protocol : protocolManager.getBaseProtocols(baseProtocolVersion)) {
-                    pipeline.add(protocol);
-                }
+            // Add base protocols
+            for (final Protocol protocol : protocolManager.getBaseProtocols(info.protocolVersion(), clientboundBaseProtocolVersion)) {
+                pipeline.add(protocol);
             }
 
             // Add other protocols


### PR DESCRIPTION
Splits the base protocol list in clientbound and serverbound. Useful when client and server version are not both 1.7+ (ViaLegacy, ViaBedrock)
Related to https://github.com/ViaVersion/ViaVersion/pull/4106