### PR TITLE
Skip ViaProxy update check in runViaProxy gradle task

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -30,6 +30,7 @@ tasks.register<JavaExec>("runViaProxy") {
     mainClass.set("net.raphimc.viaproxy.ViaProxy")
     classpath = viaProxyConfiguration
     workingDir = file("run")
+    jvmArgs = listOf("-DskipUpdateCheck")
 
     doFirst {
         val jarsDir = file("$workingDir/jars")


### PR DESCRIPTION
Update check isn't needed in this use case