### PR TITLE
Make EntityTrackerBase#clearEntities calling removeEntity for every e…

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/data/entity/EntityTrackerBase.java
+++ b/common/src/main/java/com/viaversion/viaversion/data/entity/EntityTrackerBase.java
@@ -30,9 +30,7 @@ import com.viaversion.viaversion.util.Key;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
-import it.unimi.dsi.fastutil.ints.IntSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class EntityTrackerBase implements EntityTracker, ClientEntityIdChangeListener {

--- a/common/src/main/java/com/viaversion/viaversion/data/entity/EntityTrackerBase.java
+++ b/common/src/main/java/com/viaversion/viaversion/data/entity/EntityTrackerBase.java
@@ -30,7 +30,9 @@ import com.viaversion.viaversion.util.Key;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class EntityTrackerBase implements EntityTracker, ClientEntityIdChangeListener {
@@ -95,7 +97,10 @@ public class EntityTrackerBase implements EntityTracker, ClientEntityIdChangeLis
 
     @Override
     public void clearEntities() {
-        entities.clear();
+        // Call wrapper function in case protocols need to do additional removals
+        for (final int id : entities.keySet().toIntArray()) {
+            removeEntity(id);
+        }
     }
 
     @Override


### PR DESCRIPTION
…ntry

Some protocols store additional entity data as maps/lists which also needs to be cleared on dimension switch, this could have been caused small memory leaks in the past where data was never cleared.