### PR TITLE
Fix: System chat messages sent during configuration are hidden on 1.8 servers behind Velocity

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/Protocol1_20To1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/Protocol1_20To1_20_2.java
@@ -282,11 +282,15 @@ public final class Protocol1_20To1_20_2 extends AbstractProtocol<ClientboundPack
             }
 
             if (configurationBridge.queuedOrSentJoinGame()) {
-                if (!packetWrapper.user().isClientSide() && !Via.getPlatform().isProxy() && unmappedId == ClientboundPackets1_19_4.SYSTEM_CHAT.getId()) {
-                    // Cancelling this on the Vanilla server will cause it to exceptionally resend a message
-                    // Assume that we have already sent the login packet and just let it through
-                    super.transform(direction, State.PLAY, packetWrapper);
-                    return;
+                final ProtocolVersion serverProtocolVersion = Via.getAPI().getServerVersion().lowestSupportedProtocolVersion();
+
+                if (serverProtocolVersion.newerThanOrEqualTo(ProtocolVersion.v1_13)) {
+                    if (!packetWrapper.user().isClientSide() && !Via.getPlatform().isProxy() && unmappedId == ClientboundPackets1_19_4.SYSTEM_CHAT.getId()) {
+                        // Cancelling this on a 1.13+ Vanilla server will cause it to exceptionally resend a message
+                        // Assume that we have already sent the login packet and just let it through
+                        super.transform(direction, State.PLAY, packetWrapper);
+                        return;
+                    }
                 }
 
                 configurationBridge.addPacketToQueue(packetWrapper, true);


### PR DESCRIPTION
Fixes [#4478](https://github.com/ViaVersion/ViaVersion/issues/4478)

The problem was introduced in commit [18c4f90](https://github.com/ViaVersion/ViaVersion/commit/18c4f90cb0ed6fc9ca7b2d2d194663ff81343628) to fix an additional message being sent by the Vanilla server.

I checked the Vanilla source code and the "exceptional" message was introduced in Minecraft 1.13 and as far as I can see has been kept in the latest versions.

## 1.12 EntityPlayer
```java
@Override
public void sendMessage(final IChatBaseComponent ichatbasecomponent) {
    this.playerConnection.sendPacket(new PacketPlayOutChat(ichatbasecomponent));
}
```

## 1.13 EntityPlayer
```java
@Override
public void sendMessage(final IChatBaseComponent ichatbasecomponent) {
    this.a(ichatbasecomponent, ChatMessageType.SYSTEM);
}

public void a(final IChatBaseComponent ichatbasecomponent, final ChatMessageType chatmessagetype) {
    this.playerConnection.a(new PacketPlayOutChat(ichatbasecomponent, chatmessagetype), future -> {
        if (!future.isSuccess() && (chatmessagetype == ChatMessageType.GAME_INFO || chatmessagetype == ChatMessageType.SYSTEM)) {
            this.playerConnection.sendPacket(new PacketPlayOutChat(EntityPlayer.cd, ChatMessageType.SYSTEM));
        }
    });
}
```