### PR TITLE
Properly remove custom_data component if we created it in 1.20.5+ protocols

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -484,9 +484,7 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
 
         if (customData.remove(nbtTagName("remove_custom_name")) != null) {
             dataContainer.remove(StructuredDataKey.CUSTOM_NAME);
-            if (customData.isEmpty()) {
-                dataContainer.remove(StructuredDataKey.CUSTOM_DATA);
-            }
+            removeCustomTag(dataContainer, customData);
         }
 
         final IntArrayTag emptyEnchantments = customData.getIntArrayTag(nbtTagName("0_enchants"));
@@ -504,9 +502,7 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
             if (customData.remove(nbtTagName("remove_glint")) != null) {
                 dataContainer.remove(StructuredDataKey.ENCHANTMENT_GLINT_OVERRIDE);
             }
-            if (customData.isEmpty()) {
-                dataContainer.remove(StructuredDataKey.CUSTOM_DATA);
-            }
+            removeCustomTag(dataContainer, customData);
         }
         return item;
     }

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/StructuredItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/StructuredItemRewriter.java
@@ -246,12 +246,9 @@ public class StructuredItemRewriter<C extends ClientboundPacketType, S extends S
     }
 
     protected void removeCustomTag(final StructuredDataContainer data, final CompoundTag customData) {
-        // Only remove if we initially added it and it's now empty again
-        if (customData.contains(MARKER_KEY)) {
-            customData.remove(MARKER_KEY);
-            if (customData.isEmpty()) {
-                data.remove(StructuredDataKey.CUSTOM_DATA);
-            }
+        // Only remove if we initially added it and only the marker is left
+        if (customData.contains(MARKER_KEY) && customData.size() == 1) {
+            data.remove(StructuredDataKey.CUSTOM_DATA);
         }
     }
 


### PR DESCRIPTION
Adds StructuredItemRewriter#removeCustomTag which removes the initial created custom data component if we created it for tracking.