### PR TITLE
Use "intentionally_empty" sound event for 1.8 blocking

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/rewriter/BlockItemPacketRewriter1_21_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/rewriter/BlockItemPacketRewriter1_21_4.java
@@ -26,6 +26,7 @@ import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.BlockPosition;
 import com.viaversion.viaversion.api.minecraft.Holder;
+import com.viaversion.viaversion.api.minecraft.SoundEvent;
 import com.viaversion.viaversion.api.minecraft.data.StructuredDataContainer;
 import com.viaversion.viaversion.api.minecraft.data.StructuredDataKey;
 import com.viaversion.viaversion.api.minecraft.item.Item;
@@ -176,7 +177,13 @@ public final class BlockItemPacketRewriter1_21_4 extends StructuredItemRewriter<
                 // Make sword "eatable" to enable clientside instant blocking on 1.8. Set consume animation to block,
                 // and consume time really high, so the eating animation doesn't play
                 item.dataContainer().set(StructuredDataKey.CONSUMABLE1_21_2,
-                    new Consumable1_21_2(3600, 3, Holder.of(964), false, new Consumable1_21_2.ConsumeEffect[0]));
+                    new Consumable1_21_2(
+                        2, 
+                        3,
+                        Holder.of(new SoundEvent("minecraft:intentionally_empty", null)),
+                        false,
+                        new Consumable1_21_2.ConsumeEffect[0])
+                );
             }
         }
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/rewriter/BlockItemPacketRewriter1_21_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/rewriter/BlockItemPacketRewriter1_21_4.java
@@ -176,7 +176,7 @@ public final class BlockItemPacketRewriter1_21_4 extends StructuredItemRewriter<
                 // Make sword "eatable" to enable clientside instant blocking on 1.8. Set consume animation to block,
                 // and consume time really high, so the eating animation doesn't play
                 item.dataContainer().set(StructuredDataKey.CONSUMABLE1_21_2,
-                    new Consumable1_21_2(3600, 3, Holder.of(0), false, new Consumable1_21_2.ConsumeEffect[0]));
+                    new Consumable1_21_2(3600, 3, Holder.of(964), false, new Consumable1_21_2.ConsumeEffect[0]));
             }
         }
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/rewriter/BlockItemPacketRewriter1_21_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/rewriter/BlockItemPacketRewriter1_21_4.java
@@ -178,7 +178,7 @@ public final class BlockItemPacketRewriter1_21_4 extends StructuredItemRewriter<
                 // and consume time really high, so the eating animation doesn't play
                 item.dataContainer().set(StructuredDataKey.CONSUMABLE1_21_2,
                     new Consumable1_21_2(
-                        2, 
+                        3600, 
                         3,
                         Holder.of(new SoundEvent("minecraft:intentionally_empty", null)),
                         false,


### PR DESCRIPTION
Uses "intentionally_empty" sound event which is no sound, for the consumable blocking in 1.21.4+ on 1.8 server.