### PR TITLE
Fix footstep particle causing null kick

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/data/FullMappingsBase.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/data/FullMappingsBase.java
@@ -95,7 +95,7 @@ public class FullMappingsBase implements FullMappings {
     }
 
     @Override
-    public String mappedIdentifier(final int mappedId) {
+    public @Nullable String mappedIdentifier(final int mappedId) {
         if (mappedId < 0 || mappedId >= mappedIdToString.length) {
             return null;
         }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/ParticleRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/ParticleRewriter1_21_2.java
@@ -18,7 +18,6 @@
 package com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter;
 
 import com.viaversion.viaversion.api.connection.UserConnection;
-import com.viaversion.viaversion.api.data.ParticleMappings;
 import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.type.Types;
@@ -45,8 +44,7 @@ public final class ParticleRewriter1_21_2 extends ParticleRewriter<ClientboundPa
     public void rewriteParticle(final UserConnection connection, final Particle particle) {
         super.rewriteParticle(connection, particle);
         
-        ParticleMappings particleMappings = protocol.getMappingData().getParticleMappings();
-        final String identifier = particleMappings.mappedIdentifier(particle.id());
+        final String identifier = protocol.getMappingData().getParticleMappings().mappedIdentifier(particle.id());
         if ("minecraft:dust_color_transition".equals(identifier)) {
             floatsToARGB(particle, 0);
             floatsToARGB(particle, 1);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/ParticleRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/ParticleRewriter1_21_2.java
@@ -18,7 +18,6 @@
 package com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter;
 
 import com.viaversion.viaversion.api.connection.UserConnection;
-import com.viaversion.viaversion.api.data.MappingData;
 import com.viaversion.viaversion.api.data.ParticleMappings;
 import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.protocol.Protocol;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/ParticleRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/ParticleRewriter1_21_2.java
@@ -45,17 +45,8 @@ public final class ParticleRewriter1_21_2 extends ParticleRewriter<ClientboundPa
     @Override
     public void rewriteParticle(final UserConnection connection, final Particle particle) {
         super.rewriteParticle(connection, particle);
-
-        MappingData mappingData = protocol.getMappingData();
-        if (mappingData == null) {
-            return;
-        }
-
-        ParticleMappings particleMappings = mappingData.getParticleMappings();
-        if (particleMappings == null) {
-            return;
-        }
-
+        
+        ParticleMappings particleMappings = protocol.getMappingData().getParticleMappings();
         final String identifier = particleMappings.mappedIdentifier(particle.id());
         if ("minecraft:dust_color_transition".equals(identifier)) {
             floatsToARGB(particle, 0);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/ParticleRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/ParticleRewriter1_21_2.java
@@ -18,6 +18,8 @@
 package com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter;
 
 import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.data.MappingData;
+import com.viaversion.viaversion.api.data.ParticleMappings;
 import com.viaversion.viaversion.api.minecraft.Particle;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.type.Types;
@@ -44,11 +46,21 @@ public final class ParticleRewriter1_21_2 extends ParticleRewriter<ClientboundPa
     public void rewriteParticle(final UserConnection connection, final Particle particle) {
         super.rewriteParticle(connection, particle);
 
-        final String identifier = protocol.getMappingData().getParticleMappings().mappedIdentifier(particle.id());
-        if (identifier.equals("minecraft:dust_color_transition")) {
+        MappingData mappingData = protocol.getMappingData();
+        if (mappingData == null) {
+            return;
+        }
+
+        ParticleMappings particleMappings = mappingData.getParticleMappings();
+        if (particleMappings == null) {
+            return;
+        }
+
+        final String identifier = particleMappings.mappedIdentifier(particle.id());
+        if ("minecraft:dust_color_transition".equals(identifier)) {
             floatsToARGB(particle, 0);
             floatsToARGB(particle, 1);
-        } else if (identifier.equals("minecraft:dust")) {
+        } else if ("minecraft:dust".equals(identifier)) {
             floatsToARGB(particle, 0);
         }
     }


### PR DESCRIPTION
Added checks for when getMappingData returns null and getParticleMappings returns null.

Also swapped the equals check around to stop null issues.

This fixes the recent bug I found when playing 1.8.x bedwarspractice and was getting kicked when using invis and the footstep particles spawned.