### PR TITLE
Add missing PLAYER_CHAT handlers in 1.20/1.21 versions

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/Protocol1_20_3To1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/Protocol1_20_3To1_20_5.java
@@ -95,6 +95,7 @@ public final class Protocol1_20_3To1_20_5 extends AbstractProtocol<ClientboundPa
 
         componentRewriter.registerComponentPacket(ClientboundPackets1_20_3.SYSTEM_CHAT);
         componentRewriter.registerComponentPacket(ClientboundPackets1_20_3.DISGUISED_CHAT);
+        componentRewriter.registerPlayerChat(ClientboundPackets1_20_3.PLAYER_CHAT, Types.VAR_INT);
         componentRewriter.registerPlayerCombatKill1_20(ClientboundPackets1_20_3.PLAYER_COMBAT_KILL);
 
         // People add item hovers to all sorts of weird places...

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/Protocol1_20_5To1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/Protocol1_20_5To1_21.java
@@ -130,6 +130,8 @@ public final class Protocol1_20_5To1_21 extends AbstractProtocol<ClientboundPack
 
             final int chatType = wrapper.read(Types.VAR_INT);
             wrapper.write(ChatType.TYPE, Holder.of(chatType));
+            componentRewriter.processTag(wrapper.user(), wrapper.passthrough(Types.TAG)); // Name
+            componentRewriter.processTag(wrapper.user(), wrapper.passthrough(Types.OPTIONAL_TAG)); // Target Name
         });
 
         registerClientbound(ClientboundPackets1_20_5.UPDATE_ATTRIBUTES, wrapper -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/Protocol1_21_2To1_21_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_2to1_21_4/Protocol1_21_2To1_21_4.java
@@ -86,6 +86,7 @@ public final class Protocol1_21_2To1_21_4 extends AbstractProtocol<ClientboundPa
         componentRewriter.registerPlayerCombatKill1_20(ClientboundPackets1_21_2.PLAYER_COMBAT_KILL);
         componentRewriter.registerComponentPacket(ClientboundPackets1_21_2.SYSTEM_CHAT);
         componentRewriter.registerDisguisedChat(ClientboundPackets1_21_2.DISGUISED_CHAT);
+        componentRewriter.registerPlayerChat(ClientboundPackets1_21_2.PLAYER_CHAT, ChatType.TYPE);
         componentRewriter.registerPing();
 
         particleRewriter.registerExplode1_21_2(ClientboundPackets1_21_2.EXPLODE);
@@ -112,34 +113,6 @@ public final class Protocol1_21_2To1_21_4 extends AbstractProtocol<ClientboundPa
         new StatisticsRewriter<>(this).register(ClientboundPackets1_21_2.AWARD_STATS);
         new AttributeRewriter<>(this).register1_21(ClientboundPackets1_21_2.UPDATE_ATTRIBUTES);
 
-
-        registerClientbound(ClientboundPackets1_21_2.PLAYER_CHAT, wrapper -> {
-            wrapper.passthrough(Types.UUID); // Sender
-            wrapper.passthrough(Types.VAR_INT); // Index
-            wrapper.passthrough(Types.OPTIONAL_SIGNATURE_BYTES); // Signature
-            wrapper.passthrough(Types.STRING); // Plain content
-            wrapper.passthrough(Types.LONG); // Timestamp
-            wrapper.passthrough(Types.LONG); // Salt
-
-            final int lastSeen = wrapper.passthrough(Types.VAR_INT);
-            for (int i = 0; i < lastSeen; i++) {
-                final int index = wrapper.passthrough(Types.VAR_INT);
-                if (index == 0) {
-                    wrapper.passthrough(Types.SIGNATURE_BYTES);
-                }
-            }
-
-            componentRewriter.processTag(wrapper.user(), wrapper.passthrough(Types.OPTIONAL_TAG)); // Unsigned content
-
-            final int filterMaskType = wrapper.passthrough(Types.VAR_INT);
-            if (filterMaskType == 2) { // Partially filtered
-                wrapper.passthrough(Types.LONG_ARRAY_PRIMITIVE); // Mask
-            }
-
-            wrapper.passthrough(ChatType.TYPE); // Chat Type
-            componentRewriter.processTag(wrapper.user(), wrapper.passthrough(Types.TAG)); // Name
-            componentRewriter.processTag(wrapper.user(), wrapper.passthrough(Types.OPTIONAL_TAG)); // Target Name
-        });
         registerClientbound(ClientboundPackets1_21_2.PLAYER_INFO_UPDATE, wrapper -> {
             // Added "show hat" - true by default, keep it like that
             final BitSet actions = wrapper.passthroughAndMap(Types.PROFILE_ACTIONS_ENUM1_21_2, Types.PROFILE_ACTIONS_ENUM1_21_4);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/Protocol1_21To1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/Protocol1_21To1_21_2.java
@@ -22,6 +22,7 @@ import com.viaversion.viaversion.api.data.MappingData;
 import com.viaversion.viaversion.api.data.MappingDataBase;
 import com.viaversion.viaversion.api.minecraft.data.StructuredDataKey;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_21_2;
+import com.viaversion.viaversion.api.minecraft.item.data.ChatType;
 import com.viaversion.viaversion.api.protocol.AbstractProtocol;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.packet.State;
@@ -91,6 +92,7 @@ public final class Protocol1_21To1_21_2 extends AbstractProtocol<ClientboundPack
         componentRewriter.registerPlayerCombatKill1_20(ClientboundPackets1_21.PLAYER_COMBAT_KILL);
         componentRewriter.registerComponentPacket(ClientboundPackets1_21.SYSTEM_CHAT);
         componentRewriter.registerDisguisedChat(ClientboundPackets1_21.DISGUISED_CHAT);
+        componentRewriter.registerPlayerChat(ClientboundPackets1_21.PLAYER_CHAT, ChatType.TYPE);
         componentRewriter.registerPing();
 
         particleRewriter.registerLevelParticles1_20_5(ClientboundPackets1_21.LEVEL_PARTICLES);


### PR DESCRIPTION
This PR fixes a network protocol error which occures if a signed chat message contains a show item hover event with an old custom model data.

Example log: https://mclo.gs/rlpXuL8

