### PR TITLE
Fix default dripstone particle in 1.21.9->1.21.11

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/Protocol1_21_9To1_21_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/Protocol1_21_9To1_21_11.java
@@ -137,6 +137,11 @@ public final class Protocol1_21_9To1_21_11 extends AbstractProtocol<ClientboundP
             if (!tag.getBoolean("natural")) {
                 attributes.putFloat("visual/sky_light_factor", 0F);
             }
+            if (tag.getBoolean("ultrawarm")) {
+                final CompoundTag defaultDripstoneParticle = new CompoundTag();
+                defaultDripstoneParticle.putString("type", "dripping_dripstone_lava");
+                attributes.put("visual/default_dripstone_particle", defaultDripstoneParticle);
+            }
 
             moveAttribute(tag, attributes, "cloud_height", "visual/cloud_height", cloudHeight -> {
                 if (cloudHeight instanceof NumberTag numberTag) {


### PR DESCRIPTION
<details>
<summary>Before this commit</summary>
<img width="2560" height="1440" alt="2025-12-06_19 09 58" src="https://github.com/user-attachments/assets/3415f551-2616-4a1e-b015-6c41ca20028e" />
</details>
<details>
<summary>After this commit</summary>
<img width="2560" height="1440" alt="2025-12-06_19 12 09" src="https://github.com/user-attachments/assets/10b03759-d132-494b-bbd8-5693c4acd594" />
</details>