### PR TITLE
Fix ProtocolVersion#isKnown javadoc to make difference with isRegiste…

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/protocol/version/ProtocolVersion.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/protocol/version/ProtocolVersion.java
@@ -285,9 +285,9 @@ public class ProtocolVersion implements Comparable<ProtocolVersion> {
     }
 
     /**
-     * Returns whether the protocol is set. Should only be unknown for unregistered protocols returned by {@link #getProtocol(int)}.
+     * Returns whether the protocol version is {@link #unknown}. For checking if the protocol version is registered, use {@link #isRegistered(VersionType, int)}
      *
-     * @return true if the protocol is set
+     * @return true if the protocol version is unknown
      */
     public boolean isKnown() {
         return version != -1;


### PR DESCRIPTION
…red more clear

The current javadoc is wrong as it indicates that ProtocolVersion#getProtocol will return a protocol instance with -1 as protocol id, which is never the case. From what I see the function is used as check if a protocol version instance is equal to the unknown protocol version, and should therefore be explained in the javadoc.