### PR TITLE
When original initializer closes the connection, immediately stop

### DIFF
--- a/velocity/src/main/java/com/viaversion/viaversion/velocity/handlers/VelocityChannelInitializer.java
+++ b/velocity/src/main/java/com/viaversion/viaversion/velocity/handlers/VelocityChannelInitializer.java
@@ -54,13 +54,13 @@ public class VelocityChannelInitializer extends ChannelInitializer<Channel> {
 
     @Override
     protected void initChannel(Channel channel) throws Exception {
+        INIT_CHANNEL.invoke(original, channel);
         // When forks like VeloFlame close connection early
         // and prevent injection of Minecraft decoders on bot connections,
         // ViaVersion has to skip these conditions as these are bot attacks.
         if (!channel.isActive()) {
             return;
         }
-        INIT_CHANNEL.invoke(original, channel);
 
         UserConnection user = new UserConnectionImpl(channel, clientSide);
         new ProtocolPipelineImpl(user);


### PR DESCRIPTION
This correctly adddresses the issue of the original initializer closing the connection, it will now immediately stop properly unlike my other faulty PR. Thank you for pointing out!