### PR TITLE
Restore 1.8 hitbox margin for 1.21.11+ clients

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -505,4 +505,12 @@ public interface ViaVersionConfig extends Config {
      * @return the max length of error messages
      */
     int maxErrorLength();
+
+    /**
+     * If enabled, 1.21.11+ clients on 1.8 (or older) servers will get wider entity hitboxes,
+     * but only when attacking with an item.
+     *
+     * @return true if enabled
+     */
+    boolean use1_8HitboxMargin();
 }

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -98,6 +98,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     private boolean fix1_21PlacementRotation;
     private boolean cancelSwingInInventory;
     private int maxErrorLength;
+    private boolean use1_8HitboxMargin;
 
     protected AbstractViaConfig(final File configFile, final Logger logger) {
         super(configFile, logger);
@@ -164,6 +165,7 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
         hideScoreboardNumbers = getBoolean("hide-scoreboard-numbers", false);
         fix1_21PlacementRotation = getBoolean("fix-1_21-placement-rotation", true);
         cancelSwingInInventory = getBoolean("cancel-swing-in-inventory", true);
+        use1_8HitboxMargin = getBoolean("use-1_8-hitbox-margin", true);
         packetTrackerConfig = loadRateLimitConfig(getSection("packet-limiter"), "%pps", 1);
         packetSizeTrackerConfig = loadRateLimitConfig(getSection("packet-size-limiter"), "%bps", 1024);
         maxErrorLength = getInt("max-error-length", 1500);
@@ -612,5 +614,10 @@ public abstract class AbstractViaConfig extends Config implements ViaVersionConf
     @Override
     public int maxErrorLength() {
         return maxErrorLength;
+    }
+
+    @Override
+    public boolean use1_8HitboxMargin() {
+        return use1_8HitboxMargin;
     }
 }

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -230,3 +230,5 @@ chunk-border-fix: false
 left-handed-handling: true
 # Tries to cancel block break/place sounds sent by 1.8 servers to 1.9+ clients to prevent them from playing twice
 cancel-block-sounds: true
+# If enabled, 1.21.11+ clients on 1.8 servers will get wider entity hitboxes when attacking with items
+use-1_8-hitbox-margin: true


### PR DESCRIPTION
This uses the new 1.21.11 `attack_range` item component to restore the 0.1 hitbox margin on entities from 1.8 combat.

Unfortunately, this is only an item component so it only works when attacking with items. I hope that in the future this becomes an entity attribute, so that we can also restore old hitbox sizes for e.g. creepers.