### PR TITLE
Add connection details protocol implementation

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
@@ -145,6 +145,16 @@ public interface ViaPlatform<T> {
     boolean kickPlayer(UUID uuid, String message);
 
     /**
+     * Send a custom payload to a player.
+     *
+     * @param uuid    The player's UUID
+     * @param channel The channel to send the payload on
+     * @param message The data to send
+     */
+    default void sendCustomPayload(UUID uuid, String channel, String message) {
+    }
+
+    /**
      * Disconnects an UserConnection for a reason
      *
      * @param connection The UserConnection

--- a/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
@@ -152,7 +152,7 @@ public interface ViaPlatform<T> {
      * @param message The data to send
      */
     default void sendCustomPayload(UUID uuid, String channel, String message) {
-        throw new UnsupportedOperationException("Not implemented on this platform");
+        throw new UnsupportedOperationException("ViaPlatform#sendCustomPayload is not implemented on this platform.");
     }
 
     /**

--- a/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/platform/ViaPlatform.java
@@ -152,6 +152,7 @@ public interface ViaPlatform<T> {
      * @param message The data to send
      */
     default void sendCustomPayload(UUID uuid, String channel, String message) {
+        throw new UnsupportedOperationException("Not implemented on this platform");
     }
 
     /**

--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
@@ -33,8 +33,8 @@ import java.util.UUID;
  */
 public final class ConnectionDetails {
 
-    public static final String VELOCITY_CHANNEL = "vv:velocity_details";
-    public static final String FABRIC_CHANNEL = "vv:fabric_details";
+    public static final String PROXY_CHANNEL = "vv:proxy_details";
+    public static final String MOD_CHANNEL = "vv:mod_details";
 
     public static void sendConnectionDetails(final UserConnection connection, final String channel) {
         final ProtocolInfo protocolInfo = connection.getProtocolInfo();

--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
@@ -35,6 +35,7 @@ public final class ConnectionDetails {
 
     public static final String PROXY_CHANNEL = "vv:proxy_details";
     public static final String MOD_CHANNEL = "vv:mod_details";
+    public static final String APP_CHANNEL = "vv:app_details";
 
     public static void sendConnectionDetails(final UserConnection connection, final String channel) {
         final ProtocolInfo protocolInfo = connection.getProtocolInfo();

--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
@@ -22,6 +22,7 @@ import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.ProtocolInfo;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.platform.ViaPlatform;
+import com.viaversion.viaversion.api.platform.ViaServerProxyPlatform;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import java.util.UUID;
 
@@ -44,6 +45,7 @@ public final class ConnectionDetails {
         final JsonObject payload = new JsonObject();
         payload.addProperty("platformName", platformName);
         payload.addProperty("platformVersion", platformVersion);
+        payload.addProperty("fromProxy", Via.getPlatform() instanceof ViaServerProxyPlatform<?>);
         payload.addProperty("version", nativeVersion.getOriginalVersion());
         payload.addProperty("versionName", nativeVersion.getName());
 

--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.connection;
+
+import com.google.gson.JsonObject;
+import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.connection.ProtocolInfo;
+import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.platform.ViaPlatform;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import java.util.UUID;
+
+/**
+ * Optional utility to provide the target server of a player's connection with the player's native version and the
+ * current platform name/version for version-specific handling.
+ * <p>
+ * Requires {@link ViaPlatform#sendCustomPayload(UUID, String, String)} to be implemented
+ */
+public final class ConnectionDetails {
+
+    public static final String CHANNEL = "vv:player_details";
+
+    public static void sendConnectionDetails(final UserConnection connection) {
+        final ProtocolInfo protocolInfo = connection.getProtocolInfo();
+        final ProtocolVersion nativeVersion = protocolInfo.protocolVersion();
+        final String platformName = Via.getPlatform().getPlatformName();
+        final String platformVersion = Via.getPlatform().getPlatformVersion();
+
+        final JsonObject payload = new JsonObject();
+        payload.addProperty("platformName", platformName);
+        payload.addProperty("platformVersion", platformVersion);
+        payload.addProperty("version", nativeVersion.getOriginalVersion());
+        payload.addProperty("versionName", nativeVersion.getName());
+
+        Via.getPlatform().sendCustomPayload(protocolInfo.getUuid(), CHANNEL, payload.toString());
+    }
+
+}

--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionDetails.java
@@ -22,7 +22,6 @@ import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.ProtocolInfo;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.platform.ViaPlatform;
-import com.viaversion.viaversion.api.platform.ViaServerProxyPlatform;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import java.util.UUID;
 
@@ -34,22 +33,20 @@ import java.util.UUID;
  */
 public final class ConnectionDetails {
 
-    public static final String CHANNEL = "vv:player_details";
+    public static final String VELOCITY_CHANNEL = "vv:velocity_details";
+    public static final String FABRIC_CHANNEL = "vv:fabric_details";
 
-    public static void sendConnectionDetails(final UserConnection connection) {
+    public static void sendConnectionDetails(final UserConnection connection, final String channel) {
         final ProtocolInfo protocolInfo = connection.getProtocolInfo();
         final ProtocolVersion nativeVersion = protocolInfo.protocolVersion();
-        final String platformName = Via.getPlatform().getPlatformName();
         final String platformVersion = Via.getPlatform().getPlatformVersion();
 
         final JsonObject payload = new JsonObject();
-        payload.addProperty("platformName", platformName);
         payload.addProperty("platformVersion", platformVersion);
-        payload.addProperty("fromProxy", Via.getPlatform() instanceof ViaServerProxyPlatform<?>);
         payload.addProperty("version", nativeVersion.getOriginalVersion());
         payload.addProperty("versionName", nativeVersion.getName());
 
-        Via.getPlatform().sendCustomPayload(protocolInfo.getUuid(), CHANNEL, payload.toString());
+        Via.getPlatform().sendCustomPayload(protocolInfo.getUuid(), channel, payload.toString());
     }
 
 }

--- a/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/VelocityPlugin.java
@@ -27,6 +27,7 @@ import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.command.ViaCommandSender;
 import com.viaversion.viaversion.api.platform.PlatformTask;
@@ -178,6 +179,11 @@ public class VelocityPlugin implements ViaServerProxyPlatform<Player> {
     @Override
     public void sendMessage(UUID uuid, String message) {
         PROXY.getPlayer(uuid).ifPresent(player -> player.sendMessage(COMPONENT_SERIALIZER.deserialize(message)));
+    }
+
+    @Override
+    public void sendCustomPayload(final UUID uuid, final String channel, final String message) {
+        PROXY.getPlayer(uuid).flatMap(Player::getCurrentServer).ifPresent(server -> server.sendPluginMessage(MinecraftChannelIdentifier.from(channel), message.getBytes()));
     }
 
     @Override

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
@@ -18,17 +18,33 @@
 package com.viaversion.viaversion.velocity.listeners;
 
 import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.ServerPostConnectEvent;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+import com.viaversion.viaversion.VelocityPlugin;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.connection.ConnectionDetails;
 
 public class ConnectionDetailsListener {
+    private static final MinecraftChannelIdentifier CHANNEL = MinecraftChannelIdentifier.from(ConnectionDetails.CHANNEL);
 
     @Subscribe
-    public void onPostServerJoin(ServerPostConnectEvent e) {
-        final UserConnection connection = Via.getAPI().getConnection(e.getPlayer().getUniqueId());
+    public void onPostServerJoin(final ServerPostConnectEvent event) {
+        final UserConnection connection = Via.getAPI().getConnection(event.getPlayer().getUniqueId());
         ConnectionDetails.sendConnectionDetails(connection);
     }
 
+    @Subscribe
+    public void onProxyInitialize(final ProxyInitializeEvent event) {
+        VelocityPlugin.PROXY.getChannelRegistrar().register(CHANNEL);
+    }
+
+    @Subscribe
+    public void onPluginMessage(final PluginMessageEvent event) {
+        if (CHANNEL.equals(event.getIdentifier())) {
+            event.setResult(PluginMessageEvent.ForwardResult.handled());
+        }
+    }
 }

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.velocity.listeners;
+
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.player.ServerPostConnectEvent;
+import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.connection.ConnectionDetails;
+
+public class ConnectionDetailsListener {
+
+    @Subscribe
+    public void onPostServerJoin(ServerPostConnectEvent e) {
+        final UserConnection connection = Via.getAPI().getConnection(e.getPlayer().getUniqueId());
+        ConnectionDetails.sendConnectionDetails(connection);
+    }
+
+}

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
@@ -17,7 +17,6 @@
  */
 package com.viaversion.viaversion.velocity.listeners;
 
-import com.google.gson.JsonObject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.ServerPostConnectEvent;
@@ -27,15 +26,14 @@ import com.viaversion.viaversion.VelocityPlugin;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.connection.ConnectionDetails;
-import com.viaversion.viaversion.util.GsonUtil;
 
 public class ConnectionDetailsListener {
-    private static final MinecraftChannelIdentifier CHANNEL = MinecraftChannelIdentifier.from(ConnectionDetails.CHANNEL);
+    private static final MinecraftChannelIdentifier CHANNEL = MinecraftChannelIdentifier.from(ConnectionDetails.VELOCITY_CHANNEL);
 
     @Subscribe
     public void onPostServerJoin(final ServerPostConnectEvent event) {
         final UserConnection connection = Via.getAPI().getConnection(event.getPlayer().getUniqueId());
-        ConnectionDetails.sendConnectionDetails(connection);
+        ConnectionDetails.sendConnectionDetails(connection, ConnectionDetails.VELOCITY_CHANNEL);
     }
 
     @Subscribe
@@ -45,18 +43,8 @@ public class ConnectionDetailsListener {
 
     @Subscribe
     public void onPluginMessage(final PluginMessageEvent event) {
-        if (!CHANNEL.equals(event.getIdentifier())) {
-            return;
-        }
-
-        try {
-            final JsonObject payload = GsonUtil.getGson().fromJson(new String(event.getData()), JsonObject.class);
-            final boolean fromProxy = payload.get("fromProxy").getAsBoolean();
-            if (fromProxy) {
-                event.setResult(PluginMessageEvent.ForwardResult.handled());
-            }
-        } catch (final Exception e) {
-            Via.getPlatform().getLogger().warning("Failed to handle connection details payload: " + e.getMessage());
+        if (CHANNEL.equals(event.getIdentifier())) {
+            event.setResult(PluginMessageEvent.ForwardResult.handled());
         }
     }
 }

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
@@ -28,12 +28,12 @@ import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.connection.ConnectionDetails;
 
 public class ConnectionDetailsListener {
-    private static final MinecraftChannelIdentifier CHANNEL = MinecraftChannelIdentifier.from(ConnectionDetails.VELOCITY_CHANNEL);
+    private static final MinecraftChannelIdentifier CHANNEL = MinecraftChannelIdentifier.from(ConnectionDetails.PROXY_CHANNEL);
 
     @Subscribe
     public void onPostServerJoin(final ServerPostConnectEvent event) {
         final UserConnection connection = Via.getAPI().getConnection(event.getPlayer().getUniqueId());
-        ConnectionDetails.sendConnectionDetails(connection, ConnectionDetails.VELOCITY_CHANNEL);
+        ConnectionDetails.sendConnectionDetails(connection, ConnectionDetails.PROXY_CHANNEL);
     }
 
     @Subscribe

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/listeners/ConnectionDetailsListener.java
@@ -51,8 +51,8 @@ public class ConnectionDetailsListener {
 
         try {
             final JsonObject payload = GsonUtil.getGson().fromJson(new String(event.getData()), JsonObject.class);
-            final String platformName = payload.get("platformName").getAsString();
-            if (Via.getPlatform().getPlatformName().equals(platformName)) {
+            final boolean fromProxy = payload.get("fromProxy").getAsBoolean();
+            if (fromProxy) {
                 event.setResult(PluginMessageEvent.ForwardResult.handled());
             }
         } catch (final Exception e) {

--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaLoader.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/platform/VelocityViaLoader.java
@@ -25,6 +25,7 @@ import com.viaversion.viaversion.api.platform.providers.ViaProviders;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.v1_8to1_9.provider.BossBarProvider;
+import com.viaversion.viaversion.velocity.listeners.ConnectionDetailsListener;
 import com.viaversion.viaversion.velocity.listeners.UpdateListener;
 import com.viaversion.viaversion.velocity.providers.VelocityBossBarProvider;
 import com.viaversion.viaversion.velocity.providers.VelocityVersionProvider;
@@ -48,6 +49,7 @@ public class VelocityViaLoader implements ViaPlatformLoader {
         // We don't need main hand patch because Join Game packet makes client send hand data again
 
         VelocityPlugin.PROXY.getEventManager().register(plugin, new UpdateListener());
+        VelocityPlugin.PROXY.getEventManager().register(plugin, new ConnectionDetailsListener());
 
         int pingInterval = ((VelocityViaConfig) Via.getPlatform().getConf()).getVelocityPingInterval();
         if (pingInterval > 0) {


### PR DESCRIPTION
Adds an optional custom payload protocol which platforms can use to communicate the native version of users across backend servers, the current implementation supports Velocity by sending the player's native version to the backend servers. Platforms may call ConnectionDetails#sendConnectionDetails themselves to ensure the packet getting handled by the server.

Documentation: https://github.com/ViaVersion/ViaVersion/wiki/Player-Details-Protocol