### PR TITLE
Don't convert creative-slot-lock/map-post-processing in 1.20.3->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/BlockItemPacketRewriter1_20_5.java
@@ -593,11 +593,6 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
 
         updateProfile(data, tag.get("SkullOwner"));
 
-        final CompoundTag customCreativeLock = tag.getCompoundTag("CustomCreativeLock");
-        if (customCreativeLock != null) {
-            data.set(StructuredDataKey.CREATIVE_SLOT_LOCK);
-        }
-
         final ListTag<StringTag> canPlaceOnTag = tag.getListTag("CanPlaceOn", StringTag.class);
         if (canPlaceOnTag != null) {
             data.set(StructuredDataKey.CAN_PLACE_ON1_20_5, updateBlockPredicates(canPlaceOnTag, (hideFlagsValue & StructuredDataConverter.HIDE_CAN_PLACE_ON) == 0));
@@ -606,16 +601,6 @@ public final class BlockItemPacketRewriter1_20_5 extends ItemRewriter<Clientboun
         final ListTag<StringTag> canDestroyTag = tag.getListTag("CanDestroy", StringTag.class);
         if (canDestroyTag != null) {
             data.set(StructuredDataKey.CAN_BREAK1_20_5, updateBlockPredicates(canDestroyTag, (hideFlagsValue & StructuredDataConverter.HIDE_CAN_DESTROY) == 0));
-        }
-
-        final IntTag mapScaleDirectionTag = tag.getIntTag("map_scale_direction");
-        if (mapScaleDirectionTag != null) {
-            data.set(StructuredDataKey.MAP_POST_PROCESSING, 1); // Scale
-        } else {
-            final NumberTag mapToLockTag = tag.getNumberTag("map_to_lock");
-            if (mapToLockTag != null) {
-                data.set(StructuredDataKey.MAP_POST_PROCESSING, 0); // Lock
-            }
         }
 
         // Only for VB, but kept here for simplicity; In VV we back up the original tag and later restore it, in VB

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
@@ -341,7 +341,6 @@ public final class StructuredDataConverter {
             }
             getBlockEntityTag(tag, "decorated_pot").put("sherds", sherds);
         });
-        register(StructuredDataKey.CREATIVE_SLOT_LOCK, (data, tag) -> tag.put("CustomCreativeLock", new CompoundTag()));
         register(StructuredDataKey.DEBUG_STICK_STATE, (data, tag) -> tag.put("DebugProperty", data));
         register(StructuredDataKey.RECIPES, (data, tag) -> tag.put("Recipes", data));
         register(StructuredDataKey.ENTITY_DATA, (data, tag) -> tag.put("EntityTag", data));

--- a/common/src/main/java/com/viaversion/viaversion/rewriter/item/ItemDataComponentConverter.java
+++ b/common/src/main/java/com/viaversion/viaversion/rewriter/item/ItemDataComponentConverter.java
@@ -115,7 +115,7 @@ public final class ItemDataComponentConverter {
             return new Result<>(ItemComponentRegistry.V1_21_5.TOOLTIP_DISPLAY, new Types_v1_21_5.TooltipDisplay(tooltipDisplay.hideTooltip(), result));
         });
         this.direct(StructuredDataKey.REPAIR_COST, ItemComponentRegistry.V1_21_5.REPAIR_COST);
-        this.unit(StructuredDataKey.CREATIVE_SLOT_LOCK, ItemComponentRegistry.V1_21_5.CREATIVE_SLOT_LOCK);
+        this.notSerializable(StructuredDataKey.CREATIVE_SLOT_LOCK);
         this.direct(StructuredDataKey.ENCHANTMENT_GLINT_OVERRIDE, ItemComponentRegistry.V1_21_5.ENCHANTMENT_GLINT_OVERRIDE);
         this.register(StructuredDataKey.INTANGIBLE_PROJECTILE, value -> new Result<>(ItemComponentRegistry.V1_21_5.INTANGIBLE_PROJECTILE, null));
         this.register(StructuredDataKey.FOOD1_21_2, foodProperties -> {
@@ -149,7 +149,7 @@ public final class ItemDataComponentConverter {
         this.direct(StructuredDataKey.MAP_COLOR, ItemComponentRegistry.V1_21_5.MAP_COLOR);
         this.direct(StructuredDataKey.MAP_ID, ItemComponentRegistry.V1_21_5.MAP_ID);
         this.register(StructuredDataKey.MAP_DECORATIONS, passthroughNbtCodec(ItemComponentRegistry.V1_21_5.MAP_DECORATIONS));
-        this.intToEnum(StructuredDataKey.MAP_POST_PROCESSING, ItemComponentRegistry.V1_21_5.MAP_POST_PROCESSING, Types_v1_20_5.MapPostProcessing.class);
+        this.notSerializable(StructuredDataKey.MAP_POST_PROCESSING);
         this.register(StructuredDataKey.V1_21_5.chargedProjectiles, convertItemArrayFunction(ItemComponentRegistry.V1_21_5.CHARGED_PROJECTILES));
         this.register(StructuredDataKey.V1_21_5.bundleContents, convertItemArrayFunction(ItemComponentRegistry.V1_21_5.BUNDLE_CONTENTS));
         this.notImplemented(StructuredDataKey.POTION_CONTENTS1_21_2);
@@ -285,6 +285,12 @@ public final class ItemDataComponentConverter {
 
     private <I> void notImplemented(final StructuredDataKey<I> key) {
         this.register(key, value -> null);
+    }
+
+    private <I> void notSerializable(final StructuredDataKey<I> key) {
+        this.register(key, value -> {
+            throw new IllegalStateException(key.identifier() + " is not serializable");
+        });
     }
 
     private void unit(final StructuredDataKey<Unit> key, final ItemComponent<?> result) {


### PR DESCRIPTION
Also makes them not serializable in ItemDataComponentConverter. These are not supposed to be synced over the network and the item hasher will crash now in 1.21.5+ versions