### PR TITLE
Fix block ids not getting remapped

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/rewriter/BlockRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/BlockRewriter.java
@@ -67,11 +67,11 @@ public class BlockRewriter<C extends ClientboundPacketType> {
     }
 
     public void registerBlockEvent(C packetType) {
-        if (protocol.getMappingData().getBlockMappings() == null) {
-            return;
-        }
-
         protocol.registerClientbound(packetType, wrapper -> {
+            if (protocol.getMappingData().getBlockMappings() == null) {
+                return;
+            }
+
             wrapper.passthrough(positionType); // Location
             wrapper.passthrough(Types.UNSIGNED_BYTE); // Action id
             wrapper.passthrough(Types.UNSIGNED_BYTE); // Action param


### PR DESCRIPTION
Block ids are not getting remapped, because `getBlockMappings()` is always null as the mappings are not loaded before the registration/initialization.

It's also possible to load the mappings before and wait for all mappings to be loaded (as this is done on an executor thread), but this approach is way less invasive, and still correct.

This only affects players using Geyser at the moment (as Geyser uses the block id to translate block event, chest animation not working etc.), but who knows if Java Edition extends its validation, or alters behavior.