### PR TITLE
[ci skip] Include the newest ViaProxy version from 3.0.0 to 4.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ checkerQual = "3.51.0"
 paper = "1.20.4-R0.1-SNAPSHOT"
 legacyBukkit = "1.8.8-R0.1-SNAPSHOT"
 velocity = "3.1.1"
-viaProxy = "3.4.7-SNAPSHOT"
+viaProxy = "[3.0.0,4.0.0)"
 
 [libraries]
 


### PR DESCRIPTION
We always have to update it anyway so this is easier than constantly forgetting about changing the version & having weird issues in testing afterward.