### PR TITLE
Remove arbitrary chat-nbt-fix config option in 1.11.1->1.12

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -234,13 +234,6 @@ public interface ViaVersionConfig extends Config {
     boolean isChunkBorderFix();
 
     /**
-     * Should we fix nbt array's in json chat messages for 1.12 clients
-     *
-     * @return true if enabled
-     */
-    boolean is1_12NBTArrayFix();
-
-    /**
      * Should we make team colours based on the last colour in team prefix
      *
      * @return true if enabled

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -66,7 +66,6 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private int pistonReplacementId;
     private boolean chunkBorderFix;
     private boolean autoTeam;
-    private boolean nbtArrayFix;
     private BlockedProtocolVersions blockedProtocolVersions;
     private String blockedDisconnectMessage;
     private String reloadDisconnectMessage;
@@ -133,7 +132,6 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         pistonReplacementId = getInt("replacement-piston-id", 0);
         chunkBorderFix = getBoolean("chunk-border-fix", false);
         autoTeam = getBoolean("auto-team", true);
-        nbtArrayFix = getBoolean("chat-nbt-fix", true);
         blockedProtocolVersions = loadBlockedProtocolVersions();
         blockedDisconnectMessage = getString("block-disconnect-msg", "You are using an unsupported Minecraft version!");
         reloadDisconnectMessage = getString("reload-disconnect-msg", "Server reload, please rejoin!");
@@ -377,11 +375,6 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     public boolean isAutoTeam() {
         // Collision has to be enabled first
         return preventCollision && autoTeam;
-    }
-
-    @Override
-    public boolean is1_12NBTArrayFix() {
-        return nbtArrayFix;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_11_1to1_12/Protocol1_11_1To1_12.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_11_1to1_12/Protocol1_11_1To1_12.java
@@ -21,7 +21,6 @@ import com.google.gson.JsonElement;
 import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.nbt.tag.IntTag;
 import com.viaversion.nbt.tag.StringTag;
-import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.ClientWorld;
 import com.viaversion.viaversion.api.minecraft.chunks.Chunk;
@@ -32,7 +31,6 @@ import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_12;
 import com.viaversion.viaversion.api.platform.providers.ViaProviders;
 import com.viaversion.viaversion.api.protocol.AbstractProtocol;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
-import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_9_3;
 import com.viaversion.viaversion.data.entity.EntityTrackerBase;
@@ -43,8 +41,6 @@ import com.viaversion.viaversion.protocols.v1_11_1to1_12.packet.ServerboundPacke
 import com.viaversion.viaversion.protocols.v1_11_1to1_12.provider.InventoryQuickMoveProvider;
 import com.viaversion.viaversion.protocols.v1_11_1to1_12.rewriter.EntityPacketRewriter1_12;
 import com.viaversion.viaversion.protocols.v1_11_1to1_12.rewriter.ItemPacketRewriter1_12;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.Protocol1_12_2To1_13;
-import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ClientboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_9_1to1_9_3.packet.ClientboundPackets1_9_3;
 import com.viaversion.viaversion.protocols.v1_9_1to1_9_3.packet.ServerboundPackets1_9_3;
 import com.viaversion.viaversion.rewriter.SoundRewriter;
@@ -63,7 +59,6 @@ public class Protocol1_11_1To1_12 extends AbstractProtocol<ClientboundPackets1_9
         super.registerPackets();
 
         registerClientbound(ClientboundPackets1_9_3.CHAT, wrapper -> {
-            if (!Via.getConfig().is1_12NBTArrayFix()) return;
             final JsonElement element = wrapper.passthrough(Types.COMPONENT);
             TranslateRewriter.toClient(wrapper.user(), element);
             ChatItemRewriter.toClient(element);

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -93,8 +93,6 @@ hologram-y: -0.96
 # Should we disable piston animation for 1.11/1.11.1 clients?
 # In some cases, when firing lots of pistons, it crashes them.
 piston-animation-patch: false
-# Should we fix nbt for 1.12 and above clients in chat messages (causes invalid item)
-chat-nbt-fix: true
 # Experimental - Should we fix shift quick move action for 1.12 clients (causes shift + double click not to work when moving items) (only works on 1.8-1.11.2 bukkit based servers)
 quick-move-action-fix: false
 # Should we use prefix for team color on 1.13 and above clients?


### PR DESCRIPTION
I should have removed that when I rewrote the chat item rewriters in that protocol, but I somehow forgot.