### PR TITLE
Rewrite display name component in player info packet in 1.20.3->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/Protocol1_20_3To1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/Protocol1_20_3To1_20_5.java
@@ -103,6 +103,7 @@ public final class Protocol1_20_3To1_20_5 extends AbstractProtocol<ClientboundPa
         componentRewriter.registerBossEvent(ClientboundPackets1_20_3.BOSS_EVENT);
         componentRewriter.registerComponentPacket(ClientboundPackets1_20_3.DISCONNECT);
         componentRewriter.registerTabList(ClientboundPackets1_20_3.TAB_LIST);
+        componentRewriter.registerPlayerInfoUpdate1_20_3(ClientboundPackets1_20_3.PLAYER_INFO_UPDATE);
         componentRewriter.registerPing();
 
         registerClientbound(State.LOGIN, ClientboundLoginPackets.HELLO, wrapper -> {

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/ComponentRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/ComponentRewriter.java
@@ -143,6 +143,9 @@ public class ComponentRewriter<C extends ClientboundPacketType> implements com.v
     public void registerPlayerInfoUpdate1_20_3(final C packetType) {
         protocol.registerClientbound(packetType, wrapper -> {
             final BitSet actions = wrapper.passthrough(Types.PROFILE_ACTIONS_ENUM);
+            if (!actions.get(5)) { // Update display name
+                return;
+            }
             final int entries = wrapper.passthrough(Types.VAR_INT);
             for (int i = 0; i < entries; i++) {
                 wrapper.passthrough(Types.UUID);
@@ -169,9 +172,7 @@ public class ComponentRewriter<C extends ClientboundPacketType> implements com.v
                 if (actions.get(4)) {
                     wrapper.passthrough(Types.VAR_INT); // Latency
                 }
-                if (actions.get(5)) { // Update display name
-                    processTag(wrapper.user(), wrapper.passthrough(Types.OPTIONAL_TAG));
-                }
+                processTag(wrapper.user(), wrapper.passthrough(Types.OPTIONAL_TAG));
             }
         });
     }


### PR DESCRIPTION
Closes https://github.com/ViaVersion/ViaFabricPlus/issues/529. Decided to keep this only in this very protocol since joining this server worked with older ViaFabricPlus versions for MC 1.20.4.