### PR TITLE
Use correct version in json to tag conversion in 1.21.4->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
@@ -299,7 +299,8 @@ public final class ComponentRewriter1_21_5 extends JsonNBTComponentRewriter<Clie
     }
 
     public Tag uglyJsonToTag(final UserConnection connection, final String value) {
-        final Tag contents = SerializerVersion.V1_21_5.toTag(SerializerVersion.V1_21_4.toComponent(value));
+        // Use the same version for deserializing and serializing, as we handle the remaining changes ourselves
+        final Tag contents = SerializerVersion.V1_21_4.toTag(SerializerVersion.V1_21_4.toComponent(value));
         processTag(connection, contents);
         return contents;
     }


### PR DESCRIPTION
Not sure if the return value should be put through the 1.21.5 serializer first, but that probably doesn't make a difference.

Closes https://github.com/ViaVersion/ViaVersion/issues/4445
Closes https://github.com/ViaVersion/ViaVersion/issues/4437