### PR TITLE
Only print invalid custom payload channel warnings in debug mode

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/ItemPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/ItemPacketRewriter1_13.java
@@ -205,7 +205,7 @@ public class ItemPacketRewriter1_13 extends ItemRewriter<ClientboundPackets1_12_
                     String old = channel;
                     channel = getOldPluginChannelId(channel);
                     if (channel == null) {
-                        if (!Via.getConfig().isSuppressConversionWarnings()) {
+                        if (Via.getManager().isDebug()) {
                             protocol.getLogger().warning("Ignoring serverbound plugin message with channel: " + old);
                         }
                         wrapper.cancel();
@@ -217,7 +217,7 @@ public class ItemPacketRewriter1_13 extends ItemRewriter<ClientboundPackets1_12_
                             String rewritten = getOldPluginChannelId(s);
                             if (rewritten != null) {
                                 rewrittenChannels.add(rewritten);
-                            } else if (!Via.getConfig().isSuppressConversionWarnings()) {
+                            } else if (Via.getManager().isDebug()) {
                                 protocol.getLogger().warning("Ignoring plugin channel in serverbound " + channel + ": " + s);
                             }
                         }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/Protocol1_15_2To1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/Protocol1_15_2To1_16.java
@@ -172,7 +172,7 @@ public class Protocol1_15_2To1_16 extends AbstractProtocol<ClientboundPackets1_1
                         final String channel = wrapper.get(Types.STRING, 0);
                         final String namespacedChannel = Key.namespaced(channel);
                         if (channel.length() > 32) {
-                            if (!Via.getConfig().isSuppressConversionWarnings()) {
+                            if (Via.getManager().isDebug()) {
                                 getLogger().warning("Ignoring serverbound plugin channel, as it is longer than 32 characters: " + channel);
                             }
                             wrapper.cancel();
@@ -181,7 +181,7 @@ public class Protocol1_15_2To1_16 extends AbstractProtocol<ClientboundPackets1_1
                             List<String> checkedChannels = new ArrayList<>(channels.length);
                             for (String registeredChannel : channels) {
                                 if (registeredChannel.length() > 32) {
-                                    if (!Via.getConfig().isSuppressConversionWarnings()) {
+                                    if (Via.getManager().isDebug()) {
                                         getLogger().warning("Ignoring serverbound plugin channel register of '" + registeredChannel + "', as it is longer than 32 characters");
                                     }
                                     continue;


### PR DESCRIPTION
We previously had people complaining about this being an error and not understanding what it means + servers can't do anything about these errors anyway.