### PR TITLE
Update ViaNBT dependency from 5.1.0 to 5.1.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ metadata.format.version = "1.1"
 
 gson = "2.12.1"
 fastutil = "8.5.15"
-vianbt = "5.1.0"
+vianbt = "5.1.2"
 mcstructs = "5-3.1.1-SNAPSHOT"
 
 # Common provided


### PR DESCRIPTION
As title says.

ViaVersion compiles just fine and the issue with deserializing SNBT with zero signed byte tags is fixed.