### PR TITLE
[ci skip] Add Java resolving plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "viaversion-parent"
 
 includeBuild("build-logic")


### PR DESCRIPTION
Allows the project to compile even when JDK 17 is not natively installed.