### PR TITLE
Add option to hide scoreboard numbers

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -464,4 +464,11 @@ public interface ViaVersionConfig extends Config {
      * @return true if enabled
      */
     boolean cancelBlockSounds();
+
+    /**
+     * Hides scoreboard numbers for 1.20.3+ clients on older server versions.
+     *
+     * @return true if enabled
+     */
+    boolean hideScoreboardNumbers();
 }

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -94,6 +94,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private boolean enforceSecureChat;
     private boolean handleInvalidItemCount;
     private boolean cancelBlockSounds;
+    private boolean hideScoreboardNumbers;
 
     protected AbstractViaConfig(final File configFile, final Logger logger) {
         super(configFile, logger);
@@ -161,6 +162,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         enforceSecureChat = getBoolean("enforce-secure-chat", false);
         handleInvalidItemCount = getBoolean("handle-invalid-item-count", false);
         cancelBlockSounds = getBoolean("cancel-block-sounds", true);
+        hideScoreboardNumbers = getBoolean("hide-scoreboard-numbers", false);
     }
 
     private BlockedProtocolVersions loadBlockedProtocolVersions() {
@@ -541,5 +543,10 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public boolean cancelBlockSounds() {
         return cancelBlockSounds;
+    }
+
+    @Override
+    public boolean hideScoreboardNumbers() {
+        return hideScoreboardNumbers;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.v1_20_2to1_20_3;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.MappingData;
 import com.viaversion.viaversion.api.data.MappingDataBase;
@@ -107,8 +108,13 @@ public final class Protocol1_20_2To1_20_3 extends AbstractProtocol<ClientboundPa
             final byte action = wrapper.passthrough(Types.BYTE); // Method
             if (action == 0 || action == 2) {
                 convertComponent(wrapper); // Display Name
-                wrapper.passthrough(Types.VAR_INT); // Render type
-                wrapper.write(Types.BOOLEAN, false); // Null number format
+                int render = wrapper.passthrough(Types.VAR_INT); // Render type
+                if (render == 0 && Via.getConfig().hideScoreboardNumbers()) { // 0 = "integer", 1 = "hearts"
+                    wrapper.write(Types.BOOLEAN, true); // has number format
+                    wrapper.write(Types.VAR_INT, 0); // Blank format
+                } else {
+                    wrapper.write(Types.BOOLEAN, false); // has number format
+                }
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
@@ -108,7 +108,7 @@ public final class Protocol1_20_2To1_20_3 extends AbstractProtocol<ClientboundPa
             final byte action = wrapper.passthrough(Types.BYTE); // Method
             if (action == 0 || action == 2) {
                 convertComponent(wrapper); // Display Name
-                int render = wrapper.passthrough(Types.VAR_INT); // Render type
+                final int render = wrapper.passthrough(Types.VAR_INT); // Render type
                 if (render == 0 && Via.getConfig().hideScoreboardNumbers()) { // 0 = "integer", 1 = "hearts"
                     wrapper.write(Types.BOOLEAN, true); // has number format
                     wrapper.write(Types.VAR_INT, 0); // Blank format

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -164,6 +164,9 @@ enforce-secure-chat: false
 # Handles items with invalid count values (higher than max stack size) on 1.20.3 servers.
 handle-invalid-item-count: false
 #
+# Hides scoreboard numbers for 1.20.3+ clients on older server versions.
+hide-scoreboard-numbers: false
+#
 #----------------------------------------------------------#
 #             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #
 #----------------------------------------------------------#


### PR DESCRIPTION
Useful for minigame servers where scoreboard numbers are always used purely for ordering purposes. Enabling the config makes it so 1.20.3+ clients will see the scoreboard without the red numbers on the right.

Tested on a 1.8 server with 1.21.1 client, both with the setting off and on, produces the expected results