### PR TITLE
Check for non-negative value for damage & repair cost in 1.20.3->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -449,12 +449,12 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
         updateDisplay(connection, data, tag.getCompoundTag("display"), hideFlagsValue);
 
         final NumberTag damage = tag.getNumberTag("Damage");
-        if (damage != null && damage.asInt() != 0) {
+        if (damage != null && damage.asInt() > 0) {
             data.set(StructuredDataKey.DAMAGE, damage.asInt());
         }
 
         final NumberTag repairCost = tag.getNumberTag("RepairCost");
-        if (repairCost != null && repairCost.asInt() != 0) {
+        if (repairCost != null && repairCost.asInt() > 0) {
             data.set(StructuredDataKey.REPAIR_COST, repairCost.asInt());
         }
 


### PR DESCRIPTION
In 1.20.5, codecs introduced the non-negative int type which will fail if a value <= 0 is present. In 1.20.4, Mojang gracefully handled negative values.

Fixes https://github.com/ViaVersion/ViaFabricPlus/issues/763