### PR TITLE
Fix legacy item/entity hover events in 1.21.4->1.21.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
@@ -304,6 +304,7 @@ public final class ComponentRewriter1_21_5 extends JsonNBTComponentRewriter<Clie
 
         final StringTag typeTag = contents.getStringTag("type");
         if (typeTag != null) {
+            typeTag.setValue(protocol.getEntityRewriter().mappedEntityIdentifier(typeTag.getValue()));
             hoverEventTag.put("id", typeTag);
         }
     }
@@ -348,5 +349,10 @@ public final class ComponentRewriter1_21_5 extends JsonNBTComponentRewriter<Clie
                 compoundTag.put("filtered", uglyJsonToTag(connection, filtered));
             }
         }
+    }
+
+    @Override
+    protected SerializerVersion inputSerializerVersion() {
+        return SerializerVersion.V1_21_4;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/text/NBTComponentRewriter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/text/NBTComponentRewriter.java
@@ -58,9 +58,9 @@ public class NBTComponentRewriter<C extends ClientboundPacketType> extends Compo
         } else if (action.equals("show_entity")) {
             processTag(connection, hoverEventTag.get("name"));
 
-            final StringTag typeTag = hoverEventTag.getStringTag("id");
-            if (typeTag != null && protocol.getEntityRewriter() != null) {
-                typeTag.setValue(protocol.getEntityRewriter().mappedEntityIdentifier(typeTag.getValue()));
+            final StringTag idTag = hoverEventTag.getStringTag("id");
+            if (idTag != null && protocol.getEntityRewriter() != null) {
+                idTag.setValue(protocol.getEntityRewriter().mappedEntityIdentifier(idTag.getValue()));
             }
         } else if (action.equals("show_item")) {
             final CompoundTag componentsTag = hoverEventTag.getCompoundTag("components");


### PR DESCRIPTION
The input version needs to be overridden for the convertLegacyItemContents/convertLegacyEntityContents, and we also need to map the entity type (potion->splash_potion)