### PR TITLE
Don't perform length validation on zero bit storage in 1.18 palette type

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/type/types/chunk/PaletteType1_18.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/types/chunk/PaletteType1_18.java
@@ -48,7 +48,7 @@ public class PaletteType1_18 extends PaletteTypeBase {
             // Single value storage
             palette = new DataPaletteImpl(type.size(), 1);
             palette.addId(Types.VAR_INT.readPrimitive(buffer));
-            readValues(buffer, 0, palette); // Just eat it if not empty - thanks, Hypixel
+            readValues(buffer, 0, palette);
             return palette;
         }
 
@@ -76,13 +76,15 @@ public class PaletteType1_18 extends PaletteTypeBase {
 
     protected void readValues(final ByteBuf buffer, final int bitsPerValue, final DataPaletteImpl palette) {
         final long[] values = Types.LONG_ARRAY_PRIMITIVE.read(buffer);
-        if (values.length > 0) {
-            final int valuesPerLong = (char) (64 / bitsPerValue);
-            final int expectedLength = (type.size() + valuesPerLong - 1) / valuesPerLong;
-            if (values.length == expectedLength) { // Thanks, Hypixel
-                CompactArrayUtil.iterateCompactArrayWithPadding(bitsPerValue, type.size(), values,
-                    bitsPerValue == globalPaletteBits ? palette::setIdAt : palette::setPaletteIndexAt);
-            }
+        if (values.length == 0 || bitsPerValue == 0) {
+            return;
+        }
+
+        final int valuesPerLong = (char) (64 / bitsPerValue);
+        final int expectedLength = (type.size() + valuesPerLong - 1) / valuesPerLong;
+        if (values.length == expectedLength) {
+            CompactArrayUtil.iterateCompactArrayWithPadding(bitsPerValue, type.size(), values,
+                bitsPerValue == globalPaletteBits ? palette::setIdAt : palette::setPaletteIndexAt);
         }
     }
 


### PR DESCRIPTION
Minecraft has its own ZeroBitStorage type for this case so we don't need to perform the validation, also removed the comments as this is just how our code should work to match Vanilla behaviour (at least for the first one; I did not verify the readValues code)

Closes https://github.com/ViaVersion/ViaVersion/issues/4476