### PR TITLE
Treat changes in clientbound base protocol handlers as separate protocols

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/ProtocolManagerImpl.java
@@ -40,6 +40,7 @@ import com.viaversion.viaversion.api.protocol.version.VersionType;
 import com.viaversion.viaversion.protocol.packet.PacketWrapperImpl;
 import com.viaversion.viaversion.protocol.packet.VersionedPacketTransformerImpl;
 import com.viaversion.viaversion.protocols.base.InitialBaseProtocol;
+import com.viaversion.viaversion.protocols.base.v1_16.ClientboundBaseProtocol1_16;
 import com.viaversion.viaversion.protocols.base.v1_7.ClientboundBaseProtocol1_7;
 import com.viaversion.viaversion.protocols.base.v1_7.ServerboundBaseProtocol1_7;
 import com.viaversion.viaversion.protocols.v1_10to1_11.Protocol1_10To1_11;
@@ -141,7 +142,8 @@ public class ProtocolManagerImpl implements ProtocolManager {
         // Base Protocol
         BASE_PROTOCOL.initialize();
         BASE_PROTOCOL.register(Via.getManager().getProviders());
-        registerBaseProtocol(Direction.CLIENTBOUND, new ClientboundBaseProtocol1_7(), Range.atLeast(ProtocolVersion.v1_7_2));
+        registerBaseProtocol(Direction.CLIENTBOUND, new ClientboundBaseProtocol1_7(), Range.closedOpen(ProtocolVersion.v1_7_2, ProtocolVersion.v1_16));
+        registerBaseProtocol(Direction.CLIENTBOUND, new ClientboundBaseProtocol1_16(), Range.atLeast(ProtocolVersion.v1_16));
         registerBaseProtocol(Direction.SERVERBOUND, new ServerboundBaseProtocol1_7(), Range.atLeast(ProtocolVersion.v1_7_2));
 
         registerProtocol(new Protocol1_8To1_9(), ProtocolVersion.v1_9, ProtocolVersion.v1_8);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/v1_16/ClientboundBaseProtocol1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/v1_16/ClientboundBaseProtocol1_16.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.base.v1_16;
+
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
+import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.protocols.base.v1_7.ClientboundBaseProtocol1_7;
+import java.util.UUID;
+
+public class ClientboundBaseProtocol1_16 extends ClientboundBaseProtocol1_7 {
+
+    @Override
+    public UUID passthroughUUID(final PacketWrapper wrapper) {
+        return wrapper.passthrough(Types.UUID);
+    }
+
+}

--- a/common/src/main/java/com/viaversion/viaversion/protocols/base/v1_7/ClientboundBaseProtocol1_7.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/base/v1_7/ClientboundBaseProtocol1_7.java
@@ -26,6 +26,7 @@ import com.viaversion.viaversion.api.connection.ProtocolInfo;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.protocol.AbstractProtocol;
 import com.viaversion.viaversion.api.protocol.ProtocolPathEntry;
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.packet.State;
 import com.viaversion.viaversion.api.protocol.packet.provider.PacketTypesProvider;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
@@ -131,17 +132,8 @@ public class ClientboundBaseProtocol1_7 extends AbstractProtocol<BaseClientbound
         registerClientbound(ClientboundLoginPackets.LOGIN_FINISHED, wrapper -> {
             final ProtocolInfo info = wrapper.user().getProtocolInfo();
 
-            if (info.serverProtocolVersion().olderThan(ProtocolVersion.v1_16)) {
-                String uuidString = wrapper.passthrough(Types.STRING);
-                if (uuidString.length() == 32) { // Trimmed UUIDs are 32 characters
-                    // Trimmed
-                    uuidString = addDashes(uuidString);
-                }
-                info.setUuid(UUID.fromString(uuidString));
-            } else {
-                final UUID uuid = wrapper.passthrough(Types.UUID);
-                info.setUuid(uuid);
-            }
+            final UUID uuid = passthroughUUID(wrapper);
+            info.setUuid(uuid);
 
             final String username = wrapper.passthrough(Types.STRING);
             info.setUsername(username);
@@ -154,6 +146,15 @@ public class ClientboundBaseProtocol1_7 extends AbstractProtocol<BaseClientbound
     @Override
     public boolean isBaseProtocol() {
         return true;
+    }
+
+    public UUID passthroughUUID(final PacketWrapper wrapper) {
+        String uuidString = wrapper.passthrough(Types.STRING);
+        if (uuidString.length() == 32) { // Trimmed UUIDs are 32 characters
+            // Trimmed
+            uuidString = addDashes(uuidString);
+        }
+        return UUID.fromString(uuidString);
     }
 
     public static String addDashes(String trimmedUUID) {


### PR DESCRIPTION
ViaAprilFools needs to enforce 1.16 uuid reading for the infinite snapshot and therefore adds the base protocols manually which means we need an own one for this change.