### PR TITLE
Fix Network Protocol Error when converting wolf_variant Registry Data Packet from 1.20.6 to 1.21

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/Protocol1_20_5To1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/Protocol1_20_5To1_21.java
@@ -237,6 +237,7 @@ public final class Protocol1_20_5To1_21 extends AbstractProtocol<ClientboundPack
         addEntityTracker(connection, new EntityTrackerBase(connection, EntityTypes1_20_5.PLAYER));
         connection.put(new EfficiencyAttributeStorage());
         connection.put(new PlayerPositionStorage());
+        EntityPacketRewriter1_21.receivedValidWolfVariantRegistryData = false;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
@@ -40,9 +40,11 @@ import com.viaversion.viaversion.protocols.v1_20_5to1_21.storage.PlayerPositionS
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.rewriter.RegistryDataRewriter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPacket1_20_5, Protocol1_20_5To1_21> {
-    public boolean receivedValidWolfArmorRegistryData = false;
+    public boolean receivedValidWolfVariantRegistryData = false;
 
     public EntityPacketRewriter1_21(final Protocol1_20_5To1_21 protocol) {
         super(protocol);
@@ -62,10 +64,10 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
         registryDataRewriter.addEntries("damage_type", new RegistryEntry("minecraft:campfire", campfireDamageType));
         registryDataRewriter.addHandler(
             "wolf_variant", (key, value) -> {
-                if (getValidWolfArmorRegistryEntryKeys().contains(key)) {
-                    receivedValidWolfArmorRegistryData = (value.contains("wild_texture") && value.contains("angry_texture") && value.contains("biomes") && value.contains("tame_texture"));
+                if (Arrays.asList(getValidWolfVariantRegistryEntryKeys()).contains(key)) {
+                    receivedValidWolfVariantRegistryData = (value.contains("wild_texture") && value.contains("angry_texture") && value.contains("biomes") && value.contains("tame_texture"));
                 } else {
-                    receivedValidWolfArmorRegistryData = false;
+                    receivedValidWolfVariantRegistryData = false;
                 }
             }
         );
@@ -103,72 +105,8 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
             jukeboxSongsPacket.write(Types.REGISTRY_ENTRY_ARRAY, protocol.getMappingData().jukeboxSongs());
             jukeboxSongsPacket.send(Protocol1_20_5To1_21.class);
 
-            if (!receivedValidWolfArmorRegistryData) {
-                final PacketWrapper wolfVariantPacket = wrapper.create(ClientboundConfigurationPackets1_20_5.REGISTRY_DATA);
-                // Add wolf_variant registries
-                final CompoundTag ashenWolfVariant = new CompoundTag();
-                ashenWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_ashen");
-                ashenWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_ashen_angry");
-                ashenWolfVariant.putString("biomes", "minecraft:snowy_taiga");
-                ashenWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_ashen_tame");
-                final CompoundTag blackWolfVariant = new CompoundTag();
-                blackWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_black");
-                blackWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_black_angry");
-                blackWolfVariant.putString("biomes", "minecraft:old_growth_pine_taiga");
-                blackWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_black_tame");
-                final CompoundTag chestnutWolfVariant = new CompoundTag();
-                chestnutWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_chestnut");
-                chestnutWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_chestnut_angry");
-                chestnutWolfVariant.putString("biomes", "minecraft:old_growth_spruce_taiga");
-                chestnutWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_chestnut_tame");
-                final CompoundTag paleWolfVariant = new CompoundTag();
-                paleWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf");
-                paleWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_angry");
-                paleWolfVariant.putString("biomes", "minecraft:taiga");
-                paleWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_tame");
-                final CompoundTag rustyWolfVariant = new CompoundTag();
-                rustyWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_rusty");
-                rustyWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_rusty_angry");
-                rustyWolfVariant.putString("biomes", "#minecraft:is_jungle");
-                rustyWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_rusty_tame");
-                final CompoundTag snowyWolfVariant = new CompoundTag();
-                snowyWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_snowy");
-                snowyWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_snowy_angry");
-                snowyWolfVariant.putString("biomes", "minecraft:grove");
-                snowyWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_snowy_tame");
-                final CompoundTag spottedWolfVariant = new CompoundTag();
-                spottedWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_spotted");
-                spottedWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_spotted_angry");
-                spottedWolfVariant.putString("biomes", "#minecraft:is_savanna");
-                spottedWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_spotted_tame");
-                final CompoundTag stripedWolfVariant = new CompoundTag();
-                stripedWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_striped");
-                stripedWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_striped_angry");
-                stripedWolfVariant.putString("biomes", "#minecraft:is_badlands");
-                stripedWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_striped_tame");
-                final CompoundTag woodsWolfVariant = new CompoundTag();
-                woodsWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_woods");
-                woodsWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_woods_angry");
-                woodsWolfVariant.putString("biomes", "minecraft:forest");
-                woodsWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_woods_tame");
-
-                final RegistryEntry[] wolfVariantRegistryEntryArray = new RegistryEntry[9];
-                wolfVariantRegistryEntryArray[0] = new RegistryEntry("minecraft:ashen", ashenWolfVariant);
-                wolfVariantRegistryEntryArray[1] = new RegistryEntry("minecraft:black", blackWolfVariant);
-                wolfVariantRegistryEntryArray[2] = new RegistryEntry("minecraft:chestnut", chestnutWolfVariant);
-                wolfVariantRegistryEntryArray[3] = new RegistryEntry("minecraft:pale", paleWolfVariant);
-                wolfVariantRegistryEntryArray[4] = new RegistryEntry("minecraft:rusty", rustyWolfVariant);
-                wolfVariantRegistryEntryArray[5] = new RegistryEntry("minecraft:snowy", snowyWolfVariant);
-                wolfVariantRegistryEntryArray[6] = new RegistryEntry("minecraft:spotted", spottedWolfVariant);
-                wolfVariantRegistryEntryArray[7] = new RegistryEntry("minecraft:striped", stripedWolfVariant);
-                wolfVariantRegistryEntryArray[8] = new RegistryEntry("minecraft:woods", woodsWolfVariant);
-
-                wolfVariantPacket.write(Types.STRING, "minecraft:wolf_variant");
-                wolfVariantPacket.write(
-                    Types.REGISTRY_ENTRY_ARRAY,
-                    wolfVariantRegistryEntryArray
-                );
-                wolfVariantPacket.send(Protocol1_20_5To1_21.class);
+            if (!receivedValidWolfVariantRegistryData) {
+                createDefaultWolfVariantRegistryDataPacket(wrapper).send(Protocol1_20_5To1_21.class);
             }
         });
 
@@ -217,18 +155,84 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
         });
     }
 
-    private static ArrayList<String> getValidWolfArmorRegistryEntryKeys() {
-        final ArrayList<String> validWolfArmorKeys = new ArrayList<>();
-        validWolfArmorKeys.add("minecraft:ashen");
-        validWolfArmorKeys.add("minecraft:black");
-        validWolfArmorKeys.add("minecraft:chestnut");
-        validWolfArmorKeys.add("minecraft:pale");
-        validWolfArmorKeys.add("minecraft:rusty");
-        validWolfArmorKeys.add("minecraft:snowy");
-        validWolfArmorKeys.add("minecraft:spotted");
-        validWolfArmorKeys.add("minecraft:striped");
-        validWolfArmorKeys.add("minecraft:woods");
-        return validWolfArmorKeys;
+    private static PacketWrapper createDefaultWolfVariantRegistryDataPacket(PacketWrapper wrapper) {
+        final PacketWrapper wolfVariantPacket = wrapper.create(ClientboundConfigurationPackets1_20_5.REGISTRY_DATA);
+        wolfVariantPacket.write(Types.STRING, "minecraft:wolf_variant");
+        wolfVariantPacket.write(Types.REGISTRY_ENTRY_ARRAY, getWolfVariantRegistryEntries());
+        return wolfVariantPacket;
+    }
+
+    private static RegistryEntry[] getWolfVariantRegistryEntries() {
+        final CompoundTag ashenWolfVariant = new CompoundTag();
+        ashenWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_ashen");
+        ashenWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_ashen_angry");
+        ashenWolfVariant.putString("biomes", "minecraft:snowy_taiga");
+        ashenWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_ashen_tame");
+        final CompoundTag blackWolfVariant = new CompoundTag();
+        blackWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_black");
+        blackWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_black_angry");
+        blackWolfVariant.putString("biomes", "minecraft:old_growth_pine_taiga");
+        blackWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_black_tame");
+        final CompoundTag chestnutWolfVariant = new CompoundTag();
+        chestnutWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_chestnut");
+        chestnutWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_chestnut_angry");
+        chestnutWolfVariant.putString("biomes", "minecraft:old_growth_spruce_taiga");
+        chestnutWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_chestnut_tame");
+        final CompoundTag paleWolfVariant = new CompoundTag();
+        paleWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf");
+        paleWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_angry");
+        paleWolfVariant.putString("biomes", "minecraft:taiga");
+        paleWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_tame");
+        final CompoundTag rustyWolfVariant = new CompoundTag();
+        rustyWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_rusty");
+        rustyWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_rusty_angry");
+        rustyWolfVariant.putString("biomes", "#minecraft:is_jungle");
+        rustyWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_rusty_tame");
+        final CompoundTag snowyWolfVariant = new CompoundTag();
+        snowyWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_snowy");
+        snowyWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_snowy_angry");
+        snowyWolfVariant.putString("biomes", "minecraft:grove");
+        snowyWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_snowy_tame");
+        final CompoundTag spottedWolfVariant = new CompoundTag();
+        spottedWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_spotted");
+        spottedWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_spotted_angry");
+        spottedWolfVariant.putString("biomes", "#minecraft:is_savanna");
+        spottedWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_spotted_tame");
+        final CompoundTag stripedWolfVariant = new CompoundTag();
+        stripedWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_striped");
+        stripedWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_striped_angry");
+        stripedWolfVariant.putString("biomes", "#minecraft:is_badlands");
+        stripedWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_striped_tame");
+        final CompoundTag woodsWolfVariant = new CompoundTag();
+        woodsWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_woods");
+        woodsWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_woods_angry");
+        woodsWolfVariant.putString("biomes", "minecraft:forest");
+        woodsWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_woods_tame");
+        return new RegistryEntry[]{
+            new RegistryEntry("minecraft:ashen", ashenWolfVariant),
+            new RegistryEntry("minecraft:black", blackWolfVariant),
+            new RegistryEntry("minecraft:chestnut", chestnutWolfVariant),
+            new RegistryEntry("minecraft:pale", paleWolfVariant),
+            new RegistryEntry("minecraft:rusty", rustyWolfVariant),
+            new RegistryEntry("minecraft:snowy", snowyWolfVariant),
+            new RegistryEntry("minecraft:spotted", spottedWolfVariant),
+            new RegistryEntry("minecraft:striped", stripedWolfVariant),
+            new RegistryEntry("minecraft:woods", woodsWolfVariant),
+        };
+    }
+
+    private static String[] getValidWolfVariantRegistryEntryKeys() {
+        return new String[]{
+            "minecraft:ashen",
+            "minecraft:black",
+            "minecraft:chestnut",
+            "minecraft:pale",
+            "minecraft:rusty",
+            "minecraft:snowy",
+            "minecraft:spotted",
+            "minecraft:striped",
+            "minecraft:woods"
+        };
     }
 
     private void storePosition(final PacketWrapper wrapper) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
@@ -39,8 +39,10 @@ import com.viaversion.viaversion.protocols.v1_20_5to1_21.storage.EfficiencyAttri
 import com.viaversion.viaversion.protocols.v1_20_5to1_21.storage.PlayerPositionStorage;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.rewriter.RegistryDataRewriter;
+import java.util.ArrayList;
 
 public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPacket1_20_5, Protocol1_20_5To1_21> {
+    public boolean receivedValidWolfArmorRegistryData = false;
 
     public EntityPacketRewriter1_21(final Protocol1_20_5To1_21 protocol) {
         super(protocol);
@@ -58,6 +60,15 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
         campfireDamageType.putString("message_id", "inFire");
         campfireDamageType.putFloat("exhaustion", 0.1F);
         registryDataRewriter.addEntries("damage_type", new RegistryEntry("minecraft:campfire", campfireDamageType));
+        registryDataRewriter.addHandler(
+            "wolf_variant", (key, value) -> {
+                if (getValidWolfArmorRegistryEntryKeys().contains(key)) {
+                    receivedValidWolfArmorRegistryData = (value.contains("wild_texture") && value.contains("angry_texture") && value.contains("biomes") && value.contains("tame_texture"));
+                } else {
+                    receivedValidWolfArmorRegistryData = false;
+                }
+            }
+        );
         protocol.registerClientbound(ClientboundConfigurationPackets1_20_5.REGISTRY_DATA, registryDataRewriter::handle);
 
         protocol.registerFinishConfiguration(ClientboundConfigurationPackets1_20_5.FINISH_CONFIGURATION, wrapper -> {
@@ -91,6 +102,74 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
             jukeboxSongsPacket.write(Types.STRING, "minecraft:jukebox_song");
             jukeboxSongsPacket.write(Types.REGISTRY_ENTRY_ARRAY, protocol.getMappingData().jukeboxSongs());
             jukeboxSongsPacket.send(Protocol1_20_5To1_21.class);
+
+            if (!receivedValidWolfArmorRegistryData) {
+                final PacketWrapper wolfVariantPacket = wrapper.create(ClientboundConfigurationPackets1_20_5.REGISTRY_DATA);
+                // Add wolf_variant registries
+                final CompoundTag ashenWolfVariant = new CompoundTag();
+                ashenWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_ashen");
+                ashenWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_ashen_angry");
+                ashenWolfVariant.putString("biomes", "minecraft:snowy_taiga");
+                ashenWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_ashen_tame");
+                final CompoundTag blackWolfVariant = new CompoundTag();
+                blackWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_black");
+                blackWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_black_angry");
+                blackWolfVariant.putString("biomes", "minecraft:old_growth_pine_taiga");
+                blackWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_black_tame");
+                final CompoundTag chestnutWolfVariant = new CompoundTag();
+                chestnutWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_chestnut");
+                chestnutWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_chestnut_angry");
+                chestnutWolfVariant.putString("biomes", "minecraft:old_growth_spruce_taiga");
+                chestnutWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_chestnut_tame");
+                final CompoundTag paleWolfVariant = new CompoundTag();
+                paleWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf");
+                paleWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_angry");
+                paleWolfVariant.putString("biomes", "minecraft:taiga");
+                paleWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_tame");
+                final CompoundTag rustyWolfVariant = new CompoundTag();
+                rustyWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_rusty");
+                rustyWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_rusty_angry");
+                rustyWolfVariant.putString("biomes", "#minecraft:is_jungle");
+                rustyWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_rusty_tame");
+                final CompoundTag snowyWolfVariant = new CompoundTag();
+                snowyWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_snowy");
+                snowyWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_snowy_angry");
+                snowyWolfVariant.putString("biomes", "minecraft:grove");
+                snowyWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_snowy_tame");
+                final CompoundTag spottedWolfVariant = new CompoundTag();
+                spottedWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_spotted");
+                spottedWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_spotted_angry");
+                spottedWolfVariant.putString("biomes", "#minecraft:is_savanna");
+                spottedWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_spotted_tame");
+                final CompoundTag stripedWolfVariant = new CompoundTag();
+                stripedWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_striped");
+                stripedWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_striped_angry");
+                stripedWolfVariant.putString("biomes", "#minecraft:is_badlands");
+                stripedWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_striped_tame");
+                final CompoundTag woodsWolfVariant = new CompoundTag();
+                woodsWolfVariant.putString("wild_texture", "minecraft:entity/wolf/wolf_woods");
+                woodsWolfVariant.putString("angry_texture", "minecraft:entity/wolf/wolf_woods_angry");
+                woodsWolfVariant.putString("biomes", "minecraft:forest");
+                woodsWolfVariant.putString("tame_texture", "minecraft:entity/wolf/wolf_woods_tame");
+
+                final RegistryEntry[] wolfVariantRegistryEntryArray = new RegistryEntry[9];
+                wolfVariantRegistryEntryArray[0] = new RegistryEntry("minecraft:ashen", ashenWolfVariant);
+                wolfVariantRegistryEntryArray[1] = new RegistryEntry("minecraft:black", blackWolfVariant);
+                wolfVariantRegistryEntryArray[2] = new RegistryEntry("minecraft:chestnut", chestnutWolfVariant);
+                wolfVariantRegistryEntryArray[3] = new RegistryEntry("minecraft:pale", paleWolfVariant);
+                wolfVariantRegistryEntryArray[4] = new RegistryEntry("minecraft:rusty", rustyWolfVariant);
+                wolfVariantRegistryEntryArray[5] = new RegistryEntry("minecraft:snowy", snowyWolfVariant);
+                wolfVariantRegistryEntryArray[6] = new RegistryEntry("minecraft:spotted", spottedWolfVariant);
+                wolfVariantRegistryEntryArray[7] = new RegistryEntry("minecraft:striped", stripedWolfVariant);
+                wolfVariantRegistryEntryArray[8] = new RegistryEntry("minecraft:woods", woodsWolfVariant);
+
+                wolfVariantPacket.write(Types.STRING, "minecraft:wolf_variant");
+                wolfVariantPacket.write(
+                    Types.REGISTRY_ENTRY_ARRAY,
+                    wolfVariantRegistryEntryArray
+                );
+                wolfVariantPacket.send(Protocol1_20_5To1_21.class);
+            }
         });
 
         registerLogin1_20_5(ClientboundPackets1_20_5.LOGIN);
@@ -136,6 +215,20 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
                 storeOnGround(wrapper);
             }
         });
+    }
+
+    private static ArrayList<String> getValidWolfArmorRegistryEntryKeys() {
+        final ArrayList<String> validWolfArmorKeys = new ArrayList<>();
+        validWolfArmorKeys.add("minecraft:ashen");
+        validWolfArmorKeys.add("minecraft:black");
+        validWolfArmorKeys.add("minecraft:chestnut");
+        validWolfArmorKeys.add("minecraft:pale");
+        validWolfArmorKeys.add("minecraft:rusty");
+        validWolfArmorKeys.add("minecraft:snowy");
+        validWolfArmorKeys.add("minecraft:spotted");
+        validWolfArmorKeys.add("minecraft:striped");
+        validWolfArmorKeys.add("minecraft:woods");
+        return validWolfArmorKeys;
     }
 
     private void storePosition(final PacketWrapper wrapper) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
@@ -39,12 +39,10 @@ import com.viaversion.viaversion.protocols.v1_20_5to1_21.storage.EfficiencyAttri
 import com.viaversion.viaversion.protocols.v1_20_5to1_21.storage.PlayerPositionStorage;
 import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.rewriter.RegistryDataRewriter;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPacket1_20_5, Protocol1_20_5To1_21> {
-    public boolean receivedValidWolfVariantRegistryData = false;
+    public static boolean receivedValidWolfVariantRegistryData = false;
 
     public EntityPacketRewriter1_21(final Protocol1_20_5To1_21 protocol) {
         super(protocol);
@@ -65,7 +63,7 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
         registryDataRewriter.addHandler(
             "wolf_variant", (key, value) -> {
                 if (Arrays.asList(getValidWolfVariantRegistryEntryKeys()).contains(key)) {
-                    receivedValidWolfVariantRegistryData = (value.contains("wild_texture") && value.contains("angry_texture") && value.contains("biomes") && value.contains("tame_texture"));
+                    receivedValidWolfVariantRegistryData |= (value.contains("wild_texture") && value.contains("angry_texture") && value.contains("biomes") && value.contains("tame_texture"));
                 } else {
                     receivedValidWolfVariantRegistryData = false;
                 }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java
@@ -43,6 +43,17 @@ import java.util.Arrays;
 
 public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPacket1_20_5, Protocol1_20_5To1_21> {
     public static boolean receivedValidWolfVariantRegistryData = false;
+    public final String[] validWolfVariantRegistryEntryKeys = new String[]{
+        "minecraft:ashen",
+        "minecraft:black",
+        "minecraft:chestnut",
+        "minecraft:pale",
+        "minecraft:rusty",
+        "minecraft:snowy",
+        "minecraft:spotted",
+        "minecraft:striped",
+        "minecraft:woods"
+    };
 
     public EntityPacketRewriter1_21(final Protocol1_20_5To1_21 protocol) {
         super(protocol);
@@ -62,7 +73,7 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
         registryDataRewriter.addEntries("damage_type", new RegistryEntry("minecraft:campfire", campfireDamageType));
         registryDataRewriter.addHandler(
             "wolf_variant", (key, value) -> {
-                if (Arrays.asList(getValidWolfVariantRegistryEntryKeys()).contains(key)) {
+                if (Arrays.asList(validWolfVariantRegistryEntryKeys).contains(key)) {
                     receivedValidWolfVariantRegistryData |= (value.contains("wild_texture") && value.contains("angry_texture") && value.contains("biomes") && value.contains("tame_texture"));
                 } else {
                     receivedValidWolfVariantRegistryData = false;
@@ -216,20 +227,6 @@ public final class EntityPacketRewriter1_21 extends EntityRewriter<ClientboundPa
             new RegistryEntry("minecraft:spotted", spottedWolfVariant),
             new RegistryEntry("minecraft:striped", stripedWolfVariant),
             new RegistryEntry("minecraft:woods", woodsWolfVariant),
-        };
-    }
-
-    private static String[] getValidWolfVariantRegistryEntryKeys() {
-        return new String[]{
-            "minecraft:ashen",
-            "minecraft:black",
-            "minecraft:chestnut",
-            "minecraft:pale",
-            "minecraft:rusty",
-            "minecraft:snowy",
-            "minecraft:spotted",
-            "minecraft:striped",
-            "minecraft:woods"
         };
     }
 


### PR DESCRIPTION
Fixes the following network protocol error in ViaFabric:

```
Description: Registry Loading

-- Head --
Thread: Render thread
Stacktrace:
	at knot//net.minecraft.registry.RegistryLoader.createLoadingException(RegistryLoader.java:280)
	at knot//net.minecraft.registry.RegistryLoader.writeAndCreateLoadingException(RegistryLoader.java:261)
	at knot//net.minecraft.registry.RegistryLoader.load(RegistryLoader.java:228)

-- Loading info --
Details:
	Errors: 
		minecraft:root/minecraft:wolf_variant: Registry must be non-empty: minecraft:wolf_variant
Stacktrace:
	at knot//net.minecraft.registry.RegistryLoader.createLoadingException(RegistryLoader.java:280)
	at knot//net.minecraft.registry.RegistryLoader.writeAndCreateLoadingException(RegistryLoader.java:261)
	at knot//net.minecraft.registry.RegistryLoader.load(RegistryLoader.java:228)
	at knot//net.minecraft.registry.RegistryLoader.loadFromNetwork(RegistryLoader.java:203)
	at knot//net.minecraft.client.network.ClientRegistries.createRegistryManager(ClientRegistries.java:95)
	at knot//net.minecraft.client.network.ClientRegistries.createRegistryManager(ClientRegistries.java:146)
	at knot//net.minecraft.client.network.ClientConfigurationNetworkHandler.method_57043(ClientConfigurationNetworkHandler.java:127)
	at knot//net.minecraft.client.network.ClientConfigurationNetworkHandler.openClientDataPack(ClientConfigurationNetworkHandler.java:115)
	at knot//net.minecraft.client.network.ClientConfigurationNetworkHandler.onReady(ClientConfigurationNetworkHandler.java:127)
	at knot//net.minecraft.network.packet.s2c.config.ReadyS2CPacket.apply(ReadyS2CPacket.java:22)
	at knot//net.minecraft.network.packet.s2c.config.ReadyS2CPacket.apply(ReadyS2CPacket.java:8)
	at knot//net.minecraft.network.NetworkThreadUtils.method_11072(NetworkThreadUtils.java:27)
	at knot//net.minecraft.util.thread.ThreadExecutor.executeTask(ThreadExecutor.java:164)
	at knot//net.minecraft.util.thread.ReentrantThreadExecutor.executeTask(ReentrantThreadExecutor.java:23)
	at knot//net.minecraft.util.thread.ThreadExecutor.runTask(ThreadExecutor.java:138)
	at knot//net.minecraft.util.thread.ThreadExecutor.runTasks(ThreadExecutor.java:123)
	at knot//net.minecraft.client.MinecraftClient.render(MinecraftClient.java:1318)
	at knot//net.minecraft.client.MinecraftClient.run(MinecraftClient.java:947)
	at knot//net.minecraft.client.main.Main.main(Main.java:265)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:506)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:102)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
```
The network protocol error is present in versions 1.21 and newer.

The problem accrues when the server sends an invalid wolf_variant registry data packet that contains entries with invalid tags, the vanilla client for 1.20.6 simply uses default values for those tags, but this behavior changed in 1.21, where instead the client ignores entries with invalid tags, and crashes if there's no entry with valid tags in them, creating a bug which can be exploited to allow vanilla 1.20.6 clients to join a server while not allowing newer clients using ViaProxy/ViaFabric/ViaFabricPlus/ViaForge to join.

To fix this, if the received registry data packet doesn't contain any valid entry, we construct and send a default registry data packet for wolf_variant registries, containing default values extracted from the notchain server, however if the received registry data packet contains at least one valid entry this patch does nothing.