### PR TITLE
Add PacketWrapper#sendFutureRaw, cleanup login disconnect handling.

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/packet/PacketWrapper.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/packet/PacketWrapper.java
@@ -238,6 +238,14 @@ public interface PacketWrapper {
 
     /**
      * Sends this packet to the associated user, submitted to netty's event loop.
+     * <b>Unlike {@link #sendFuture(Class)}, this method does not handle the pipeline with packet id and data changes.</b>
+     *
+     * @throws InformativeException if it fails to write
+     */
+    ChannelFuture sendFutureRaw() throws InformativeException;
+
+    /**
+     * Sends this packet to the associated user, submitted to netty's event loop.
      * <b>Unlike {@link #send(Class)}, this method does not handle the pipeline with packet id and data changes.</b>
      *
      * @throws InformativeException if it fails to write

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/v1_7/ServerboundBaseProtocol1_7.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/v1_7/ServerboundBaseProtocol1_7.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.base.v1_7;
 
+import com.google.gson.JsonObject;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.ProtocolInfo;
 import com.viaversion.viaversion.api.connection.UserConnection;
@@ -31,6 +32,7 @@ import com.viaversion.viaversion.protocols.base.ServerboundLoginPackets;
 import com.viaversion.viaversion.protocols.base.packet.BaseClientboundPacket;
 import com.viaversion.viaversion.protocols.base.packet.BasePacketTypesProvider;
 import com.viaversion.viaversion.protocols.base.packet.BaseServerboundPacket;
+import com.viaversion.viaversion.protocols.v1_8to1_9.Protocol1_8To1_9;
 import com.viaversion.viaversion.util.ChatColorUtil;
 import com.viaversion.viaversion.util.ComponentUtil;
 import io.netty.channel.ChannelFuture;
@@ -62,10 +64,16 @@ public class ServerboundBaseProtocol1_7 extends AbstractProtocol<BaseClientbound
 
                 final String disconnectMessage = ChatColorUtil.translateAlternateColorCodes(Via.getConfig().getBlockedDisconnectMsg());
                 final PacketWrapper disconnectPacket = PacketWrapper.create(ClientboundLoginPackets.LOGIN_DISCONNECT, user);
-                disconnectPacket.write(Types.COMPONENT, ComponentUtil.plainToJson(disconnectMessage));
+
+                final JsonObject object = ComponentUtil.plainToJson(disconnectMessage);
+                if (protocol.olderThanOrEqualTo(ProtocolVersion.v1_8)) {
+                    disconnectPacket.write(Types.STRING, object.toString());
+                } else {
+                    disconnectPacket.write(Types.COMPONENT, object);
+                }
 
                 // Send and close
-                final ChannelFuture future = disconnectPacket.sendFuture(null);
+                final ChannelFuture future = disconnectPacket.sendFutureRaw();
                 future.addListener(f -> user.getChannel().close());
             }
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/Protocol1_8To1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/Protocol1_8To1_9.java
@@ -83,14 +83,7 @@ public class Protocol1_8To1_9 extends AbstractProtocol<ClientboundPackets1_8, Cl
     protected void registerPackets() {
         super.registerPackets();
 
-        registerClientbound(State.LOGIN, ClientboundLoginPackets.LOGIN_DISCONNECT, wrapper -> {
-            if (wrapper.isReadable(Types.COMPONENT, 0)) {
-                // Already written as component in the base protocol
-                return;
-            }
-
-            STRING_TO_JSON.write(wrapper, wrapper.read(Types.STRING));
-        });
+        registerClientbound(State.LOGIN, ClientboundLoginPackets.LOGIN_DISCONNECT, wrapper -> STRING_TO_JSON.write(wrapper, wrapper.read(Types.STRING)));
 
         // Other Handlers
         SpawnPacketRewriter1_9.register(this);


### PR DESCRIPTION
Removes the special handling in Protocol1_8To1_9 and always send the correct/expected data by the client in ServerboundBaseProtocol1_7 itself. Also prevent sending the packet through the protocol pipeline since packet/format changes should also be handled inside the base protocol.