### PR TITLE
Fix handshake packet transfer handling

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/InitialBaseProtocol.java
@@ -130,6 +130,10 @@ public class InitialBaseProtocol extends AbstractProtocol<BaseClientboundPacket,
                 wrapper.set(Types.VAR_INT, 0, serverProtocol.getOriginalVersion());
             }
 
+            if (state == TRANSFER_INTENT && serverProtocol.olderThan(ProtocolVersion.v1_20_5)) {
+                wrapper.set(Types.VAR_INT, 1, LOGIN_INTENT);
+            }
+
             // Send client intention into the pipeline in case protocols down the line need to transform it
             try {
                 final List<Protocol> protocols = new ArrayList<>(pipeline.pipes());
@@ -148,14 +152,8 @@ public class InitialBaseProtocol extends AbstractProtocol<BaseClientboundPacket,
             // Set initial state
             if (state == STATUS_INTENT) {
                 info.setState(State.STATUS);
-            } else if (state == LOGIN_INTENT) {
+            } else if (state == LOGIN_INTENT || state == TRANSFER_INTENT) {
                 info.setState(State.LOGIN);
-            } else if (state == TRANSFER_INTENT) {
-                info.setState(State.LOGIN);
-
-                if (serverProtocol.olderThan(ProtocolVersion.v1_20_5)) {
-                    wrapper.set(Types.VAR_INT, 1, LOGIN_INTENT);
-                }
             }
         });
     }


### PR DESCRIPTION
The packet content has to be modified before wrapper.resetReader() is called, else it will fail