### PR TITLE
Fix item meta not being saved when including block state data

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
@@ -79,6 +79,7 @@ public final class BukkitPickItemProvider extends PickItemProvider {
             final ItemStack item = new ItemStack(block.getBlockData().getPlacementMaterial(), 1);
             if (includeData && item.getItemMeta() instanceof final BlockStateMeta blockStateMeta) {
                 blockStateMeta.setBlockState(block.getState());
+                item.setItemMeta(blockStateMeta);
             }
             return item;
         } else if (block.getType().isItem()) {


### PR DESCRIPTION
ItemMeta always gets cloned when accessed - it seems like the set was just forgotten