### PR TITLE
Cancel unknown block entities in BlockRewriter#registerBlockEntityData 

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/rewriter/BlockRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/BlockRewriter.java
@@ -268,7 +268,7 @@ public class BlockRewriter<C extends ClientboundPacketType> {
             final int blockEntityId = wrapper.read(Types.VAR_INT);
             final Mappings mappings = protocol.getMappingData().getBlockEntityMappings();
             if (mappings != null) {
-                final int mappedBlockEntityId = mappings.getNewIdOrDefault(blockEntityId, -1);
+                final int mappedBlockEntityId = mappings.getNewId(blockEntityId);
                 if (mappedBlockEntityId == -1) {
                     wrapper.cancel();
                     return;

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/BlockRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/BlockRewriter.java
@@ -268,7 +268,12 @@ public class BlockRewriter<C extends ClientboundPacketType> {
             final int blockEntityId = wrapper.read(Types.VAR_INT);
             final Mappings mappings = protocol.getMappingData().getBlockEntityMappings();
             if (mappings != null) {
-                wrapper.write(Types.VAR_INT, mappings.getNewIdOrDefault(blockEntityId, blockEntityId));
+                final int mappedBlockEntityId = mappings.getNewIdOrDefault(blockEntityId, -1);
+                if (mappedBlockEntityId == -1) {
+                    wrapper.cancel();
+                    return;
+                }
+                wrapper.write(Types.VAR_INT, mappedBlockEntityId);
             } else {
                 wrapper.write(Types.VAR_INT, blockEntityId);
             }

--- a/common/src/main/java/com/viaversion/viaversion/util/SerializerVersion.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/SerializerVersion.java
@@ -50,7 +50,7 @@ public enum SerializerVersion {
     V1_20_3(TextComponentCodec.V1_20_3, SNbt.V1_14),
     V1_20_5(TextComponentCodec.V1_20_5, SNbt.V1_14),
     V1_21_4(TextComponentCodec.V1_21_4, SNbt.V1_14),
-    V1_21_5(TextComponentCodec.V1_21_5, SNbt.V1_21_5);
+    V1_21_5(TextComponentCodec.V1_21_5, null/*Currently not needed and also not implemented 100% in MCStructs*/);
 
     final TextComponentSerializer jsonSerializer;
     final SNbt<? extends Tag> sNbt;


### PR DESCRIPTION
Mojang changed block entity type parsing in 1.20.5 to throw on invalid block entities instead of ignoring them, we forgot to update our handle for newer protocols which will now kick if you join with a 1.21.4 client on a 1.21.5 server and set a test block. As this change should not hurt in older versions (as an invalid id would also cause the data to be ignored) I decided to put this directly instead of having multiple register methods.