### PR TITLE
Fix "Filter Invalid Teams Packet" fix storing teams of players which the client does not store

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/storage/ScoreboardTeamStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/storage/ScoreboardTeamStorage.java
@@ -41,6 +41,12 @@ public final class ScoreboardTeamStorage implements StorableObject {
     }
 
     public void addPlayerToTeam(final String team, final String[] player) {
+        for (final Set<String> players : this.teams.values()) {
+            for (final String toRemove : player) {
+                players.remove(toRemove);
+            }
+        }
+
         final Set<String> players = this.teams.computeIfAbsent(team, k -> new HashSet<>());
         Collections.addAll(players, player);
     }


### PR DESCRIPTION
In the vanilla client, if it receives a "Add Player to Team" packet, it will automatically remove the player from any other team the client thinks the player is on

However, the fix from PR #4643 does not do this, and is storing the team of the player when the player is possibly not on that team by the clients knowledge

So I figured I would make a PR to address this minor thing