### PR TITLE
Fix MappingDataBase#getOldBlockId implementation

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/data/MappingDataBase.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/data/MappingDataBase.java
@@ -179,7 +179,7 @@ public class MappingDataBase implements MappingData {
 
     @Override
     public int getOldBlockId(final int id) {
-        return blockMappings.getNewIdOrDefault(id, 1);
+        return blockMappings.inverse().getNewIdOrDefault(id, 1);
     }
 
     @Override


### PR DESCRIPTION
Fixes items with block predicates causing disconnections, can be tested with a 1.21.3 client on an older server with: /give @p golden_pickaxe[can_break={predicates:[{blocks:"coal_ore"}],show_in_tooltip:false}] 1