### PR TITLE
Make warning when no working pipe is found more clear.

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/ViaManagerImpl.java
@@ -145,10 +145,9 @@ public class ViaManagerImpl implements ViaManager {
 
             if (!protocolManager.isWorkingPipe()) {
                 platform.getLogger().warning("ViaVersion does not have any compatible versions for this server version!");
-                platform.getLogger().warning("Please remember that ViaVersion only adds support for versions newer than the server version.");
-                platform.getLogger().warning("If you need support for older versions you may need to use one or more ViaVersion addons too.");
-                platform.getLogger().warning("In that case please read the ViaVersion resource page carefully or use https://viaversion.com/setup");
-                platform.getLogger().warning("and if you're still unsure, feel free to join our Discord-Server for further assistance.");
+                platform.getLogger().warning("ViaVersion only supports newer client versions. Use ViaBackwards to allow older versions (ViaRewind for 1.7/1.8) to join.");
+                platform.getLogger().warning("Get setup help at https://viaversion.com/setup or download ViaBackwards/ViaRewind directly at https://ci.viaversion.com/");
+                platform.getLogger().warning("Need more help? Join our Discord at https://viaversion.com/discord!");
             } else if (protocolVersion.highestSupportedProtocolVersion().olderThan(ProtocolVersion.v1_13)) {
                 platform.getLogger().warning("This version of Minecraft is extremely outdated and support for it has reached its end of life. "
                     + "You will still be able to run Via on this Minecraft version, but we will prioritize issues with legacy Minecraft versions less. "


### PR DESCRIPTION
We had this in the past on our Discord server where people didn't understand what the original log message means. Since this is only relevant for serverside platforms (as clientside impls usually just have all jars inbuilt) I decided to simplify this message and to explicit mention ViaBackwards/ViaRewind as those are the only serverside supported Via addons we had in the past years (except ViaAprilFools but shrug).