### PR TITLE
Improve 1.21 client enchantments in legacy servers

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/v1_20_5to1_21/LegacyChangeItemListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/v1_20_5to1_21/LegacyChangeItemListener.java
@@ -27,6 +27,7 @@ import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 
 public class LegacyChangeItemListener extends PlayerChangeItemListener {
 
@@ -43,21 +44,24 @@ public class LegacyChangeItemListener extends PlayerChangeItemListener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onInventoryClose(final InventoryCloseEvent event) {
-        if (!(event.getPlayer() instanceof Player player)) return;
-        if (event.getInventory().getType() != InventoryType.CRAFTING &&
-            event.getInventory().getType() != InventoryType.PLAYER) return;
-        sendArmorUpdate(player);
+        if (event.getPlayer() instanceof Player player &&
+            (event.getInventory().getType() == InventoryType.CRAFTING ||
+                event.getInventory().getType() == InventoryType.PLAYER)) {
+            sendArmorUpdate(player);
+        }
     }
 
-    void sendArmorUpdate(final Player player) {
+    private void sendArmorUpdate(final Player player) {
         final UserConnection connection = getUserConnection(player);
         final EfficiencyAttributeStorage storage = getEfficiencyStorage(connection);
-        if (storage == null) return;
+        if (storage == null) {
+            return;
+        }
 
-        final var inventory = player.getInventory();
-        ItemStack helmet = inventory.getHelmet();
-        ItemStack leggings = swiftSneak != null ? inventory.getLeggings() : null;
-        ItemStack boots = depthStrider != null ? inventory.getBoots() : null;
+        final PlayerInventory inventory = player.getInventory();
+        final ItemStack helmet = inventory.getHelmet();
+        final ItemStack leggings = swiftSneak != null ? inventory.getLeggings() : null;
+        final ItemStack boots = depthStrider != null ? inventory.getBoots() : null;
 
         storage.setEnchants(player.getEntityId(), connection, storage.activeEnchants()
             .aquaAffinity(helmet != null ? helmet.getEnchantmentLevel(aquaAffinity) : 0)

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/v1_20_5to1_21/LegacyChangeItemListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/v1_20_5to1_21/LegacyChangeItemListener.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.bukkit.listeners.v1_20_5to1_21;
+
+import com.viaversion.viaversion.ViaVersionPlugin;
+import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.protocols.v1_20_5to1_21.storage.EfficiencyAttributeStorage;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.BlockDamageEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
+
+public class LegacyChangeItemListener extends PlayerChangeItemListener {
+
+    public LegacyChangeItemListener(final ViaVersionPlugin plugin) {
+        super(plugin);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockDamageEvent(final BlockDamageEvent event) {
+        final Player player = event.getPlayer();
+        final ItemStack item = event.getItemInHand();
+        sendAttributeUpdate(player, item, Slot.HAND);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onInventoryClose(final InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) return;
+        if (event.getInventory().getType() != InventoryType.CRAFTING &&
+            event.getInventory().getType() != InventoryType.PLAYER) return;
+        sendArmorUpdate(player);
+    }
+
+    void sendArmorUpdate(final Player player) {
+        final UserConnection connection = getUserConnection(player);
+        final EfficiencyAttributeStorage storage = getEfficiencyStorage(connection);
+        if (storage == null) return;
+
+        final var inventory = player.getInventory();
+        ItemStack helmet = inventory.getHelmet();
+        ItemStack leggings = swiftSneak != null ? inventory.getLeggings() : null;
+        ItemStack boots = depthStrider != null ? inventory.getBoots() : null;
+
+        storage.setEnchants(player.getEntityId(), connection, storage.activeEnchants()
+            .aquaAffinity(helmet != null ? helmet.getEnchantmentLevel(aquaAffinity) : 0)
+            .swiftSneak(leggings != null ? leggings.getEnchantmentLevel(swiftSneak) : 0)
+            .depthStrider(boots != null ? boots.getEnchantmentLevel(depthStrider) : 0));
+    }
+
+}

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/v1_20_5to1_21/PlayerChangeItemListener.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/listeners/v1_20_5to1_21/PlayerChangeItemListener.java
@@ -55,7 +55,7 @@ public class PlayerChangeItemListener extends ViaBukkitListener {
     }
 
     protected EfficiencyAttributeStorage getEfficiencyStorage(final UserConnection connection) {
-        return isOnPipe(connection) ? connection.get(EfficiencyAttributeStorage.class) : null;
+        return connection != null ? connection.get(EfficiencyAttributeStorage.class) : null;
     }
 
     void sendAttributeUpdate(final Player player, @Nullable final ItemStack item, final Slot slot) {
@@ -63,7 +63,7 @@ public class PlayerChangeItemListener extends ViaBukkitListener {
         final EfficiencyAttributeStorage storage = getEfficiencyStorage(connection);
         if (storage == null) return;
 
-        var enchants = storage.activeEnchants();
+        EfficiencyAttributeStorage.ActiveEnchants enchants = storage.activeEnchants();
         enchants = switch (slot) {
             case HAND -> enchants.efficiency(item != null ? item.getEnchantmentLevel(efficiency) : 0);
             case HELMET -> enchants.aquaAffinity(item != null ? item.getEnchantmentLevel(aquaAffinity) : 0);

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/platform/BukkitViaLoader.java
@@ -28,6 +28,7 @@ import com.viaversion.viaversion.bukkit.listeners.multiversion.PlayerSneakListen
 import com.viaversion.viaversion.bukkit.listeners.v1_14_4to1_15.EntityToggleGlideListener;
 import com.viaversion.viaversion.bukkit.listeners.v1_19_3to1_19_4.ArmorToggleListener;
 import com.viaversion.viaversion.bukkit.listeners.v1_18_2to1_19.BlockBreakListener;
+import com.viaversion.viaversion.bukkit.listeners.v1_20_5to1_21.LegacyChangeItemListener;
 import com.viaversion.viaversion.bukkit.listeners.v1_8to1_9.ArmorListener;
 import com.viaversion.viaversion.bukkit.listeners.v1_8to1_9.BlockListener;
 import com.viaversion.viaversion.bukkit.listeners.v1_8to1_9.DeathListener;
@@ -184,7 +185,7 @@ public class BukkitViaLoader implements ViaPlatformLoader {
             if (PaperViaInjector.hasClass("io.papermc.paper.event.player.PlayerInventorySlotChangeEvent")) {
                 new PaperPlayerChangeItemListener(plugin).register();
             } else {
-                new PlayerChangeItemListener(plugin).register();
+                new LegacyChangeItemListener(plugin).register();
             }
         }
     }

--- a/common/src/main/java/com/viaversion/viaversion/ViaListener.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaListener.java
@@ -48,7 +48,10 @@ public abstract class ViaListener {
      * @return True if on pipe
      */
     protected boolean isOnPipe(UUID uuid) {
-        UserConnection userConnection = getUserConnection(uuid);
+        return isOnPipe(getUserConnection(uuid));
+    }
+
+    protected boolean isOnPipe(UserConnection userConnection) {
         return userConnection != null &&
             (requiredPipeline == null || userConnection.getProtocolInfo().getPipeline().contains(requiredPipeline));
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/BlockItemPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/BlockItemPacketRewriter1_21.java
@@ -26,6 +26,7 @@ import com.viaversion.viaversion.api.minecraft.data.StructuredDataKey;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.minecraft.item.data.AttributeModifiers1_20_5;
 import com.viaversion.viaversion.api.minecraft.item.data.AttributeModifiers1_21;
+import com.viaversion.viaversion.api.minecraft.item.data.Enchantments;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_20_2;
@@ -79,20 +80,21 @@ public final class BlockItemPacketRewriter1_21 extends StructuredItemRewriter<Cl
         protocol.registerClientbound(ClientboundPackets1_20_5.CONTAINER_SET_SLOT, wrapper -> {
             final short containerId = wrapper.passthrough(Types.UNSIGNED_BYTE); // Container id
             wrapper.passthrough(Types.VAR_INT); // State id
-            Short slotId = wrapper.passthrough(Types.SHORT); // Slot id
+            final short slotId = wrapper.passthrough(Types.SHORT); // Slot id
             final Item item = handleItemToClient(wrapper.user(), wrapper.read(itemType));
             wrapper.write(mappedItemType, item);
 
             // When a players' armor is set, update their attributes
-            if (containerId != 0
-                || slotId > BOOTS_SLOT
-                || slotId < HELMET_SLOT
-                || slotId == CHESTPLATE_SLOT) return;
+            if (containerId != 0 || slotId > BOOTS_SLOT || slotId < HELMET_SLOT || slotId == CHESTPLATE_SLOT) {
+                return;
+            }
 
             final EfficiencyAttributeStorage storage = wrapper.user().get(EfficiencyAttributeStorage.class);
-            if (storage == null) return;
-            var enchants = item.dataContainer().get(StructuredDataKey.ENCHANTMENTS);
-            var active = storage.activeEnchants();
+            if (storage == null) {
+                return;
+            }
+            Enchantments enchants = item.dataContainer().get(StructuredDataKey.ENCHANTMENTS);
+            EfficiencyAttributeStorage.ActiveEnchants active = storage.activeEnchants();
             active = switch (slotId) {
                 case HELMET_SLOT -> active.aquaAffinity(enchants == null ? 0 : enchants.getLevel(AQUA_AFFINITY_ID));
                 case LEGGINGS_SLOT -> active.swiftSneak(enchants == null ? 0 : enchants.getLevel(SWIFT_SNEAK_ID));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/BlockItemPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/BlockItemPacketRewriter1_21.java
@@ -81,8 +81,8 @@ public final class BlockItemPacketRewriter1_21 extends StructuredItemRewriter<Cl
             final short containerId = wrapper.passthrough(Types.UNSIGNED_BYTE); // Container id
             wrapper.passthrough(Types.VAR_INT); // State id
             final short slotId = wrapper.passthrough(Types.SHORT); // Slot id
-            final Item item = handleItemToClient(wrapper.user(), wrapper.read(itemType));
-            wrapper.write(mappedItemType, item);
+            final Item item = handleItemToClient(wrapper.user(), wrapper.read(itemType()));
+            wrapper.write(mappedItemType(), item);
 
             // When a players' armor is set, update their attributes
             if (containerId != 0 || slotId > BOOTS_SLOT || slotId < HELMET_SLOT || slotId == CHESTPLATE_SLOT) {
@@ -90,9 +90,6 @@ public final class BlockItemPacketRewriter1_21 extends StructuredItemRewriter<Cl
             }
 
             final EfficiencyAttributeStorage storage = wrapper.user().get(EfficiencyAttributeStorage.class);
-            if (storage == null) {
-                return;
-            }
             Enchantments enchants = item.dataContainer().get(StructuredDataKey.ENCHANTMENTS);
             EfficiencyAttributeStorage.ActiveEnchants active = storage.activeEnchants();
             active = switch (slotId) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
@@ -111,7 +111,8 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
                 map(Types.STRING); // World
                 handler(worldDataTrackerHandlerByKey1_20_5(3));
                 handler(playerTrackerHandler());
-                handler(wrapper -> wrapper.user().get(EfficiencyAttributeStorage.class).onLoginSent(wrapper.user()));
+                handler(wrapper -> wrapper.user().get(EfficiencyAttributeStorage.class)
+                    .onLoginSent(wrapper.get(Types.INT, 0), wrapper.user()));
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/storage/EfficiencyAttributeStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/storage/EfficiencyAttributeStorage.java
@@ -127,11 +127,11 @@ public final class EfficiencyAttributeStorage implements StorableObject {
 
         public ActiveEnchants efficiency(int level) {
             return efficiency.level == level ? this : new ActiveEnchants(entityId,
-                    new ActiveEnchant(efficiency, level),
-                    soulSpeed,
-                    swiftSneak,
-                    aquaAffinity,
-                    depthStrider);
+                new ActiveEnchant(efficiency, level),
+                soulSpeed,
+                swiftSneak,
+                aquaAffinity,
+                depthStrider);
         }
 
         public ActiveEnchants soulSpeed(int level) {
@@ -142,6 +142,7 @@ public final class EfficiencyAttributeStorage implements StorableObject {
                 aquaAffinity,
                 depthStrider);
         }
+
         public ActiveEnchants swiftSneak(int level) {
             return swiftSneak.level == level ? this : new ActiveEnchants(entityId,
                 efficiency,
@@ -150,6 +151,7 @@ public final class EfficiencyAttributeStorage implements StorableObject {
                 aquaAffinity,
                 depthStrider);
         }
+
         public ActiveEnchants aquaAffinity(int level) {
             return aquaAffinity.level == level ? this : new ActiveEnchants(entityId,
                 efficiency,
@@ -158,6 +160,7 @@ public final class EfficiencyAttributeStorage implements StorableObject {
                 new ActiveEnchant(aquaAffinity, level),
                 depthStrider);
         }
+
         public ActiveEnchants depthStrider(int level) {
             return depthStrider.level == level ? this : new ActiveEnchants(entityId,
                 efficiency,

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
@@ -36,14 +36,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ItemRewriter<C extends ClientboundPacketType, S extends ServerboundPacketType,
     T extends Protocol<C, ?, ?, S>> extends RewriterBase<T> implements com.viaversion.viaversion.api.rewriter.ItemRewriter<T> {
-    private final Type<Item> itemType;
-    private final Type<Item> mappedItemType;
-    private final Type<Item[]> itemArrayType;
-    private final Type<Item[]> mappedItemArrayType;
-    private final Type<Item> itemCostType;
-    private final Type<Item> mappedItemCostType;
-    private final Type<Item> optionalItemCostType;
-    private final Type<Item> mappedOptionalItemCostType;
+    protected final Type<Item> itemType;
+    protected final Type<Item> mappedItemType;
+    protected final Type<Item[]> itemArrayType;
+    protected final Type<Item[]> mappedItemArrayType;
+    protected final Type<Item> itemCostType;
+    protected final Type<Item> mappedItemCostType;
+    protected final Type<Item> optionalItemCostType;
+    protected final Type<Item> mappedOptionalItemCostType;
 
     public ItemRewriter(
         T protocol,

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/ItemRewriter.java
@@ -36,14 +36,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ItemRewriter<C extends ClientboundPacketType, S extends ServerboundPacketType,
     T extends Protocol<C, ?, ?, S>> extends RewriterBase<T> implements com.viaversion.viaversion.api.rewriter.ItemRewriter<T> {
-    protected final Type<Item> itemType;
-    protected final Type<Item> mappedItemType;
-    protected final Type<Item[]> itemArrayType;
-    protected final Type<Item[]> mappedItemArrayType;
-    protected final Type<Item> itemCostType;
-    protected final Type<Item> mappedItemCostType;
-    protected final Type<Item> optionalItemCostType;
-    protected final Type<Item> mappedOptionalItemCostType;
+    private final Type<Item> itemType;
+    private final Type<Item> mappedItemType;
+    private final Type<Item[]> itemArrayType;
+    private final Type<Item[]> mappedItemArrayType;
+    private final Type<Item> itemCostType;
+    private final Type<Item> mappedItemCostType;
+    private final Type<Item> optionalItemCostType;
+    private final Type<Item> mappedOptionalItemCostType;
 
     public ItemRewriter(
         T protocol,


### PR DESCRIPTION
Fixes #4235 

Legacy servers (anything without modern paper PlayerInventorySlotChangeEvent) will attempt to sync enchantments 
 in a few occasions:
- punching blocks (efficiency)
- closing inventory (armor)
- the clientbound set container slot packet (armor)

From testing it seems to be working ok (1.8 server) and even if there's still some ways to desync it (eg: right clicking to equip armor) i think it's good enough, worst case scenario reopening the inventory will fix it.