### PR TITLE
fix: Proxy Plugin Messaging Channel 

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/connection/ConnectionManagerImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/ConnectionManagerImpl.java
@@ -76,9 +76,9 @@ public class ConnectionManagerImpl implements ConnectionManager {
 
         UUID id = connection.getProtocolInfo().getUuid();
         if (connection.isServerSide()) {
-            serverConnections.remove(id);
+            serverConnections.remove(id, connection);
         } else {
-            clientConnections.remove(id);
+            clientConnections.remove(id, connection);
         }
 
         connection.clearStoredObjects();


### PR DESCRIPTION
This fixes the issue with proxy plugin messaging channel where the message is only sent to the first server they join due to getClientConnection returning null. This is due to it getting removed after they switch server.

This fixes #4565 