### PR TITLE
Handle early connection closure for bot attacks

### DIFF
--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/handlers/VelocityChannelInitializer.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/handlers/VelocityChannelInitializer.java
@@ -57,7 +57,7 @@ public class VelocityChannelInitializer extends ChannelInitializer<Channel> {
         // When forks like VeloFlame close connection early
         // and prevent injection of Minecraft decoders on bot connections,
         // ViaVersion has to skip these conditions as these are bot attacks.
-        if (!channel.isActive) {
+        if (!channel.isActive()) {
             return;
         }
         INIT_CHANNEL.invoke(original, channel);


### PR DESCRIPTION
Add handling for early connection closure in bot attacks.

This is key and essential to support [VeloFlame](https://builtbybit.com/resources/veloflame-secure-minecraft-proxy.80990/), it will block the bot early and not inject it, meaning, packet decoders will not be available for ViaVersion, and throw an exception. This patch is key because it prevents viaversion from triggering on velocity bot attacks, when VeloFlame is installed it makes sure memory is lean and not inject useless handlers when already closed.
