### PR TITLE
Add Copyable interface and unify copy() methods

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/Particle.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/Particle.java
@@ -22,15 +22,15 @@
  */
 package com.viaversion.viaversion.api.minecraft;
 
-import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Type;
+import com.viaversion.viaversion.util.Copyable;
 import com.viaversion.viaversion.util.IdHolder;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.List;
 
-public final class Particle implements IdHolder {
+public final class Particle implements IdHolder, Copyable {
     private final List<ParticleData<?>> arguments = new ArrayList<>(4);
     private int id;
 
@@ -73,6 +73,7 @@ public final class Particle implements IdHolder {
         arguments.set(index, new ParticleData<>(type, value));
     }
 
+    @Override
     public Particle copy() {
         final Particle particle = new Particle(id);
         for (ParticleData<?> argument : arguments) {
@@ -89,7 +90,7 @@ public final class Particle implements IdHolder {
             '}';
     }
 
-    public static final class ParticleData<T> {
+    public static final class ParticleData<T> implements Copyable {
         private final Type<T> type;
         private T value;
 
@@ -118,12 +119,9 @@ public final class Particle implements IdHolder {
             wrapper.write(type, value);
         }
 
+        @Override
         public ParticleData<T> copy() {
-            if (value instanceof Item item) {
-                return new ParticleData<>(type, (T) item.copy());
-            } else {
-                return new ParticleData<>(type, value);
-            }
+            return new ParticleData<>(type, copy(value));
         }
 
         @Override

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/RegistryEntry.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/RegistryEntry.java
@@ -23,6 +23,7 @@
 package com.viaversion.viaversion.api.minecraft;
 
 import com.viaversion.nbt.tag.Tag;
+import com.viaversion.viaversion.util.Copyable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -31,12 +32,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param key key of the registry entry
  * @param tag data of the registry entry, or null if the client should use its default
  */
-public record RegistryEntry(String key, @Nullable Tag tag) {
+public record RegistryEntry(String key, @Nullable Tag tag) implements Copyable {
 
     public RegistryEntry withKey(final String key) {
         return new RegistryEntry(key, tag != null ? tag.copy() : null);
     }
 
+    @Override
     public RegistryEntry copy() {
         return new RegistryEntry(key, tag != null ? tag.copy() : null);
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/EmptyStructuredData.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/EmptyStructuredData.java
@@ -54,6 +54,11 @@ final class EmptyStructuredData<T> implements StructuredData<T> {
     }
 
     @Override
+    public StructuredData<T> copy() {
+        return new EmptyStructuredData<>(this.key, this.id);
+    }
+
+    @Override
     public T value() {
         return null;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/FilledStructuredData.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/FilledStructuredData.java
@@ -23,7 +23,10 @@
 package com.viaversion.viaversion.api.minecraft.data;
 
 import com.google.common.base.Preconditions;
+import com.viaversion.nbt.tag.Tag;
+import com.viaversion.viaversion.api.minecraft.item.StructuredItem;
 import io.netty.buffer.ByteBuf;
+import java.lang.reflect.Array;
 import java.util.Objects;
 
 final class FilledStructuredData<T> implements StructuredData<T> {
@@ -57,6 +60,28 @@ final class FilledStructuredData<T> implements StructuredData<T> {
     @Override
     public StructuredDataKey<T> key() {
         return key;
+    }
+
+    @Override
+    public StructuredData<T> copy() {
+        return new FilledStructuredData<>(this.key, this.copyValue(this.value), this.id);
+    }
+
+    private T copyValue(final T object) {
+        if (object instanceof Tag tag) {
+            return (T) tag.copy();
+        } else if (object instanceof StructuredItem structuredItem) {
+            return (T) structuredItem.copy();
+        } else if (object.getClass().isArray()) {
+            final Object[] array = (Object[]) object;
+            final Object[] copy = (Object[]) Array.newInstance(array.getClass().getComponentType(), array.length);
+            for (int i = 0; i < array.length; i++) {
+                copy[i] = copyValue((T) array[i]);
+            }
+            return (T) copy;
+        } else {
+            return object;
+        }
     }
 
     @Override

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/FilledStructuredData.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/FilledStructuredData.java
@@ -23,10 +23,7 @@
 package com.viaversion.viaversion.api.minecraft.data;
 
 import com.google.common.base.Preconditions;
-import com.viaversion.nbt.tag.Tag;
-import com.viaversion.viaversion.api.minecraft.item.StructuredItem;
 import io.netty.buffer.ByteBuf;
-import java.lang.reflect.Array;
 import java.util.Objects;
 
 final class FilledStructuredData<T> implements StructuredData<T> {
@@ -64,24 +61,7 @@ final class FilledStructuredData<T> implements StructuredData<T> {
 
     @Override
     public StructuredData<T> copy() {
-        return new FilledStructuredData<>(this.key, this.copyValue(this.value), this.id);
-    }
-
-    private T copyValue(final T object) {
-        if (object instanceof Tag tag) {
-            return (T) tag.copy();
-        } else if (object instanceof StructuredItem structuredItem) {
-            return (T) structuredItem.copy();
-        } else if (object.getClass().isArray()) {
-            final Object[] array = (Object[]) object;
-            final Object[] copy = (Object[]) Array.newInstance(array.getClass().getComponentType(), array.length);
-            for (int i = 0; i < array.length; i++) {
-                copy[i] = copyValue((T) array[i]);
-            }
-            return (T) copy;
-        } else {
-            return object;
-        }
+        return new FilledStructuredData<>(this.key, this.copy(this.value), this.id);
     }
 
     @Override

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredData.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredData.java
@@ -22,11 +22,12 @@
  */
 package com.viaversion.viaversion.api.minecraft.data;
 
+import com.viaversion.viaversion.util.Copyable;
 import com.viaversion.viaversion.util.IdHolder;
 import io.netty.buffer.ByteBuf;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public interface StructuredData<T> extends IdHolder {
+public interface StructuredData<T> extends IdHolder, Copyable {
 
     /**
      * Returns filled structured data, equivalent to an Optional with a value in vanilla.
@@ -52,7 +53,8 @@ public interface StructuredData<T> extends IdHolder {
         return new EmptyStructuredData<>(key, id);
     }
 
-    @Nullable T value();
+    @Nullable
+    T value();
 
     void setValue(final T value);
 
@@ -60,6 +62,7 @@ public interface StructuredData<T> extends IdHolder {
 
     StructuredDataKey<T> key();
 
+    @Override
     StructuredData<T> copy();
 
     /**

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredData.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredData.java
@@ -60,6 +60,8 @@ public interface StructuredData<T> extends IdHolder {
 
     StructuredDataKey<T> key();
 
+    StructuredData<T> copy();
+
     /**
      * Returns whether the structured data is present. Even if true, the value may be null.
      *

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredDataContainer.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredDataContainer.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.data.FullMappings;
 import com.viaversion.viaversion.api.protocol.Protocol;
+import com.viaversion.viaversion.util.Copyable;
 import com.viaversion.viaversion.util.Unit;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
@@ -53,7 +54,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * </ul>
  * Other methods (e.g. {@link #getData(StructuredDataKey)} and {@link #has(StructuredDataKey)}) will handle both empty and non-empty data.
  */
-public final class StructuredDataContainer {
+public final class StructuredDataContainer implements Copyable {
 
     private final Map<StructuredDataKey<?>, StructuredData<?>> data;
     private FullMappings lookup;
@@ -245,6 +246,7 @@ public final class StructuredDataContainer {
         }
     }
 
+    @Override
     public StructuredDataContainer copy() {
         final Reference2ObjectOpenHashMap<StructuredDataKey<?>, StructuredData<?>> map = new Reference2ObjectOpenHashMap<>();
         for (final StructuredData<?> value : data.values()) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredDataContainer.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredDataContainer.java
@@ -246,7 +246,11 @@ public final class StructuredDataContainer {
     }
 
     public StructuredDataContainer copy() {
-        final StructuredDataContainer copy = new StructuredDataContainer(new Reference2ObjectOpenHashMap<>(data));
+        final Reference2ObjectOpenHashMap<StructuredDataKey<?>, StructuredData<?>> map = new Reference2ObjectOpenHashMap<>();
+        for (final StructuredData<?> value : data.values()) {
+            map.put(value.key(), value.copy());
+        }
+        final StructuredDataContainer copy = new StructuredDataContainer(map);
         copy.lookup = this.lookup;
         return copy;
     }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/Item.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/Item.java
@@ -24,9 +24,10 @@ package com.viaversion.viaversion.api.minecraft.item;
 
 import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.viaversion.api.minecraft.data.StructuredDataContainer;
+import com.viaversion.viaversion.util.Copyable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public interface Item {
+public interface Item extends Copyable {
 
     /**
      * Returns the item identifier.
@@ -102,6 +103,7 @@ public interface Item {
      *
      * @return copy of the item
      */
+    @Override
     Item copy();
 
     /**

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/AdventureModePredicate.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/AdventureModePredicate.java
@@ -23,10 +23,11 @@
 package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.type.Type;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
-public record AdventureModePredicate(BlockPredicate[] predicates, boolean showInTooltip) {
+public record AdventureModePredicate(BlockPredicate[] predicates, boolean showInTooltip) implements Copyable {
 
     public static final Type<AdventureModePredicate> TYPE = new Type<>(AdventureModePredicate.class) {
         @Override
@@ -49,5 +50,10 @@ public record AdventureModePredicate(BlockPredicate[] predicates, boolean showIn
             predicates[i] = this.predicates[i].rewrite(blockIdRewriter);
         }
         return new AdventureModePredicate(predicates, showInTooltip);
+    }
+
+    @Override
+    public AdventureModePredicate copy() {
+        return new AdventureModePredicate(copy(predicates), showInTooltip);
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/ArmorTrimMaterial.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/ArmorTrimMaterial.java
@@ -25,13 +25,14 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 import com.viaversion.nbt.tag.Tag;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.misc.HolderType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import java.util.Map;
 
 public record ArmorTrimMaterial(String assetName, int itemId, float itemModelIndex,
-                                Map<String, String> overrideArmorMaterials, Tag description) {
+                                Map<String, String> overrideArmorMaterials, Tag description) implements Copyable {
 
     public ArmorTrimMaterial(final String assetName, final int itemId, final Map<String, String> overrideArmorMaterials, final Tag description) {
         this(assetName, itemId, 0F, overrideArmorMaterials, description);
@@ -144,5 +145,10 @@ public record ArmorTrimMaterial(String assetName, int itemId, float itemModelInd
 
     public ArmorTrimMaterial rewrite(final Int2IntFunction idRewriteFunction) {
         return new ArmorTrimMaterial(assetName, idRewriteFunction.applyAsInt(itemId), itemModelIndex, overrideArmorMaterials, description);
+    }
+
+    @Override
+    public ArmorTrimMaterial copy() {
+        return new ArmorTrimMaterial(assetName, itemId, itemModelIndex, new Object2ObjectArrayMap<>(overrideArmorMaterials), description);
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/ArmorTrimPattern.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/ArmorTrimPattern.java
@@ -25,10 +25,11 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 import com.viaversion.nbt.tag.Tag;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.misc.HolderType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
-public record ArmorTrimPattern(String assetName, int itemId, Tag description, boolean decal) {
+public record ArmorTrimPattern(String assetName, int itemId, Tag description, boolean decal) implements Copyable {
 
     public static final HolderType<ArmorTrimPattern> TYPE = new HolderType<>() {
         @Override
@@ -51,5 +52,10 @@ public record ArmorTrimPattern(String assetName, int itemId, Tag description, bo
 
     public ArmorTrimPattern rewrite(final Int2IntFunction idRewriteFunction) {
         return new ArmorTrimPattern(assetName, idRewriteFunction.applyAsInt(itemId), description, decal);
+    }
+
+    @Override
+    public ArmorTrimPattern copy() {
+        return new ArmorTrimPattern(assetName, itemId, description.copy(), decal);
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/AttributeModifiers1_20_5.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/AttributeModifiers1_20_5.java
@@ -25,10 +25,11 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.ArrayType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import java.util.UUID;
 
-public record AttributeModifiers1_20_5(AttributeModifier[] modifiers, boolean showInTooltip) {
+public record AttributeModifiers1_20_5(AttributeModifier[] modifiers, boolean showInTooltip) implements Copyable {
 
     public static final Type<AttributeModifiers1_20_5> TYPE = new Type<>(AttributeModifiers1_20_5.class) {
         @Override
@@ -44,6 +45,11 @@ public record AttributeModifiers1_20_5(AttributeModifier[] modifiers, boolean sh
             buffer.writeBoolean(value.showInTooltip());
         }
     };
+
+    @Override
+    public AttributeModifiers1_20_5 copy() {
+        return new AttributeModifiers1_20_5(copy(modifiers), showInTooltip);
+    }
 
     public record AttributeModifier(int attribute, ModifierData modifier, int slotType) {
 

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/AttributeModifiers1_21.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/AttributeModifiers1_21.java
@@ -25,10 +25,11 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.ArrayType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
-public record AttributeModifiers1_21(AttributeModifier[] modifiers, boolean showInTooltip) {
+public record AttributeModifiers1_21(AttributeModifier[] modifiers, boolean showInTooltip) implements Copyable {
 
     public static final Type<AttributeModifiers1_21> TYPE = new Type<>(AttributeModifiers1_21.class) {
         @Override
@@ -52,6 +53,11 @@ public record AttributeModifiers1_21(AttributeModifier[] modifiers, boolean show
             modifiers[i] = new AttributeModifier(rewriteFunction.applyAsInt(modifier.attribute()), modifier.modifier(), modifier.slotType());
         }
         return new AttributeModifiers1_21(modifiers, showInTooltip);
+    }
+
+    @Override
+    public AttributeModifiers1_21 copy() {
+        return new AttributeModifiers1_21(copy(modifiers), showInTooltip);
     }
 
     public record AttributeModifier(int attribute, ModifierData modifier, int slotType) {

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Bee.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Bee.java
@@ -26,9 +26,10 @@ import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.ArrayType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 
-public record Bee(CompoundTag entityData, int ticksInHive, int minTicksInHive) {
+public record Bee(CompoundTag entityData, int ticksInHive, int minTicksInHive) implements Copyable {
 
     public static final Type<Bee> TYPE = new Type<>(Bee.class) {
         @Override
@@ -48,4 +49,8 @@ public record Bee(CompoundTag entityData, int ticksInHive, int minTicksInHive) {
     };
     public static final Type<Bee[]> ARRAY_TYPE = new ArrayType<>(TYPE);
 
+    @Override
+    public Bee copy() {
+        return new Bee(entityData.copy(), ticksInHive, minTicksInHive);
+    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/BlockPredicate.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/BlockPredicate.java
@@ -27,12 +27,13 @@ import com.viaversion.viaversion.api.minecraft.HolderSet;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.ArrayType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public record BlockPredicate(@Nullable HolderSet holderSet, StatePropertyMatcher @Nullable [] propertyMatchers,
-                             @Nullable CompoundTag tag) {
+                             @Nullable CompoundTag tag) implements Copyable {
 
     public static final Type<BlockPredicate> TYPE = new Type<>(BlockPredicate.class) {
         @Override
@@ -64,5 +65,10 @@ public record BlockPredicate(@Nullable HolderSet holderSet, StatePropertyMatcher
 
         final HolderSet updatedHolders = holderSet.rewrite(blockIdRewriter);
         return new BlockPredicate(updatedHolders, propertyMatchers, tag);
+    }
+
+    @Override
+    public BlockPredicate copy() {
+        return new BlockPredicate(holderSet, copy(propertyMatchers), tag == null ? null : tag.copy());
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/BlockStateProperties.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/BlockStateProperties.java
@@ -24,11 +24,12 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import java.util.Map;
 
-public record BlockStateProperties(Map<String, String> properties) {
+public record BlockStateProperties(Map<String, String> properties) implements Copyable {
 
     public static final Type<BlockStateProperties> TYPE = new Type<>(BlockStateProperties.class) {
         @Override
@@ -51,4 +52,8 @@ public record BlockStateProperties(Map<String, String> properties) {
         }
     };
 
+    @Override
+    public BlockStateProperties copy() {
+        return new BlockStateProperties(new Object2ObjectOpenHashMap<>(properties));
+    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/ChatType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/ChatType.java
@@ -47,7 +47,7 @@ public record ChatType(ChatTypeDecoration chatDecoration, ChatTypeDecoration nar
     };
 
     @Override
-    public Object copy() {
+    public ChatType copy() {
         return new ChatType(chatDecoration.copy(), narrationDecoration.copy());
     }
 

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/ChatType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/ChatType.java
@@ -26,9 +26,10 @@ import com.viaversion.nbt.tag.Tag;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.misc.HolderType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 
-public record ChatType(ChatTypeDecoration chatDecoration, ChatTypeDecoration narrationDecoration) {
+public record ChatType(ChatTypeDecoration chatDecoration, ChatTypeDecoration narrationDecoration) implements Copyable {
 
     public static final HolderType<ChatType> TYPE = new HolderType<>() {
         @Override
@@ -45,7 +46,12 @@ public record ChatType(ChatTypeDecoration chatDecoration, ChatTypeDecoration nar
         }
     };
 
-    public record ChatTypeDecoration(String translationKey, int[] parameters, Tag style) {
+    @Override
+    public Object copy() {
+        return new ChatType(chatDecoration.copy(), narrationDecoration.copy());
+    }
+
+    public record ChatTypeDecoration(String translationKey, int[] parameters, Tag style) implements Copyable {
 
         public static final Type<ChatTypeDecoration> TYPE = new Type<>(ChatTypeDecoration.class) {
 
@@ -64,5 +70,10 @@ public record ChatType(ChatTypeDecoration chatDecoration, ChatTypeDecoration nar
                 Types.TAG.write(buffer, value.style());
             }
         };
+
+        @Override
+        public ChatTypeDecoration copy() {
+            return new ChatTypeDecoration(translationKey, parameters.clone(), style.copy());
+        }
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Consumable1_21_2.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Consumable1_21_2.java
@@ -27,11 +27,12 @@ import com.viaversion.viaversion.api.minecraft.SoundEvent;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.ArrayType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
 public record Consumable1_21_2(float consumeSeconds, int animationType, Holder<SoundEvent> sound,
-                               boolean hasConsumeParticles, ConsumeEffect<?>[] consumeEffects) {
+                               boolean hasConsumeParticles, ConsumeEffect<?>[] consumeEffects) implements Copyable {
 
     public static final Type<?>[] EFFECT_TYPES = {
         ApplyStatusEffects.TYPE,
@@ -113,5 +114,10 @@ public record Consumable1_21_2(float consumeSeconds, int animationType, Holder<S
     public Consumable1_21_2 rewrite(final Int2IntFunction soundIdRewriteFunction) {
         final Holder<SoundEvent> soundHolder = this.sound.updateId(soundIdRewriteFunction);
         return soundHolder == this.sound ? this : new Consumable1_21_2(consumeSeconds, animationType, soundHolder, hasConsumeParticles, consumeEffects);
+    }
+
+    @Override
+    public Consumable1_21_2 copy() {
+        return new Consumable1_21_2(consumeSeconds, animationType, sound, hasConsumeParticles, copy(consumeEffects));
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/CustomModelData1_21_4.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/CustomModelData1_21_4.java
@@ -24,9 +24,10 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 
-public record CustomModelData1_21_4(float[] floats, boolean[] booleans, String[] strings, int[] colors) {
+public record CustomModelData1_21_4(float[] floats, boolean[] booleans, String[] strings, int[] colors) implements Copyable {
 
     public static final Type<CustomModelData1_21_4> TYPE = new Type<>(CustomModelData1_21_4.class) {
         @Override
@@ -46,4 +47,9 @@ public record CustomModelData1_21_4(float[] floats, boolean[] booleans, String[]
             Types.INT_ARRAY_PRIMITIVE.write(buffer, value.colors());
         }
     };
+
+    @Override
+    public CustomModelData1_21_4 copy() {
+        return new CustomModelData1_21_4(copy(floats), copy(booleans), copy(strings), copy(colors));
+    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/DeathProtection.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/DeathProtection.java
@@ -24,10 +24,10 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.minecraft.item.data.Consumable1_21_2.ConsumeEffect;
 import com.viaversion.viaversion.api.type.Type;
-import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 
-public record DeathProtection(ConsumeEffect<?>[] deathEffects) {
+public record DeathProtection(ConsumeEffect<?>[] deathEffects) implements Copyable {
 
     public static final Type<DeathProtection> TYPE = new Type<>(DeathProtection.class) {
         @Override
@@ -41,4 +41,9 @@ public record DeathProtection(ConsumeEffect<?>[] deathEffects) {
             ConsumeEffect.ARRAY_TYPE.write(buffer, value.deathEffects);
         }
     };
+
+    @Override
+    public DeathProtection copy() {
+        return new DeathProtection(copy(deathEffects));
+    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Enchantments.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Enchantments.java
@@ -24,11 +24,12 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
-public record Enchantments(Int2IntMap enchantments, boolean showInTooltip) {
+public record Enchantments(Int2IntMap enchantments, boolean showInTooltip) implements Copyable {
 
     public static final Type<Enchantments> TYPE = new Type<>(Enchantments.class) {
         @Override
@@ -77,5 +78,10 @@ public record Enchantments(Int2IntMap enchantments, boolean showInTooltip) {
 
     public int getLevel(final int id) {
         return enchantments.getOrDefault(id, -1);
+    }
+
+    @Override
+    public Enchantments copy() {
+        return new Enchantments(new Int2IntOpenHashMap(enchantments), showInTooltip);
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/FireworkExplosion.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/FireworkExplosion.java
@@ -25,9 +25,10 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.ArrayType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 
-public record FireworkExplosion(int shape, int[] colors, int[] fadeColors, boolean hasTrail, boolean hasTwinkle) {
+public record FireworkExplosion(int shape, int[] colors, int[] fadeColors, boolean hasTrail, boolean hasTwinkle) implements Copyable {
     public static final Type<FireworkExplosion> TYPE = new Type<>(FireworkExplosion.class) {
         @Override
         public FireworkExplosion read(final ByteBuf buffer) {
@@ -50,4 +51,8 @@ public record FireworkExplosion(int shape, int[] colors, int[] fadeColors, boole
     };
     public static final Type<FireworkExplosion[]> ARRAY_TYPE = new ArrayType<>(TYPE);
 
+    @Override
+    public FireworkExplosion copy() {
+        return new FireworkExplosion(shape, copy(colors), copy(fadeColors), hasTrail, hasTwinkle);
+    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Fireworks.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Fireworks.java
@@ -24,9 +24,10 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 
-public record Fireworks(int flightDuration, FireworkExplosion[] explosions) {
+public record Fireworks(int flightDuration, FireworkExplosion[] explosions) implements Copyable {
 
     public static final Type<Fireworks> TYPE = new Type<>(Fireworks.class) {
         @Override
@@ -43,4 +44,8 @@ public record Fireworks(int flightDuration, FireworkExplosion[] explosions) {
         }
     };
 
+    @Override
+    public Fireworks copy() {
+        return new Fireworks(flightDuration, copy(explosions));
+    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/FoodProperties1_20_5.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/FoodProperties1_20_5.java
@@ -27,11 +27,12 @@ import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.ArrayType;
 import com.viaversion.viaversion.api.type.types.version.Types1_21;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public record FoodProperties1_20_5(int nutrition, float saturationModifier, boolean canAlwaysEat, float eatSeconds,
-                                   @Nullable Item usingConvertsTo, FoodEffect[] possibleEffects) {
+                                   @Nullable Item usingConvertsTo, FoodEffect[] possibleEffects) implements Copyable {
 
     public static final Type<FoodProperties1_20_5> TYPE1_20_5 = new Type<>(FoodProperties1_20_5.class) {
         @Override
@@ -75,6 +76,11 @@ public record FoodProperties1_20_5(int nutrition, float saturationModifier, bool
             FoodEffect.ARRAY_TYPE.write(buffer, value.possibleEffects);
         }
     };
+
+    @Override
+    public FoodProperties1_20_5 copy() {
+        return new FoodProperties1_20_5(nutrition, saturationModifier, canAlwaysEat, eatSeconds, usingConvertsTo == null ? null : usingConvertsTo.copy(), copy(possibleEffects));
+    }
 
     public record FoodEffect(PotionEffect effect, float probability) {
 

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Instrument1_21_2.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/Instrument1_21_2.java
@@ -27,10 +27,11 @@ import com.viaversion.viaversion.api.minecraft.Holder;
 import com.viaversion.viaversion.api.minecraft.SoundEvent;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.misc.HolderType;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
-public record Instrument1_21_2(Holder<SoundEvent> soundEvent, float useDuration, float range, Tag description) {
+public record Instrument1_21_2(Holder<SoundEvent> soundEvent, float useDuration, float range, Tag description) implements Copyable {
 
     public static final HolderType<Instrument1_21_2> TYPE = new HolderType<>() {
         @Override
@@ -54,5 +55,10 @@ public record Instrument1_21_2(Holder<SoundEvent> soundEvent, float useDuration,
     public Instrument1_21_2 rewrite(final Int2IntFunction soundIdRewriteFunction) {
         final Holder<SoundEvent> soundEvent = this.soundEvent.updateId(soundIdRewriteFunction);
         return soundEvent == this.soundEvent ? this : new Instrument1_21_2(soundEvent, useDuration, range, description);
+    }
+
+    @Override
+    public Instrument1_21_2 copy() {
+        return new Instrument1_21_2(soundEvent, useDuration, range, description.copy());
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/PotDecorations.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/PotDecorations.java
@@ -24,10 +24,11 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
-public final class PotDecorations {
+public final class PotDecorations implements Copyable {
 
     public static final Type<PotDecorations> TYPE = new Type<>(PotDecorations.class) {
         @Override
@@ -81,5 +82,10 @@ public final class PotDecorations {
             newItems[i] = idRewriteFunction.applyAsInt(itemIds[i]);
         }
         return new PotDecorations(newItems);
+    }
+
+    @Override
+    public PotDecorations copy() {
+        return new PotDecorations(copy(itemIds));
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/PotionContents.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/PotionContents.java
@@ -24,11 +24,12 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public record PotionContents(@Nullable Integer potion, @Nullable Integer customColor, PotionEffect[] customEffects,
-                             @Nullable String customName) {
+                             @Nullable String customName) implements Copyable {
 
     public PotionContents(final @Nullable Integer potion, final @Nullable Integer customColor, final PotionEffect[] customEffects) {
         this(potion, customColor, customEffects, null);
@@ -85,4 +86,9 @@ public record PotionContents(@Nullable Integer potion, @Nullable Integer customC
             Types.OPTIONAL_STRING.write(buffer, value.customName);
         }
     };
+
+    @Override
+    public PotionContents copy() {
+        return new PotionContents(potion, customColor, copy(customEffects), customName);
+    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/WrittenBook.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/WrittenBook.java
@@ -24,10 +24,11 @@ package com.viaversion.viaversion.api.minecraft.item.data;
 
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.util.Copyable;
 import io.netty.buffer.ByteBuf;
 
 public record WrittenBook(FilterableString title, String author, int generation, FilterableComponent[] pages,
-                          boolean resolved) {
+                          boolean resolved) implements Copyable {
 
     public static final Type<WrittenBook> TYPE = new Type<>(WrittenBook.class) {
         @Override
@@ -50,4 +51,8 @@ public record WrittenBook(FilterableString title, String author, int generation,
         }
     };
 
+    @Override
+    public WrittenBook copy() {
+        return new WrittenBook(title, author, generation, copy(pages), resolved);
+    }
 }

--- a/api/src/main/java/com/viaversion/viaversion/util/Copyable.java
+++ b/api/src/main/java/com/viaversion/viaversion/util/Copyable.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.util;
+
+import com.viaversion.nbt.tag.Tag;
+import java.lang.reflect.Array;
+
+public interface Copyable {
+
+    default <T> T copy(final T object) {
+        if (object == null) {
+            return null;
+        } else if (object instanceof Tag tag) {
+            return (T) tag.copy();
+        } else if (object instanceof Copyable copyable) {
+            return (T) copyable.copy();
+        } else if (object.getClass().isArray()) {
+            final Object[] array = (Object[]) object;
+            final Object[] copy = (Object[]) Array.newInstance(array.getClass().getComponentType(), array.length);
+            for (int i = 0; i < array.length; i++) {
+                copy[i] = copy(array[i]);
+            }
+            return (T) copy;
+        } else {
+            return object;
+        }
+    }
+
+    Object copy();
+
+}


### PR DESCRIPTION
Adds a global Copyable interface with a copy() function used in all mutable objects.
Implements proper copy of structured item by copying all structured data elements inside the container. 