### PR TITLE
Add Particle#copy

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/Particle.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/Particle.java
@@ -72,6 +72,14 @@ public final class Particle implements IdHolder {
         arguments.set(index, new ParticleData<>(type, value));
     }
 
+    public Particle copy() {
+        final Particle particle = new Particle(id);
+        for (ParticleData<?> argument : arguments) {
+            particle.arguments.add(argument.copy());
+        }
+        return particle;
+    }
+
     @Override
     public String toString() {
         return "Particle{" +
@@ -107,6 +115,10 @@ public final class Particle implements IdHolder {
 
         public void write(final PacketWrapper wrapper) {
             wrapper.write(type, value);
+        }
+
+        public ParticleData<T> copy() {
+            return new ParticleData<>(type, value);
         }
 
         @Override


### PR DESCRIPTION
ViaBedrock uses Particle objects in the particle mappings and I need to copy the particle before sending it, else VV messes up the data in the mappings due to object mutation