### PR TITLE
Add option to construct ChunkSectionLightImpl without block light

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/ChunkSectionLight.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/ChunkSectionLight.java
@@ -35,7 +35,7 @@ public interface ChunkSectionLight {
     /**
      * Returns whether the section has sky light.
      *
-     * @return true if skylight is present
+     * @return true if sky light is present
      */
     boolean hasSkyLight();
 
@@ -43,7 +43,7 @@ public interface ChunkSectionLight {
      * Returns whether the section has block light.
      * This returns true unless specifically set to null.
      *
-     * @return true if skylight is present
+     * @return true if block light is present
      */
     boolean hasBlockLight();
 

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/ChunkSectionLightImpl.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/chunks/ChunkSectionLightImpl.java
@@ -31,12 +31,22 @@ public class ChunkSectionLightImpl implements ChunkSectionLight {
     private NibbleArray skyLight;
 
     public ChunkSectionLightImpl() {
-        // Block light is always written
-        this.blockLight = new NibbleArray(ChunkSection.SIZE);
+        this(true);
+    }
+
+    public ChunkSectionLightImpl(final boolean holdsBlockLight) {
+        if (holdsBlockLight) {
+            this.blockLight = new NibbleArray(LIGHT_LENGTH * 2);
+        }
     }
 
     @Override
     public void setBlockLight(byte[] data) {
+        if (data == null) {
+            this.blockLight = null;
+            return;
+        }
+
         if (data.length != LIGHT_LENGTH) throw new IllegalArgumentException("Data length != " + LIGHT_LENGTH);
         if (this.blockLight == null) {
             this.blockLight = new NibbleArray(data);


### PR DESCRIPTION
Adds an optional boolean to the ChunkSectionLightImpl constructor to not add block light by default. This makes it a lot easier to use this class for the modern Minecraft lighting engine where both lights are optional