### PR TITLE
Add option to fix wrong block placement rotation in 1.20.5->1.21

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -471,4 +471,11 @@ public interface ViaVersionConfig extends Config {
      * @return true if enabled
      */
     boolean hideScoreboardNumbers();
+
+    /**
+     * Fixes 1.21+ clients on 1.20.5 servers placing water/lava buckets at the wrong location when moving fast.
+     *
+     * @return true if enabled
+     */
+    boolean fix1_21PlacementRotation();
 }

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -25,14 +25,14 @@ import com.viaversion.viaversion.api.protocol.version.BlockedProtocolVersions;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.protocol.BlockedProtocolVersionsImpl;
 import com.viaversion.viaversion.util.Config;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract class AbstractViaConfig extends Config implements ViaVersionConfig {
@@ -95,6 +95,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private boolean handleInvalidItemCount;
     private boolean cancelBlockSounds;
     private boolean hideScoreboardNumbers;
+    private boolean fix1_21PlacementRotation;
 
     protected AbstractViaConfig(final File configFile, final Logger logger) {
         super(configFile, logger);
@@ -163,6 +164,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         handleInvalidItemCount = getBoolean("handle-invalid-item-count", false);
         cancelBlockSounds = getBoolean("cancel-block-sounds", true);
         hideScoreboardNumbers = getBoolean("hide-scoreboard-numbers", false);
+        fix1_21PlacementRotation = getBoolean("fix-1_21-placement-rotation", false);
     }
 
     private BlockedProtocolVersions loadBlockedProtocolVersions() {
@@ -548,5 +550,10 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public boolean hideScoreboardNumbers() {
         return hideScoreboardNumbers;
+    }
+
+    @Override
+    public boolean fix1_21PlacementRotation() {
+        return fix1_21PlacementRotation;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/BlockItemPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/BlockItemPacketRewriter1_21.java
@@ -19,12 +19,14 @@ package com.viaversion.viaversion.protocols.v1_20_5to1_21.rewriter;
 
 import com.viaversion.nbt.tag.ByteTag;
 import com.viaversion.nbt.tag.CompoundTag;
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.data.StructuredDataContainer;
 import com.viaversion.viaversion.api.minecraft.data.StructuredDataKey;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.minecraft.item.data.AttributeModifiers1_20_5;
 import com.viaversion.viaversion.api.minecraft.item.data.AttributeModifiers1_21;
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_20_2;
 import com.viaversion.viaversion.api.type.types.version.Types1_20_5;
@@ -105,8 +107,22 @@ public final class BlockItemPacketRewriter1_21 extends StructuredItemRewriter<Cl
         protocol.registerServerbound(ServerboundPackets1_20_5.USE_ITEM, wrapper -> {
             wrapper.passthrough(Types.VAR_INT); // Hand
             wrapper.passthrough(Types.VAR_INT); // Sequence
-            wrapper.read(Types.FLOAT); // Y rotation
-            wrapper.read(Types.FLOAT); // X rotation
+            final float yaw = wrapper.read(Types.FLOAT); // Y rotation
+            final float pitch = wrapper.read(Types.FLOAT); // X rotation
+
+            if (!Via.getConfig().fix1_21PlacementRotation()) {
+                return;
+            }
+
+            // Not correct but *enough* for vanilla/normal servers to have block placement synchronized
+            final PacketWrapper playerRotation = wrapper.create(ServerboundPackets1_20_5.MOVE_PLAYER_ROT);
+            playerRotation.write(Types.FLOAT, yaw);
+            playerRotation.write(Types.FLOAT, pitch);
+            playerRotation.write(Types.BOOLEAN, true); // On Ground
+
+            wrapper.cancel();
+            playerRotation.sendToServer(Protocol1_20_5To1_21.class);
+            wrapper.sendToServer(Protocol1_20_5To1_21.class);
         });
 
         new RecipeRewriter1_20_3<>(protocol).register1_20_5(ClientboundPackets1_20_5.UPDATE_RECIPES);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/BlockItemPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/BlockItemPacketRewriter1_21.java
@@ -120,9 +120,9 @@ public final class BlockItemPacketRewriter1_21 extends StructuredItemRewriter<Cl
             playerRotation.write(Types.FLOAT, pitch);
             playerRotation.write(Types.BOOLEAN, true); // On Ground
 
-            wrapper.cancel();
             playerRotation.sendToServer(Protocol1_20_5To1_21.class);
             wrapper.sendToServer(Protocol1_20_5To1_21.class);
+            wrapper.cancel();
         });
 
         new RecipeRewriter1_20_3<>(protocol).register1_20_5(ClientboundPackets1_20_5.UPDATE_RECIPES);

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -167,6 +167,9 @@ handle-invalid-item-count: false
 # Hides scoreboard numbers for 1.20.3+ clients on older server versions.
 hide-scoreboard-numbers: false
 #
+# Fixes 1.21+ clients on 1.20.5 servers placing water/lava buckets at the wrong location when moving fast, NOTE: This may cause issues with anti-cheat plugins.
+fix-1_21-placement-rotation: false
+#
 #----------------------------------------------------------#
 #             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #
 #----------------------------------------------------------#


### PR DESCRIPTION
A vanilla client would send a full movement packet including position and valid on ground as well but this is enough to fix https://github.com/ViaVersion/ViaVersion/issues/4165 and also doesn't need tons of tracking code.