### PR TITLE
Remove newly added registry entries when already sent be the server

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/rewriter/RegistryDataRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/RegistryDataRewriter.java
@@ -79,6 +79,7 @@ public class RegistryDataRewriter {
                 if (existingKeys.contains(entry.key())) {
                     continue;
                 }
+
                 updatedEntries[index++] = entry.copy();
             }
 

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/RegistryDataRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/RegistryDataRewriter.java
@@ -73,7 +73,7 @@ public class RegistryDataRewriter {
             int index = 0;
             for (final RegistryEntry entry : entries) {
                 if (!toAddKeys.contains(entry.key())) {
-                    updatedEntries[index++] = entry.copy();
+                    updatedEntries[index++] = entry;
                 }
             }
             for (final RegistryEntry entry : toAdd) {

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/RegistryDataRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/RegistryDataRewriter.java
@@ -37,7 +37,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class RegistryDataRewriter {
     private final Map<String, Consumer<CompoundTag>> enchantmentEffectRewriters = new Object2ObjectArrayMap<>();
@@ -65,11 +67,23 @@ public class RegistryDataRewriter {
 
         final List<RegistryEntry> toAdd = this.toAdd.get(key);
         if (toAdd != null) {
-            final int length = entries.length;
-            final int toAddLength = toAdd.size();
-            entries = Arrays.copyOf(entries, length + toAddLength);
-            for (int i = 0; i < toAddLength; i++) {
-                entries[length + i] = toAdd.get(i).copy();
+            final Set<String> toAddKeys = toAdd.stream().map(RegistryEntry::key).collect(Collectors.toSet());
+
+            final RegistryEntry[] updatedEntries = new RegistryEntry[entries.length + toAdd.size()];
+            int index = 0;
+            for (final RegistryEntry entry : entries) {
+                if (!toAddKeys.contains(entry.key())) {
+                    updatedEntries[index++] = entry.copy();
+                }
+            }
+            for (final RegistryEntry entry : toAdd) {
+                updatedEntries[index++] = entry.copy();
+            }
+
+            if (index < updatedEntries.length) {
+                entries = Arrays.copyOf(updatedEntries, index);
+            } else {
+                entries = updatedEntries;
             }
         }
 

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/RegistryDataRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/RegistryDataRewriter.java
@@ -35,11 +35,11 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 public class RegistryDataRewriter {
     private final Map<String, Consumer<CompoundTag>> enchantmentEffectRewriters = new Object2ObjectArrayMap<>();
@@ -67,16 +67,18 @@ public class RegistryDataRewriter {
 
         final List<RegistryEntry> toAdd = this.toAdd.get(key);
         if (toAdd != null) {
-            final Set<String> toAddKeys = toAdd.stream().map(RegistryEntry::key).collect(Collectors.toSet());
+            final Set<String> existingKeys = new HashSet<>();
 
             final RegistryEntry[] updatedEntries = new RegistryEntry[entries.length + toAdd.size()];
             int index = 0;
             for (final RegistryEntry entry : entries) {
-                if (!toAddKeys.contains(entry.key())) {
-                    updatedEntries[index++] = entry;
-                }
+                updatedEntries[index++] = entry;
+                existingKeys.add(entry.key());
             }
             for (final RegistryEntry entry : toAdd) {
+                if (existingKeys.contains(entry.key())) {
+                    continue;
+                }
                 updatedEntries[index++] = entry.copy();
             }
 


### PR DESCRIPTION
Remove registry entries sent by older servers which do not exist in the current version to prevent duplicated entries when we send default data, assuming the server doesn't send them.

Closes https://github.com/ViaVersion/ViaFabricPlus/issues/683
Closes https://github.com/ViaVersion/ViaFabricPlus/issues/698