### PR TITLE
Don't put legacy show_text value through json conversion in 1.21.4->.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/ComponentRewriter1_21_5.java
@@ -204,9 +204,9 @@ public final class ComponentRewriter1_21_5 extends JsonNBTComponentRewriter<Clie
     }
 
     private void updateShowTextHover(final UserConnection connection, final CompoundTag hoverEventTag) {
-        if (hoverEventTag.remove("value") instanceof final StringTag value) {
-            final Tag contents = uglyJsonToTag(connection, value.getValue());
-            hoverEventTag.put("value", contents);
+        final Tag value = hoverEventTag.get("value");
+        if (value != null) {
+            processTag(connection, value);
             return;
         }
 


### PR DESCRIPTION
I don't think this ever was an inlined string for show_text. At least in 1.21.4, /tellraw doesn't work with it + can't find anything about it in MC or in MCStructs. would appreciate if you could confirm/verify