### PR TITLE
Mark ViaPlatform#isPluginEnabled as deprecated

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,7 +41,7 @@ body:
         Describe the unexpected behavior.
         If you want to attach screenshots, use the comment field at the bottom of the page.
       placeholder: |
-        Example: "Placing signs on 1.13.2 causes text to disappear."
+        Example: "Placing signs on 1.21.3 causes text to disappear."
     validations:
       required: true
 

--- a/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
@@ -164,7 +164,9 @@ public interface ViaPlatform<T> {
      * @return True if it is enabled
      */
     @Deprecated(forRemoval = true)
-    boolean isPluginEnabled();
+    default boolean isPluginEnabled() {
+        return true;
+    }
 
     /**
      * Get the API for this platform

--- a/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
@@ -163,6 +163,7 @@ public interface ViaPlatform<T> {
      *
      * @return True if it is enabled
      */
+    @Deprecated(forRemoval = true)
     boolean isPluginEnabled();
 
     /**


### PR DESCRIPTION
Doesn't work on most implementations and serves no purpose