### PR TITLE
Add cancel-swing-in-inventory option for 1.15.2->1.16 inventory swing fix

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -478,4 +478,12 @@ public interface ViaVersionConfig extends Config {
      * @return true if enabled
      */
     boolean fix1_21PlacementRotation();
+
+    /**
+     * If enabled, cancel swing packets sent while having an inventory opened on 1.15.2 and below servers.
+     * This can cause false positives with anti-cheat plugins.
+     *
+     * @return true if enabled
+     */
+    boolean cancelSwingInInventory();
 }

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -27,13 +27,14 @@ import com.viaversion.viaversion.protocol.BlockedProtocolVersionsImpl;
 import com.viaversion.viaversion.util.Config;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract class AbstractViaConfig extends Config implements ViaVersionConfig {
     public static final List<String> BUKKIT_ONLY_OPTIONS = Arrays.asList("register-userconnections-on-join", "quick-move-action-fix",
@@ -96,6 +97,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private boolean cancelBlockSounds;
     private boolean hideScoreboardNumbers;
     private boolean fix1_21PlacementRotation;
+    private boolean cancelSwingInInventory;
 
     protected AbstractViaConfig(final File configFile, final Logger logger) {
         super(configFile, logger);
@@ -165,6 +167,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         cancelBlockSounds = getBoolean("cancel-block-sounds", true);
         hideScoreboardNumbers = getBoolean("hide-scoreboard-numbers", false);
         fix1_21PlacementRotation = getBoolean("fix-1_21-placement-rotation", true);
+        cancelSwingInInventory = getBoolean("cancel-swing-in-inventory", true);
     }
 
     private BlockedProtocolVersions loadBlockedProtocolVersions() {
@@ -555,5 +558,10 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public boolean fix1_21PlacementRotation() {
         return fix1_21PlacementRotation;
+    }
+
+    @Override
+    public boolean cancelSwingInInventory() {
+        return cancelSwingInInventory;
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java
@@ -37,6 +37,7 @@ import com.viaversion.viaversion.protocols.v1_15_2to1_16.packet.ServerboundPacke
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.storage.InventoryTracker1_16;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.util.Key;
+
 import java.util.UUID;
 
 public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1_15, Protocol1_15_2To1_16> {
@@ -201,6 +202,10 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
         });
 
         protocol.registerServerbound(ServerboundPackets1_16.SWING, wrapper -> {
+            if (!Via.getConfig().cancelSwingInInventory()) {
+                return;
+            }
+
             InventoryTracker1_16 inventoryTracker = wrapper.user().get(InventoryTracker1_16.class);
             // Don't send an arm swing if the player has an inventory opened.
             if (inventoryTracker.isInventoryOpen()) {

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -170,6 +170,9 @@ hide-scoreboard-numbers: false
 # Fixes 1.21+ clients on 1.20.5 servers placing water/lava buckets at the wrong location when moving fast, NOTE: This may cause issues with anti-cheat plugins.
 fix-1_21-placement-rotation: true
 #
+# If enabled, cancel swing packets sent while having an inventory opened on 1.15.2 and below servers. This can cause false positives with anti-cheat plugins.
+cancel-swing-in-inventory: true
+#
 #----------------------------------------------------------#
 #             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #
 #----------------------------------------------------------#


### PR DESCRIPTION
This can cause issues with anticheat plugins and has been force disabled in VFP for a while now.