### PR TITLE
Add gradle task to quickly test/debug code changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ nb-configuration.xml
 
 ### MacOS ###
 .DS_Store
+
+### Run Folder ###
+common/run/

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -18,3 +18,26 @@ java {
 tasks.named<Jar>("sourcesJar") {
     from(project(":viaversion-api").sourceSets.main.get().allSource)
 }
+
+// Task to quickly test/debug code changes using ViaProxy
+tasks.register<JavaExec>("runViaProxy") {
+    dependsOn(tasks.shadowJar)
+
+    val viaProxyConfiguration = configurations.create("viaProxy")
+    viaProxyConfiguration.dependencies.add(dependencies.create(rootProject.libs.viaProxy.get().copy().setTransitive(false)))
+
+    mainClass.set("net.raphimc.viaproxy.ViaProxy")
+    classpath = viaProxyConfiguration
+    workingDir = file("run")
+
+    doFirst {
+        val jarsDir = file("$workingDir/jars")
+        jarsDir.mkdirs()
+        file("$jarsDir/${project.name}.jar").writeBytes(tasks.shadowJar.get().archiveFile.get().asFile.readBytes())
+    }
+
+    doLast {
+        file("$workingDir/jars/${project.name}.jar").delete()
+        file("$workingDir/logs").deleteRecursively()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ checkerQual = "3.48.1"
 paper = "1.20.4-R0.1-SNAPSHOT"
 legacyBukkit = "1.8.8-R0.1-SNAPSHOT"
 velocity = "3.1.1"
-
+viaProxy = "3.3.5-SNAPSHOT"
 
 [libraries]
 
@@ -40,6 +40,7 @@ checkerQual = { group = "org.checkerframework", name = "checker-qual", version.r
 paper = { group = "io.papermc.paper", name = "paper-api", version.ref = "paper" }
 legacyBukkit = { group = "org.bukkit", name = "bukkit", version.ref = "legacyBukkit" }
 velocity = { group = "com.velocitypowered", name = "velocity-api", version.ref = "velocity" }
+viaProxy = { group = "net.raphimc", name = "ViaProxy", version.ref = "viaProxy" }
 
 
 [bundles]


### PR DESCRIPTION
Adds a gradle task which starts ViaProxy with the current code changes. This allows quick and easy testing of new changes without complex server/client mod setup.

Also allows hotswapping if added as IntelliJ run configuration:
![image](https://github.com/user-attachments/assets/abbc91f1-8d72-4296-aae2-a82fafe9a8c9)
