### PR TITLE
Remove StorableObject#clearOnServerSwitch

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/connection/StorableObject.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/connection/StorableObject.java
@@ -30,15 +30,6 @@ package com.viaversion.viaversion.api.connection;
  */
 public interface StorableObject {
 
-    /**
-     * Returns whether the object should be uncached on a server switch.
-     *
-     * @return whether the object should be uncached on a server switch
-     */
-    default boolean clearOnServerSwitch() {
-        return true;
-    }
-
     default void onRemove() {
     }
 }

--- a/api/src/main/java/com/viaversion/viaversion/api/connection/UserConnection.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/connection/UserConnection.java
@@ -139,17 +139,7 @@ public interface UserConnection {
     /**
      * Clear stored objects, entity trackers and client worlds.
      */
-    default void clearStoredObjects() {
-        clearStoredObjects(false);
-    }
-
-    /**
-     * Clear stored objects, entity trackers and client worlds.
-     * If cleared for a proxy server switch, some stored objects and tracker data will be retained.
-     *
-     * @param isServerSwitch whether the clear is due to a server switch
-     */
-    void clearStoredObjects(boolean isServerSwitch);
+    void clearStoredObjects();
 
     /**
      * Sends a raw packet to the connection on the current thread.

--- a/common/src/main/java/com/viaversion/viaversion/connection/UserConnectionImpl.java
+++ b/common/src/main/java/com/viaversion/viaversion/connection/UserConnectionImpl.java
@@ -154,27 +154,14 @@ public class UserConnectionImpl implements UserConnection {
     }
 
     @Override
-    public void clearStoredObjects(boolean isServerSwitch) {
-        if (isServerSwitch) {
-            storedObjects.values().removeIf(storableObject -> {
-                if (storableObject.clearOnServerSwitch()) {
-                    storableObject.onRemove();
-                    return true;
-                }
-                return false;
-            });
-            for (EntityTracker tracker : entityTrackers.values()) {
-                tracker.clearEntities();
-            }
-        } else {
-            for (StorableObject object : storedObjects.values()) {
-                object.onRemove();
-            }
-            storedObjects.clear();
-            entityTrackers.clear();
-            itemHashers.clear();
-            clientWorlds.clear();
+    public void clearStoredObjects() {
+        for (StorableObject object : storedObjects.values()) {
+            object.onRemove();
         }
+        storedObjects.clear();
+        entityTrackers.clear();
+        itemHashers.clear();
+        clientWorlds.clear();
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/storage/DimensionRegistryStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_18_2to1_19/storage/DimensionRegistryStorage.java
@@ -37,9 +37,4 @@ public final class DimensionRegistryStorage implements StorableObject {
     public Map<CompoundTag, String> dimensions() {
         return dimensions;
     }
-
-    @Override
-    public boolean clearOnServerSwitch() {
-        return false;
-    }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19to1_19_1/storage/ChatTypeStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19to1_19_1/storage/ChatTypeStorage.java
@@ -39,9 +39,4 @@ public final class ChatTypeStorage implements StorableObject {
     public void clear() {
         chatTypes.clear();
     }
-
-    @Override
-    public boolean clearOnServerSwitch() {
-        return false;
-    }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/storage/AcknowledgedMessagesStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/storage/AcknowledgedMessagesStorage.java
@@ -114,9 +114,4 @@ public final class AcknowledgedMessagesStorage implements StorableObject {
         lastSeenMessages = new BitSet();
         delayedAckCount = 0;
     }
-
-    @Override
-    public boolean clearOnServerSwitch() {
-        return false;
-    }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/storage/BannerPatternStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/storage/BannerPatternStorage.java
@@ -38,9 +38,4 @@ public final class BannerPatternStorage implements StorableObject {
     public @Nullable String pattern(final int id) {
         return bannerPatterns.idToKey(id);
     }
-
-    @Override
-    public boolean clearOnServerSwitch() {
-        return false;
-    }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/storage/ConfigurationState.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/storage/ConfigurationState.java
@@ -92,11 +92,6 @@ public class ConfigurationState implements StorableObject {
     }
 
     @Override
-    public boolean clearOnServerSwitch() {
-        return false;
-    }
-
-    @Override
     public void onRemove() {
         for (final QueuedPacket packet : packetQueue) {
             packet.buf().release();

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/storage/LastResourcePack.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/storage/LastResourcePack.java
@@ -24,8 +24,4 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public record LastResourcePack(String url, String hash, boolean required,
                                @Nullable JsonElement prompt) implements StorableObject {
 
-    @Override
-    public boolean clearOnServerSwitch() {
-        return false;
-    }
 }


### PR DESCRIPTION
This was only ever used on BungeeCord and was most likely wrong / a workaround from otherwise broken code. I think we can finally get rid of it.