### PR TITLE
Print book conversion errors to default logger in 1.20.2->1.20.3

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/BlockItemPacketRewriter1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/BlockItemPacketRewriter1_20_3.java
@@ -43,6 +43,7 @@ import com.viaversion.viaversion.util.ComponentUtil;
 import com.viaversion.viaversion.util.Key;
 import com.viaversion.viaversion.util.SerializerVersion;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import java.util.logging.Level;
 
 public final class BlockItemPacketRewriter1_20_3 extends ItemRewriter<ClientboundPacket1_20_2, ServerboundPacket1_20_3, Protocol1_20_2To1_20_3> {
 
@@ -167,7 +168,7 @@ public final class BlockItemPacketRewriter1_20_3 extends ItemRewriter<Clientboun
             final JsonElement updatedComponent = ComponentUtil.convertJson(pageTag.getValue(), SerializerVersion.V1_19_4, SerializerVersion.V1_20_3);
             pageTag.setValue(updatedComponent.toString());
         } catch (final Exception e) {
-            Via.getManager().debugHandler().error("Error during book conversion", e);
+            Via.getPlatform().getLogger().log(Level.SEVERE, "Error during book conversion: " + pageTag.getValue(), e);
         }
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/BlockItemPacketRewriter1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/rewriter/BlockItemPacketRewriter1_20_3.java
@@ -17,10 +17,10 @@
  */
 package com.viaversion.viaversion.protocols.v1_20_2to1_20_3.rewriter;
 
+import com.google.gson.JsonElement;
 import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.nbt.tag.ListTag;
 import com.viaversion.nbt.tag.StringTag;
-import com.google.gson.JsonElement;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.ParticleMappings;
@@ -31,19 +31,19 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_20_2;
 import com.viaversion.viaversion.api.type.types.version.Types1_20_3;
-import com.viaversion.viaversion.protocols.v1_20to1_20_2.packet.ClientboundPacket1_20_2;
-import com.viaversion.viaversion.protocols.v1_20to1_20_2.packet.ClientboundPackets1_20_2;
-import com.viaversion.viaversion.protocols.v1_20to1_20_2.rewriter.RecipeRewriter1_20_2;
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.Protocol1_20_2To1_20_3;
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.packet.ServerboundPacket1_20_3;
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.packet.ServerboundPackets1_20_3;
+import com.viaversion.viaversion.protocols.v1_20to1_20_2.packet.ClientboundPacket1_20_2;
+import com.viaversion.viaversion.protocols.v1_20to1_20_2.packet.ClientboundPackets1_20_2;
+import com.viaversion.viaversion.protocols.v1_20to1_20_2.rewriter.RecipeRewriter1_20_2;
 import com.viaversion.viaversion.rewriter.BlockRewriter;
 import com.viaversion.viaversion.rewriter.ItemRewriter;
 import com.viaversion.viaversion.util.ComponentUtil;
 import com.viaversion.viaversion.util.Key;
 import com.viaversion.viaversion.util.SerializerVersion;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.logging.Level;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class BlockItemPacketRewriter1_20_3 extends ItemRewriter<ClientboundPacket1_20_2, ServerboundPacket1_20_3, Protocol1_20_2To1_20_3> {
 
@@ -168,7 +168,9 @@ public final class BlockItemPacketRewriter1_20_3 extends ItemRewriter<Clientboun
             final JsonElement updatedComponent = ComponentUtil.convertJson(pageTag.getValue(), SerializerVersion.V1_19_4, SerializerVersion.V1_20_3);
             pageTag.setValue(updatedComponent.toString());
         } catch (final Exception e) {
-            Via.getPlatform().getLogger().log(Level.SEVERE, "Error during book conversion: " + pageTag.getValue(), e);
+            if (!Via.getConfig().isSuppressConversionWarnings()) {
+                protocol.getLogger().log(Level.SEVERE, "Error during book conversion: " + pageTag.getValue(), e);
+            }
         }
     }
 }


### PR DESCRIPTION
Should always be printed like in the functions in ComponentUtil