### PR TITLE
Fix protocol error when an empty lock is sent (picking beacon, etc.)

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -563,15 +563,17 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
         dataContainer.replaceKey(StructuredDataKey.BUNDLE_CONTENTS1_21, StructuredDataKey.BUNDLE_CONTENTS1_21_2);
         dataContainer.replaceKey(StructuredDataKey.POTION_CONTENTS1_20_5, StructuredDataKey.POTION_CONTENTS1_21_2);
         dataContainer.replace(StructuredDataKey.FIRE_RESISTANT, StructuredDataKey.DAMAGE_RESISTANT, fireResistant -> new DamageResistant("minecraft:is_fire"));
-        dataContainer.replace(StructuredDataKey.LOCK, lock -> {
+        dataContainer.replace(StructuredDataKey.LOCK, tag -> {
+            final String lock = ((StringTag) tag).getValue();
+            if (lock.isEmpty()) {
+                // Previously ignored empty values since the data was arbitrary, custom_name doesn't accept empty values
+                return null;
+            }
+
             final CompoundTag predicateTag = new CompoundTag();
             final CompoundTag itemComponentsTag = new CompoundTag();
-            if (!(lock instanceof StringTag tag && (tag.getValue().isEmpty() || tag.getValue().contains(" ")))) {
-                itemComponentsTag.put("custom_name", lock);
-            }
-            if (!itemComponentsTag.isEmpty()) {
-                predicateTag.put("components", itemComponentsTag);
-            }
+            predicateTag.put("components", itemComponentsTag);
+            itemComponentsTag.put("custom_name", tag);
             return predicateTag;
         });
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -566,8 +566,12 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
         dataContainer.replace(StructuredDataKey.LOCK, lock -> {
             final CompoundTag predicateTag = new CompoundTag();
             final CompoundTag itemComponentsTag = new CompoundTag();
-            predicateTag.put("components", itemComponentsTag);
-            itemComponentsTag.put("custom_name", lock);
+            if (!(lock instanceof StringTag tag && (tag.getValue().isEmpty() || tag.getValue().contains(" ")))) {
+                itemComponentsTag.put("custom_name", lock);
+            }
+            if (!itemComponentsTag.isEmpty()) {
+                predicateTag.put("components", itemComponentsTag);
+            }
             return predicateTag;
         });
     }


### PR DESCRIPTION
In 1.8, when picking any container block, with 1.21.3 the client will disconnect with the following protocol error:
```
Caused by: io.netty.handler.codec.DecoderException: Failed to decode: Failed to parse either. First: Failed to parse either. First: Not a string: null; Second: Not a json array: null; Second: Not a JSON object: null missed input: {custom_name:""} {components:{custom_name:""}}
```