### PR TITLE
Fix 1.21.1 -> 1.21.2 chunk loading edge case

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/Protocol1_21To1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/Protocol1_21To1_21_2.java
@@ -48,6 +48,7 @@ import com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter.ComponentRewri
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter.EntityPacketRewriter1_21_2;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter.ParticleRewriter1_21_2;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.BundleStateTracker;
+import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.ChunkLoadTracker;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.PlayerPositionStorage;
 import com.viaversion.viaversion.rewriter.AttributeRewriter;
 import com.viaversion.viaversion.rewriter.SoundRewriter;
@@ -231,6 +232,7 @@ public final class Protocol1_21To1_21_2 extends AbstractProtocol<ClientboundPack
         addEntityTracker(connection, new EntityTrackerBase(connection, EntityTypes1_21_2.PLAYER));
         connection.put(new BundleStateTracker());
         connection.put(new PlayerPositionStorage());
+        connection.put(new ChunkLoadTracker());
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/EntityPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/EntityPacketRewriter1_21_2.java
@@ -18,6 +18,7 @@
 package com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter;
 
 import com.viaversion.nbt.tag.CompoundTag;
+import com.viaversion.viaversion.api.data.entity.EntityTracker;
 import com.viaversion.viaversion.api.minecraft.RegistryEntry;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_21_2;
@@ -33,6 +34,7 @@ import com.viaversion.viaversion.protocols.v1_21to1_21_2.Protocol1_21To1_21_2;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.packet.ClientboundPackets1_21_2;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.packet.ServerboundPackets1_21_2;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.BundleStateTracker;
+import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.ChunkLoadTracker;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.ClientVehicleStorage;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.PlayerPositionStorage;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
@@ -121,6 +123,12 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
             wrapper.passthrough(Types.VAR_INT); // Portal cooldown
 
             wrapper.write(Types.VAR_INT, 64); // Sea level
+
+            final EntityTracker entityTracker = tracker(wrapper.user());
+            if (entityTracker.currentWorld() != null && !entityTracker.currentWorld().equals(world)) {
+                wrapper.user().get(ChunkLoadTracker.class).clear();
+            }
+
             trackWorldDataByKey1_20_5(wrapper.user(), dimensionId, world);
 
             wrapper.user().remove(ClientVehicleStorage.class);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/ChunkLoadTracker.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/ChunkLoadTracker.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_21to1_21_2.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.minecraft.ChunkPosition;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ChunkLoadTracker implements StorableObject {
+
+    private final Set<Long> loadedChunks = new HashSet<>();
+
+    public void addChunk(final int x, final int z) {
+        this.loadedChunks.add(ChunkPosition.chunkKey(x, z));
+    }
+
+    public void removeChunk(final int x, final int z) {
+        this.loadedChunks.remove(ChunkPosition.chunkKey(x, z));
+    }
+
+    public boolean isChunkLoaded(final int x, final int z) {
+        return this.loadedChunks.contains(ChunkPosition.chunkKey(x, z));
+    }
+
+    public void clear() {
+        this.loadedChunks.clear();
+    }
+
+}


### PR DESCRIPTION
1.21.3 no longer allows overwriting an already loaded chunk. To fix this the chunk has to be unloaded first.

Fixes https://github.com/ViaVersion/ViaProxy/issues/313