### PR TITLE
Fix entity defaults across all protocols

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_10.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_10.java
@@ -22,7 +22,6 @@
  */
 package com.viaversion.viaversion.api.minecraft.entities;
 
-import com.viaversion.viaversion.api.Via;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +34,6 @@ public class EntityTypes1_10 {
             type = ObjectType.getEntityType(typeId);
         } else {
             type = EntityType.findById(typeId);
-        }
-        if (type == null) {
-            Via.getPlatform().getLogger().severe("Could not find 1.10 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_11.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_11.java
@@ -22,7 +22,6 @@
  */
 package com.viaversion.viaversion.api.minecraft.entities;
 
-import com.viaversion.viaversion.api.Via;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +34,6 @@ public class EntityTypes1_11 {
             type = ObjectType.getEntityType(typeId);
         } else {
             type = EntityType.findById(typeId);
-        }
-        if (type == null) {
-            Via.getPlatform().getLogger().severe("Could not find 1.11 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_12.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_12.java
@@ -22,7 +22,6 @@
  */
 package com.viaversion.viaversion.api.minecraft.entities;
 
-import com.viaversion.viaversion.api.Via;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +34,6 @@ public class EntityTypes1_12 {
             type = ObjectType.getEntityType(typeId);
         } else {
             type = EntityType.findById(typeId);
-        }
-        if (type == null) {
-            Via.getPlatform().getLogger().severe("Could not find 1.12 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_13.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_13.java
@@ -22,7 +22,6 @@
  */
 package com.viaversion.viaversion.api.minecraft.entities;
 
-import com.viaversion.viaversion.api.Via;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +34,6 @@ public class EntityTypes1_13 {
             type = ObjectType.getEntityType(typeId);
         } else {
             type = EntityType.findById(typeId);
-        }
-        if (type == null) {
-            Via.getPlatform().getLogger().severe("Could not find 1.13 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_14.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_14.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_14 implements EntityType {
@@ -246,7 +246,7 @@ public enum EntityTypes1_14 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_15.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_15.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_15 implements EntityType {
@@ -247,7 +247,7 @@ public enum EntityTypes1_15 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_16.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_16.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_16 implements EntityType {
@@ -251,7 +251,7 @@ public enum EntityTypes1_16 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_16_2.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_16_2.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_16_2 implements EntityType {
@@ -254,7 +254,7 @@ public enum EntityTypes1_16_2 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_17.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_17.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_17 implements EntityType {
@@ -260,7 +260,7 @@ public enum EntityTypes1_17 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_19 implements EntityType {
@@ -265,7 +265,7 @@ public enum EntityTypes1_19 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19_3.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19_3.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_19_3 implements EntityType {
@@ -266,7 +266,7 @@ public enum EntityTypes1_19_3 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19_4.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_19_4.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_19_4 implements EntityType {
@@ -273,7 +273,7 @@ public enum EntityTypes1_19_4 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_20_3.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_20_3.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_20_3 implements EntityType {
@@ -275,7 +275,7 @@ public enum EntityTypes1_20_3 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_20_5.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_20_5.java
@@ -25,8 +25,8 @@ package com.viaversion.viaversion.api.minecraft.entities;
 import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.util.EntityTypeUtil;
-import java.util.Locale;
 import com.viaversion.viaversion.util.Key;
+import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum EntityTypes1_20_5 implements EntityType {
@@ -281,7 +281,7 @@ public enum EntityTypes1_20_5 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_21_2.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_21_2.java
@@ -305,7 +305,7 @@ public enum EntityTypes1_21_2 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_21_4.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_21_4.java
@@ -304,7 +304,7 @@ public enum EntityTypes1_21_4 implements EntityType {
     }
 
     public static EntityType getTypeFromId(final int typeId) {
-        return EntityTypeUtil.getTypeFromId(TYPES, typeId, ENTITY);
+        return EntityTypeUtil.getTypeFromId(TYPES, typeId, PIG);
     }
 
     public static void initialize(final Protocol<?, ?, ?, ?> protocol) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_8.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_8.java
@@ -22,7 +22,6 @@
  */
 package com.viaversion.viaversion.api.minecraft.entities;
 
-import com.viaversion.viaversion.api.Via;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +34,6 @@ public class EntityTypes1_8 {
             type = ObjectType.getEntityType(typeId);
         } else {
             type = EntityType.findById(typeId);
-        }
-        if (type == null) {
-            Via.getPlatform().getLogger().severe("Could not find 1.8 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_9.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/entities/EntityTypes1_9.java
@@ -22,7 +22,6 @@
  */
 package com.viaversion.viaversion.api.minecraft.entities;
 
-import com.viaversion.viaversion.api.Via;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +34,6 @@ public class EntityTypes1_9 {
             type = ObjectType.getEntityType(typeId);
         } else {
             type = EntityType.findById(typeId);
-        }
-        if (type == null) {
-            Via.getPlatform().getLogger().severe("Could not find 1.9 type id " + typeId + " objectType=" + object);
-            return EntityType.ENTITY; // Fall back to the basic ENTITY
         }
         return type;
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/EntityPacketRewriter1_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_10to1_11/rewriter/EntityPacketRewriter1_11.java
@@ -331,7 +331,6 @@ public class EntityPacketRewriter1_11 extends EntityRewriter<ClientboundPackets1
     public EntityType rewriteEntityType(int numType, List<EntityData> entityData) {
         EntityType type = EntityType.findById(numType);
         if (type == null) {
-            Via.getManager().getPlatform().getLogger().severe("Error: could not find Entity type " + numType + " with entity data: " + entityData);
             return null;
         }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
@@ -83,8 +83,6 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
 
                     EntityTypes1_13.EntityType type1_13 = EntityTypes1_13.getTypeFromId(typeId, true);
                     if (type1_13 == null) {
-                        // <= 1.31.2 will ignore unknown entity types, 1.14+ will spawn a pig as default
-                        wrapper.cancel();
                         return;
                     }
 
@@ -142,7 +140,14 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
                 map(Types.SHORT); // 11 - Velocity Z
                 map(Types1_13_2.ENTITY_DATA_LIST, Types1_14.ENTITY_DATA_LIST); // 12 - Entity data
 
-                handler(trackerAndRewriterHandler(Types1_14.ENTITY_DATA_LIST));
+                handler(wrapper -> {
+                    int entityType = wrapper.get(Types.VAR_INT, 1);
+                    if (EntityTypes1_13.getTypeFromId(entityType, false) == null) {
+                        // <= 1.31.2 will ignore unknown entity types, 1.14+ will spawn a pig as default
+                        wrapper.cancel();
+                    }
+                    trackerAndRewriterHandler(Types1_14.ENTITY_DATA_LIST).handle(wrapper);
+                });
             }
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_13_2to1_14/rewriter/EntityPacketRewriter1_14.java
@@ -143,7 +143,7 @@ public class EntityPacketRewriter1_14 extends EntityRewriter<ClientboundPackets1
                 handler(wrapper -> {
                     int entityType = wrapper.get(Types.VAR_INT, 1);
                     if (EntityTypes1_13.getTypeFromId(entityType, false) == null) {
-                        // <= 1.31.2 will ignore unknown entity types, 1.14+ will spawn a pig as default
+                        // <= 1.13.2 will ignore unknown entity types, 1.14+ will spawn a pig as default
                         wrapper.cancel();
                     }
                     trackerAndRewriterHandler(Types1_14.ENTITY_DATA_LIST).handle(wrapper);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/SpawnPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/SpawnPacketRewriter1_9.java
@@ -18,12 +18,13 @@
 package com.viaversion.viaversion.protocols.v1_8to1_9.rewriter;
 
 import com.viaversion.viaversion.api.data.entity.EntityTracker;
+import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_8;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_9;
-import com.viaversion.viaversion.api.minecraft.item.DataItem;
-import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.minecraft.entitydata.EntityData;
 import com.viaversion.viaversion.api.minecraft.entitydata.types.EntityDataTypes1_9;
+import com.viaversion.viaversion.api.minecraft.item.DataItem;
+import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.protocol.remapper.ValueTransformer;
@@ -63,7 +64,11 @@ public class SpawnPacketRewriter1_9 {
                     int entityID = wrapper.get(Types.VAR_INT, 0);
                     int typeID = wrapper.get(Types.BYTE, 0);
                     EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
-                    tracker.addEntity(entityID, EntityTypes1_9.getTypeFromId(typeID, true));
+
+                    EntityType entityType = EntityTypes1_9.getTypeFromId(typeID, true);
+                    if (entityType != null) {
+                        tracker.addEntity(entityID, entityType);
+                    }
                 });
 
                 map(Types.INT, toNewDouble); // 3 - X - Needs to be divided by 32
@@ -176,7 +181,11 @@ public class SpawnPacketRewriter1_9 {
                     int entityID = wrapper.get(Types.VAR_INT, 0);
                     int typeID = wrapper.get(Types.UNSIGNED_BYTE, 0);
                     EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_9.class);
-                    tracker.addEntity(entityID, EntityTypes1_9.getTypeFromId(typeID, false));
+
+                    EntityType entityType = EntityTypes1_9.getTypeFromId(typeID, false);
+                    if (entityType != null) {
+                        tracker.addEntity(entityID, entityType);
+                    }
                 });
 
                 map(Types.INT, toNewDouble); // 3 - X - Needs to be divided by 32

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/EntityRewriter.java
@@ -510,6 +510,9 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
         }
 
         final EntityType entityType = typeFromId(trackMappedType ? mappedTypeId : typeId);
+        if (entityType == null) {
+            return null;
+        }
         tracker(wrapper.user()).addEntity(entityId, entityType);
         return entityType;
     }
@@ -557,6 +560,9 @@ public abstract class EntityRewriter<C extends ClientboundPacketType, T extends 
             byte type = wrapper.get(Types.BYTE, 0);
 
             EntityType entType = objectTypeFromId(type);
+            if (entType == null) {
+                return;
+            }
             // Register Type ID
             tracker(wrapper.user()).addEntity(entityId, entType);
         };


### PR DESCRIPTION
Minecraft <= 1.13.2 silently ignores unknown entity type ids and doesn't print any warning, while we currently still track them. Minecraft 1.14+ will spawn a pig if the entity type is invalid while we track ENTITY as wrong type. Both cases can cause various entity data issues where the server sends wrong data for non-existing entities while we still handle it.