### PR TITLE
Convert HIDE_ADDITIONAL_TOOLTIP in both directions in 1.21.4->1.21.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project properties - we put these here so they can be modified without causing a recompile of the build scripts
-projectVersion=5.4.2
+projectVersion=5.4.3-SNAPSHOT
 
 # Smile emoji (note that modrinth may not have added the version on release yet)
 mcVersions=1.21.8, 1.21.7, 1.21.6, 1.21.5, 1.21.4, 1.21.3, 1.21.2, 1.21.1, 1.21, 1.20.6, 1.20.5, 1.20.4, 1.20.3, 1.20.2, 1.20.1, 1.20, 1.19.4, 1.19.3, 1.19.2, 1.19.1, 1.19, 1.18.2, 1.18.1, 1.18, 1.17.1, 1.17, 1.16.5, 1.16.4, 1.16.3, 1.16.2, 1.16.1, 1.16, 1.15.2, 1.15.1, 1.15, 1.14.4, 1.14.3, 1.14.2, 1.14.1, 1.14, 1.13.2, 1.13.1, 1.13, 1.12.2, 1.12.1, 1.12, 1.11.2, 1.11.1, 1.11, 1.10.2, 1.10.1, 1.10, 1.9.4, 1.9.3, 1.9.2, 1.9.1, 1.9, 1.8.9

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ checkerQual = "3.49.5"
 paper = "1.20.4-R0.1-SNAPSHOT"
 legacyBukkit = "1.8.8-R0.1-SNAPSHOT"
 velocity = "3.1.1"
-viaProxy = "3.4.4-SNAPSHOT"
+viaProxy = "3.4.5-SNAPSHOT"
 
 [libraries]
 


### PR DESCRIPTION
Fixes it not being set in VB. I decided to remove the backup tag as this is the closest replacement / should work fine in VV too.