### PR TITLE
Fix legacy block picking on some paper forks

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
@@ -18,8 +18,10 @@
 package com.viaversion.viaversion.bukkit.providers;
 
 import com.viaversion.viaversion.ViaVersionPlugin;
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.BlockPosition;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.bukkit.platform.PaperViaInjector;
 import com.viaversion.viaversion.bukkit.util.LegacyBlockToItem;
 import com.viaversion.viaversion.protocols.v1_21_2to1_21_4.provider.PickItemProvider;
@@ -187,14 +189,15 @@ public class BukkitPickItemProvider extends PickItemProvider {
                     }
                     return item;
                 };
-            } else if (PaperViaInjector.hasMethod(Material.class, "isItem")) {
-                return (block, includeData) -> new ItemStack(block.getType(), 1);
-            } else {
+            } else if (Via.getAPI().getServerVersion().lowestSupportedProtocolVersion().equalTo(ProtocolVersion.v1_8)) {
                 LegacyBlockToItem legacy = LegacyBlockToItem.getInstance();
                 return legacy != null ? (block, includeData) -> legacy.blockToItem(block) : (b, i) -> null;
+            } else if (PaperViaInjector.hasMethod(Material.class, "isItem")) {
+                return (block, includeData) -> new ItemStack(block.getType(), 1, (short) 0, block.getData());
+            } else {
+                return (b, i) -> null;
             }
         }
-
     }
 
     @FunctionalInterface

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
@@ -193,7 +193,7 @@ public class BukkitPickItemProvider extends PickItemProvider {
                 LegacyBlockToItem legacy = LegacyBlockToItem.getInstance();
                 return legacy != null ? (block, includeData) -> legacy.blockToItem(block) : (b, i) -> null;
             } else if (PaperViaInjector.hasMethod(Material.class, "isItem")) {
-                return (block, includeData) -> block.getType().isItem() ? new ItemStack(block.getType(), 1, (short) 0, block.getData()) : null;
+                return (block, includeData) -> block.getType().isItem() ? new ItemStack(block.getType()) : null;
             } else {
                 return (b, i) -> null;
             }

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
@@ -189,13 +189,23 @@ public class BukkitPickItemProvider extends PickItemProvider {
                     }
                     return item;
                 };
-            } else if (Via.getAPI().getServerVersion().lowestSupportedProtocolVersion().equalTo(ProtocolVersion.v1_8)) {
-                LegacyBlockToItem legacy = LegacyBlockToItem.getInstance();
+            }
+
+            final ProtocolVersion version = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
+            if (version.equalTo(ProtocolVersion.v1_8)) {
+                final LegacyBlockToItem legacy = LegacyBlockToItem.getInstance();
                 return legacy != null ? (block, includeData) -> legacy.blockToItem(block) : (b, i) -> null;
             } else if (PaperViaInjector.hasMethod(Material.class, "isItem")) {
-                return (block, includeData) -> block.getType().isItem() ? new ItemStack(block.getType()) : null;
+                return (block, includeData) -> {
+                    if (!block.getType().isItem()) {
+                        return null;
+                    }
+                    return version.newerThanOrEqualTo(ProtocolVersion.v1_13)
+                        ? new ItemStack(block.getType())
+                        : new ItemStack(block.getType(), 1, (short) 0, block.getData());
+                };
             } else {
-                return (b, i) -> null;
+                return (block, includeData) -> null;
             }
         }
     }

--- a/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
+++ b/bukkit/src/main/java/com/viaversion/viaversion/bukkit/providers/BukkitPickItemProvider.java
@@ -193,7 +193,7 @@ public class BukkitPickItemProvider extends PickItemProvider {
                 LegacyBlockToItem legacy = LegacyBlockToItem.getInstance();
                 return legacy != null ? (block, includeData) -> legacy.blockToItem(block) : (b, i) -> null;
             } else if (PaperViaInjector.hasMethod(Material.class, "isItem")) {
-                return (block, includeData) -> new ItemStack(block.getType(), 1, (short) 0, block.getData());
+                return (block, includeData) -> block.getType().isItem() ? new ItemStack(block.getType(), 1, (short) 0, block.getData()) : null;
             } else {
                 return (b, i) -> null;
             }


### PR DESCRIPTION
As discussed in https://github.com/ViaVersion/ViaVersion/pull/4412, some forks provide the `Material#isItem()` Method for convenience, breaking the legacy support detection.

This PR changes the legacy provider to always be used when all class/method resolutions succeed during class initialization.
