### PR TITLE
Add missing game test payload sanitize in 1.20->1.20.2

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/Protocol1_20To1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/Protocol1_20To1_20_2.java
@@ -239,6 +239,14 @@ public final class Protocol1_20To1_20_2 extends AbstractProtocol<ClientboundPack
         if (channel.equals("minecraft:brand")) {
             wrapper.passthrough(Types.STRING);
             wrapper.clearInputBuffer();
+        } else if (channel.equals("minecraft:debug/game_test_add_marker")) {
+            wrapper.passthrough(Types.BLOCK_POSITION1_14);
+            wrapper.passthrough(Types.INT);
+            wrapper.passthrough(Types.STRING);
+            wrapper.passthrough(Types.INT);
+            wrapper.clearInputBuffer();
+        } else if (channel.equals("minecraft:debug/game_test_clear")) {
+            wrapper.clearInputBuffer();
         }
     }
 


### PR DESCRIPTION
VFP is going to handle them in 1.21.8->1.21.9 since the notchain servers uses them. This PR moves the "validation" part of my previous clientside changes into VV. This is missing the cancellation of the other debug packets in 1.13->1.14 (see https://github.com/ViaVersion/ViaFabricPlus/blob/main/src/main/java/com/viaversion/viafabricplus/protocoltranslator/protocol/ViaFabricPlusProtocol.java) so it's mainly for cleaning up the VFP code structure, but shouldn't hurt to be moved to VV.