### PR TITLE
Drop idle packets where only horizontal collision changed in 1.21->1.21.2

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/Protocol1_21To1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/Protocol1_21To1_21_2.java
@@ -49,6 +49,7 @@ import com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter.ParticleRewrit
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.BundleStateTracker;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.ChunkLoadTracker;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.EntityTracker1_21_2;
+import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.GroundFlagTracker;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.PlayerPositionStorage;
 import com.viaversion.viaversion.rewriter.AttributeRewriter;
 import com.viaversion.viaversion.rewriter.SoundRewriter;
@@ -234,6 +235,7 @@ public final class Protocol1_21To1_21_2 extends AbstractProtocol<ClientboundPack
         connection.put(new BundleStateTracker());
         connection.put(new PlayerPositionStorage());
         connection.put(new ChunkLoadTracker());
+        connection.put(new GroundFlagTracker());
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/EntityPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/EntityPacketRewriter1_21_2.java
@@ -40,6 +40,7 @@ import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.BundleStateTrac
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.ChunkLoadTracker;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.ClientVehicleStorage;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.EntityTracker1_21_2;
+import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.GroundFlagTracker;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.PlayerPositionStorage;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.rewriter.RegistryDataRewriter;
@@ -314,7 +315,7 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
             wrapper.passthrough(Types.DOUBLE); // X
             wrapper.passthrough(Types.DOUBLE); // Y
             wrapper.passthrough(Types.DOUBLE); // Z
-            readOnGround(wrapper);
+            handleOnGround(wrapper);
         });
         protocol.registerServerbound(ServerboundPackets1_21_2.MOVE_PLAYER_POS_ROT, wrapper -> {
             final double x = wrapper.passthrough(Types.DOUBLE); // X
@@ -322,7 +323,7 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
             final double z = wrapper.passthrough(Types.DOUBLE); // Z
             final float yaw = wrapper.passthrough(Types.FLOAT); // Yaw
             final float pitch = wrapper.passthrough(Types.FLOAT); // Pitch
-            readOnGround(wrapper);
+            handleOnGround(wrapper);
 
             final PlayerPositionStorage playerPositionStorage = wrapper.user().get(PlayerPositionStorage.class);
             if (playerPositionStorage.checkCaptureNextPlayerPositionPacket()) {
@@ -335,9 +336,19 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
         protocol.registerServerbound(ServerboundPackets1_21_2.MOVE_PLAYER_ROT, wrapper -> {
             wrapper.passthrough(Types.FLOAT); // Yaw
             wrapper.passthrough(Types.FLOAT); // Pitch
-            readOnGround(wrapper);
+            handleOnGround(wrapper);
         });
-        protocol.registerServerbound(ServerboundPackets1_21_2.MOVE_PLAYER_STATUS_ONLY, this::readOnGround);
+        protocol.registerServerbound(ServerboundPackets1_21_2.MOVE_PLAYER_STATUS_ONLY, wrapper -> {
+            final GroundFlagTracker tracker = wrapper.user().get(GroundFlagTracker.class);
+            final boolean prevOnGround = tracker.onGround();
+            final boolean prevHorizontalCollision = tracker.horizontalCollision();
+
+            handleOnGround(wrapper);
+            if (prevOnGround == tracker.onGround() && prevHorizontalCollision != tracker.horizontalCollision()) {
+                // Newer clients will send idle packets even though the on ground state didn't change, ignore them
+                wrapper.cancel();
+            }
+        });
         protocol.registerServerbound(ServerboundPackets1_21_2.ACCEPT_TELEPORTATION, wrapper -> {
             final PlayerPositionStorage playerPositionStorage = wrapper.user().get(PlayerPositionStorage.class);
             if (playerPositionStorage.checkHasPlayerPosition()) {
@@ -370,9 +381,12 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
         return registryDataRewriter;
     }
 
-    private void readOnGround(final PacketWrapper wrapper) {
+    private void handleOnGround(final PacketWrapper wrapper) {
+        final GroundFlagTracker tracker = wrapper.user().get(GroundFlagTracker.class);
+
         final short data = wrapper.read(Types.UNSIGNED_BYTE);
-        wrapper.write(Types.BOOLEAN, (data & 1) != 0); // On ground, ignoring horizontal collision data
+        wrapper.write(Types.BOOLEAN, tracker.setOnGround((data & 1) != 0)); // Ignoring horizontal collision data
+        tracker.setHorizontalCollision((data & 2) != 0);
     }
 
     private void storeEntityPositionRotation(final PacketWrapper wrapper, final boolean position, final boolean rotation) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/GroundFlagTracker.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/GroundFlagTracker.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_21to1_21_2.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+
+public final class GroundFlagTracker implements StorableObject {
+
+    private boolean onGround;
+    private boolean horizontalCollision;
+
+    public boolean onGround() {
+        return this.onGround;
+    }
+
+    public boolean setOnGround(boolean onGround) {
+        return this.onGround = onGround;
+    }
+
+    public boolean horizontalCollision() {
+        return this.horizontalCollision;
+    }
+
+    public void setHorizontalCollision(boolean horizontalCollision) {
+        this.horizontalCollision = horizontalCollision;
+    }
+
+}


### PR DESCRIPTION
Since Minecraft 1.21.2, the client now also sends idle packets when the horizontal collision flag changed. This can cause bad packets on older servers where the flag didn't exist (causing the client to send idle packets without the ground state changing).