### PR TITLE
Fix respawning with 1.21.2+ clients on older vanilla servers

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/Protocol1_21To1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/Protocol1_21To1_21_2.java
@@ -54,6 +54,7 @@ import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.ChunkLoadTracke
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.EntityTracker1_21_2;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.GroundFlagTracker;
 import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.PlayerPositionStorage;
+import com.viaversion.viaversion.protocols.v1_21to1_21_2.storage.TeleportAckCancelStorage;
 import com.viaversion.viaversion.rewriter.AttributeRewriter;
 import com.viaversion.viaversion.rewriter.SoundRewriter;
 import com.viaversion.viaversion.rewriter.StatisticsRewriter;
@@ -224,6 +225,7 @@ public final class Protocol1_21To1_21_2 extends AbstractProtocol<ClientboundPack
         addEntityTracker(connection, new EntityTracker1_21_2(connection));
         connection.put(new BundleStateTracker());
         connection.put(new GroundFlagTracker());
+        connection.put(new TeleportAckCancelStorage());
 
         final ProtocolVersion protocolVersion = connection.getProtocolInfo().protocolVersion();
         if (protocolVersion.olderThan(ProtocolVersion.v1_21_4)) { // Only needed for 1.21.2/1.21.3

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/EntityPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/EntityPacketRewriter1_21_2.java
@@ -186,7 +186,7 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
                 entityDataPacket.write(Types.VAR_INT, entityTracker.clientEntityId()); // Entity id
                 final List<EntityData> entityData = new ArrayList<>();
                 entityData.add(new EntityData(6 /*pose*/, VersionedTypes.V1_21_2.entityDataTypes.poseType, 0 /*standing*/));
-                entityData.add(new EntityData(9 /*health*/, VersionedTypes.V1_21_2.entityDataTypes.floatType, 20F)); // TODO: Track max health
+                entityData.add(new EntityData(9 /*health*/, VersionedTypes.V1_21_2.entityDataTypes.floatType, 20F)); // Max health should be tracked, but whatever
                 entityDataPacket.write(VersionedTypes.V1_21_2.entityDataList, entityData);
                 entityDataPacket.send(Protocol1_21To1_21_2.class);
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/EntityTracker1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/EntityTracker1_21_2.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 public final class EntityTracker1_21_2 extends EntityTrackerBase {
 
     private final Int2ObjectMap<BoatEntity> boats = new Int2ObjectOpenHashMap<>();
+    private double playerMaxHealthAttributeValue = 20F;
 
     public EntityTracker1_21_2(final UserConnection connection) {
         super(connection, EntityTypes1_21_2.PLAYER);
@@ -57,6 +58,14 @@ public final class EntityTracker1_21_2 extends EntityTrackerBase {
         removeEntity(entityId);
         boats.put(entityId, entity);
         addEntity(entityId, type);
+    }
+
+    public double playerMaxHealthAttributeValue() {
+        return this.playerMaxHealthAttributeValue;
+    }
+
+    public void setPlayerMaxHealthAttributeValue(final double playerMaxHealthAttributeValue) {
+        this.playerMaxHealthAttributeValue = playerMaxHealthAttributeValue;
     }
 
     public static class BoatEntity {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/TeleportAckCancelStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/TeleportAckCancelStorage.java
@@ -26,12 +26,7 @@ public class TeleportAckCancelStorage implements StorableObject {
     private final IntSet cancelTeleportIds = new IntOpenHashSet();
 
     public boolean checkShouldCancelTeleportAck(final int teleportId) {
-        if (this.cancelTeleportIds.contains(teleportId)) {
-            this.cancelTeleportIds.remove(teleportId);
-            return true;
-        } else {
-            return false;
-        }
+        return this.cancelTeleportIds.remove(teleportId);
     }
 
     public void cancelTeleportId(final int teleportId) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/TeleportAckCancelStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/TeleportAckCancelStorage.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_21to1_21_2.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+
+public class TeleportAckCancelStorage implements StorableObject {
+
+    private final IntSet cancelTeleportIds = new IntOpenHashSet();
+
+    public boolean checkShouldCancelTeleportAck(final int teleportId) {
+        if (this.cancelTeleportIds.contains(teleportId)) {
+            this.cancelTeleportIds.remove(teleportId);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public void cancelTeleportId(final int teleportId) {
+        this.cancelTeleportIds.add(teleportId);
+    }
+
+}


### PR DESCRIPTION
Fixes being unable to respawn. Caused by a change in Minecraft where <=1.21.1 clients reset some player data after respawning, while >=1.21.2 clients do not

1.21.1:
![image](https://github.com/user-attachments/assets/0d1e0726-b200-4062-92d2-0c9ec6b95f9f)

1.21.2:
![image](https://github.com/user-attachments/assets/14921c76-4627-491b-b11b-2625bfc045f1)
