### PR TITLE
Sword blocking: consumables for 1.21.4+, back to shields for 1.20.5-1.21.3

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -478,12 +478,4 @@ public interface ViaVersionConfig extends Config {
      * @return true if enabled
      */
     boolean fix1_21PlacementRotation();
-
-    /**
-     * If enabled, 1.20.5+ clients will have sword blocking mechanics on 1.8 servers using the consumable item component.
-     * Note that you won't be able to see the blocking in first person if the client is older than 1.21.4.
-     *
-     * @return true if enabled
-     */
-    boolean swordBlockingViaConsumable();
 }

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -96,7 +96,6 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private boolean cancelBlockSounds;
     private boolean hideScoreboardNumbers;
     private boolean fix1_21PlacementRotation;
-    private boolean swordBlockingViaConsumable;
 
     protected AbstractViaConfig(final File configFile, final Logger logger) {
         super(configFile, logger);
@@ -166,7 +165,6 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         cancelBlockSounds = getBoolean("cancel-block-sounds", true);
         hideScoreboardNumbers = getBoolean("hide-scoreboard-numbers", false);
         fix1_21PlacementRotation = getBoolean("fix-1_21-placement-rotation", true);
-        swordBlockingViaConsumable = getBoolean("sword-blocking-via-consumable", true);
     }
 
     private BlockedProtocolVersions loadBlockedProtocolVersions() {
@@ -557,10 +555,5 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public boolean fix1_21PlacementRotation() {
         return fix1_21PlacementRotation;
-    }
-
-    @Override
-    public boolean swordBlockingViaConsumable() {
-        return swordBlockingViaConsumable;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -619,12 +619,6 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
                 item.dataContainer().set(StructuredDataKey.MAX_DAMAGE, 326);
             }
         }
-        if (Via.getConfig().swordBlockingViaConsumable() && serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_8)) {
-            if (item.identifier() == 814 || item.identifier() == 819 || item.identifier() == 824 || item.identifier() == 829 || item.identifier() == 834) { // swords
-                // Make sword "eatable" to enable clientside instant blocking on 1.8. Consume time is set really high, so the eating animation doesn't play
-                item.dataContainer().set(StructuredDataKey.FOOD1_20_5, new FoodProperties1_20_5(0, 0F, true, 3600, null, new FoodEffect[0]));
-            }
-        }
     }
 
     private int unmappedItemId(final String name) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/rewriter/BlockItemPacketRewriter1_21_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/rewriter/BlockItemPacketRewriter1_21_4.java
@@ -140,7 +140,7 @@ public final class BlockItemPacketRewriter1_21_4 extends StructuredItemRewriter<
 
     private void appendItemDataFixComponents(final UserConnection connection, final Item item) {
         final ProtocolVersion serverVersion = connection.getProtocolInfo().serverProtocolVersion();
-        if (Via.getConfig().swordBlockingViaConsumable() && serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_8)) {
+        if (serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_8)) {
             if (item.identifier() == 849 || item.identifier() == 854 || item.identifier() == 859 || item.identifier() == 864 || item.identifier() == 869) { // swords
                 // Make sword "eatable" to enable clientside instant blocking on 1.8. Set consume animation to block,
                 // and consume time really high, so the eating animation doesn't play

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -47,7 +47,6 @@ import com.viaversion.viaversion.api.minecraft.item.data.Instrument1_20_5;
 import com.viaversion.viaversion.api.minecraft.item.data.Instrument1_21_2;
 import com.viaversion.viaversion.api.minecraft.item.data.PotionEffect;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
-import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_20_2;
 import com.viaversion.viaversion.api.type.types.version.Types1_21;
@@ -442,9 +441,6 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
 
         updateItemData(item);
 
-        // Add data components to fix issues in older protocols
-        appendItemDataFixComponents(connection, item);
-
         final Enchantments enchantments = data.get(StructuredDataKey.ENCHANTMENTS);
         if (enchantments != null && enchantments.size() != 0) {
             // Level 0 is no longer allowed
@@ -536,17 +532,6 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
     private void updateContainerIdServerbound(final PacketWrapper wrapper) {
         final int containerId = wrapper.read(Types.VAR_INT);
         wrapper.write(Types.UNSIGNED_BYTE, (short) containerId);
-    }
-
-    private void appendItemDataFixComponents(final UserConnection connection, final Item item) {
-        final ProtocolVersion serverVersion = connection.getProtocolInfo().serverProtocolVersion();
-        if (serverVersion.olderThanOrEqualTo(ProtocolVersion.v1_8) && item.dataContainer().hasValue(StructuredDataKey.CONSUMABLE1_21_2)) {
-            if (item.identifier() == 840 || item.identifier() == 845 || item.identifier() == 850 || item.identifier() == 855 || item.identifier() == 860) { // swords
-                // Change the consume animation of swords to block
-                final Consumable1_21_2 consumable = item.dataContainer().get(StructuredDataKey.CONSUMABLE1_21_2);
-                item.dataContainer().set(StructuredDataKey.CONSUMABLE1_21_2, new Consumable1_21_2(consumable.consumeSeconds(), 3, consumable.sound(), consumable.hasConsumeParticles(), consumable.consumeEffects()));
-            }
-        }
     }
 
     public static void updateItemData(final Item item) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/WorldPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/WorldPacketRewriter1_9.java
@@ -30,6 +30,7 @@ import com.viaversion.viaversion.api.minecraft.item.DataItem;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.BulkChunkType1_8;
@@ -297,8 +298,9 @@ public class WorldPacketRewriter1_9 {
             wrapper.write(Types.UNSIGNED_BYTE, (short) 255);
             // Write item in hand
             Item item = Via.getManager().getProviders().get(HandItemProvider.class).getHandItem(wrapper.user());
-            // Blocking patch
-            if (Via.getConfig().isShieldBlocking()) {
+            // Blocking patch for 1.9-1.21.3 clients
+            if (Via.getConfig().isShieldBlocking() && (!Via.getConfig().swordBlockingViaConsumable()
+                    || wrapper.user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_21_4))) {
                 EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
 
                 // Check if the shield is already there or if we have to give it here

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/WorldPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/WorldPacketRewriter1_9.java
@@ -299,8 +299,8 @@ public class WorldPacketRewriter1_9 {
             // Write item in hand
             Item item = Via.getManager().getProviders().get(HandItemProvider.class).getHandItem(wrapper.user());
             // Blocking patch for 1.9-1.21.3 clients
-            if (Via.getConfig().isShieldBlocking() && (!Via.getConfig().swordBlockingViaConsumable()
-                    || wrapper.user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_21_4))) {
+            if (Via.getConfig().isShieldBlocking() &&
+                    wrapper.user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_21_4)) {
                 EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
 
                 // Check if the shield is already there or if we have to give it here

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
@@ -103,8 +103,7 @@ public class EntityTracker1_9 extends EntityTrackerBase {
      * The item in the offhand will be cleared if there is no sword in the main hand.
      */
     public void syncShieldWithSword() {
-        if (Via.getConfig().swordBlockingViaConsumable()
-                && user().getProtocolInfo().protocolVersion().newerThanOrEqualTo(ProtocolVersion.v1_21_4)) {
+        if (user().getProtocolInfo().protocolVersion().newerThanOrEqualTo(ProtocolVersion.v1_21_4)) {
             // If sword blocking is done through consumables, don't add a shield.
             return;
         }
@@ -194,8 +193,8 @@ public class EntityTracker1_9 extends EntityTrackerBase {
                         if ((data & 0x10) == 0x10) {
                             // If sword blocking is done through consumables, don't add a shield. We can use
                             // 1.20.5 here because consumables display properly in 3rd person even in 1.20.5-1.21.3
-                            if (validBlocking.contains(entityId) && (!Via.getConfig().swordBlockingViaConsumable()
-                                    || user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_20_5))) {
+                            if (validBlocking.contains(entityId) &&
+                                    user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_20_5)) {
                                 Item shield = new DataItem(442, (byte) 1, (short) 0, null);
                                 setSecondHand(entityId, shield);
                             } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
@@ -191,10 +191,9 @@ public class EntityTracker1_9 extends EntityTrackerBase {
                     byte data = (byte) entityData.getValue();
                     if (entityId != getProvidedEntityId() && Via.getConfig().isShieldBlocking()) {
                         if ((data & 0x10) == 0x10) {
-                            // If sword blocking is done through consumables, don't add a shield. We can use
-                            // 1.20.5 here because consumables display properly in 3rd person even in 1.20.5-1.21.3
+                            // If sword blocking is done through consumables, don't add a shield.
                             if (validBlocking.contains(entityId) &&
-                                    user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_20_5)) {
+                                    user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_21_4)) {
                                 Item shield = new DataItem(442, (byte) 1, (short) 0, null);
                                 setSecondHand(entityId, shield);
                             } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
@@ -189,11 +189,11 @@ public class EntityTracker1_9 extends EntityTrackerBase {
                 if (entityData.id() == 0) {
                     // Byte
                     byte data = (byte) entityData.getValue();
-                    if (entityId != getProvidedEntityId() && Via.getConfig().isShieldBlocking()) {
+                    // If sword blocking is done through consumables (1.21.4+), don't add a shield.
+                    if (entityId != getProvidedEntityId() && Via.getConfig().isShieldBlocking()
+                            && user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_21_4)) {
                         if ((data & 0x10) == 0x10) {
-                            // If sword blocking is done through consumables, don't add a shield.
-                            if (validBlocking.contains(entityId) &&
-                                    user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_21_4)) {
+                            if (validBlocking.contains(entityId)) {
                                 Item shield = new DataItem(442, (byte) 1, (short) 0, null);
                                 setSecondHand(entityId, shield);
                             } else {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/EntityTracker1_9.java
@@ -31,6 +31,7 @@ import com.viaversion.viaversion.api.minecraft.entitydata.types.EntityDataTypes1
 import com.viaversion.viaversion.api.minecraft.item.DataItem;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.data.entity.EntityTrackerBase;
 import com.viaversion.viaversion.protocols.v1_8to1_9.Protocol1_8To1_9;
@@ -102,6 +103,12 @@ public class EntityTracker1_9 extends EntityTrackerBase {
      * The item in the offhand will be cleared if there is no sword in the main hand.
      */
     public void syncShieldWithSword() {
+        if (Via.getConfig().swordBlockingViaConsumable()
+                && user().getProtocolInfo().protocolVersion().newerThanOrEqualTo(ProtocolVersion.v1_21_4)) {
+            // If sword blocking is done through consumables, don't add a shield.
+            return;
+        }
+
         boolean swordInHand = hasSwordInHand();
 
         // Update if there is no sword in the main hand or if the player has no shield in the second hand but a sword in the main hand
@@ -185,7 +192,10 @@ public class EntityTracker1_9 extends EntityTrackerBase {
                     byte data = (byte) entityData.getValue();
                     if (entityId != getProvidedEntityId() && Via.getConfig().isShieldBlocking()) {
                         if ((data & 0x10) == 0x10) {
-                            if (validBlocking.contains(entityId)) {
+                            // If sword blocking is done through consumables, don't add a shield. We can use
+                            // 1.20.5 here because consumables display properly in 3rd person even in 1.20.5-1.21.3
+                            if (validBlocking.contains(entityId) && (!Via.getConfig().swordBlockingViaConsumable()
+                                    || user().getProtocolInfo().protocolVersion().olderThan(ProtocolVersion.v1_20_5))) {
                                 Item shield = new DataItem(442, (byte) 1, (short) 0, null);
                                 setSecondHand(entityId, shield);
                             } else {

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -215,6 +215,3 @@ chunk-border-fix: false
 left-handed-handling: true
 # Tries to cancel block break/place sounds sent by 1.8 servers to 1.9+ clients to prevent them from playing twice
 cancel-block-sounds: true
-# If enabled, 1.20.5+ clients will have sword blocking mechanics on 1.8 servers using the consumable item component.
-# Note that you won't be able to see the blocking in first person if the client is older than 1.21.4.
-sword-blocking-via-consumable: true


### PR DESCRIPTION
This PR has two commits, the first reimplements consumable blocking for 1.21.4 only, and removes all blocking-related shields from 1.21.4 clients, using consumables instead.

The reason consumable blocking is removed for 1.20.5-1.21.3 is that it currently doesn't work properly. With both `shield-blocking` and `sword-blocking-via-consumable` enabled (the former is required to still let 1.9-1.20.4 clients block), blocking in 1.20.5-1.21.3 *seems* to be working on the client, but the block doesn't actually get registered on the server *most of the time*. 

What I believe is happening is that the client starts eating, then when it receives a shield it stops using the item so the block gets cancelled server side. (I checked with a debugger and ViaVersion's `setBlocking` is correctly called with 1 `true` and 1 `false` for each shield cycle)

Obviously another solution would be to remove shields from 1.20.5-1.21.3 clients, but given the lack of first-person blocking animation for consumables, it could be somewhat confusing for users. If servers wish to have instant blocking on those versions, they can use the instant shield blocking config option, which works perfectly fine in my experience.

This change only affects 1.8 servers, and I'd probably expect most if not all of them to only care about supporting the latest version. So it shouldn't be that big of an issue to not support consumable blocking for versions in-between.

The other commit removes the `sword-blocking-via-consumable` config option. After the changes, the only reason to keep the option is to move back to shields in 1.21.4+, something you'd probably only do for consistency's sake.