### PR TITLE
Filter invalid characters in command click events in 1.21.4->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
@@ -188,7 +188,17 @@ public final class ComponentRewriter1_21_5 extends JsonNBTComponentRewriter<Clie
 
             clickEventTag.putInt("page", page);
         } else if (action.equals("run_command") || action.equals("suggest_command")) {
-            clickEventTag.put("command", clickEventTag.getStringTag("value"));
+            final String value = clickEventTag.getString("value");
+            final StringBuilder command = new StringBuilder();
+            for (final char c : value.toCharArray()) {
+                if (c != 167 && c >= ' ' && c != 127) {
+                    command.append(c);
+                } else if (action.equals("suggest_command") && c == '\n') {
+                    command.append(c);
+                }
+            }
+
+            clickEventTag.putString("command", command.toString());
         }
     }
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
@@ -190,8 +190,9 @@ public final class ComponentRewriter1_21_5 extends JsonNBTComponentRewriter<Clie
         } else if (action.equals("run_command") || action.equals("suggest_command")) {
             final String value = clickEventTag.getString("value");
             final StringBuilder command = new StringBuilder();
-            for (final char c : value.toCharArray()) {
-                if (c != 167 && c >= ' ' && c != 127) {
+            for (int i = 0; i < value.length(); i++) {
+                final char c = value.charAt(i);
+                if (c != '§' && c >= ' ' && c != 127) {
                     command.append(c);
                 } else if (action.equals("suggest_command") && c == '\n') {
                     command.append(c);


### PR DESCRIPTION
Minecraft versions prior to 1.21.4 filter out invalid characters when handling the click event on the clientside while 1.21.5+ validates and throws in the network codec per ExtraCodecs#CHAT_STRING