### PR TITLE
Change the consume animation of swords to block

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -416,7 +416,7 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
         }
 
         super.handleItemToClient(connection, item);
-        updateItemData(connection, item);
+        updateItemData(item);
 
         // Add data components to fix issues in older protocols
         appendItemDataFixComponents(connection, item);
@@ -484,7 +484,7 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
         }
     }
 
-    public static void updateItemData(final UserConnection user, final Item item) {
+    public static void updateItemData(final Item item) {
         final StructuredDataContainer dataContainer = item.dataContainer();
         dataContainer.replace(StructuredDataKey.INSTRUMENT1_20_5, StructuredDataKey.INSTRUMENT1_21_2, instrument -> {
             if (instrument.hasId()) {


### PR DESCRIPTION
Restores the blocking animation for swords on 1.8 or lower servers

![image](https://github.com/user-attachments/assets/ad1086d5-5d7c-4c32-abe2-e2a0b42747fc)

This only works on 22w44a+ client due to a client bug. The animation exists in 1.21.3, but doesn't render in first person.