### PR TITLE
Implement some fixes with the new 1.20.5 attributes

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
@@ -35,6 +35,7 @@ import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.minecraft.item.StructuredItem;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.version.Types1_20_3;
 import com.viaversion.viaversion.api.type.types.version.VersionedTypes;
@@ -408,9 +409,18 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
     private void sendRangeAttributes(final UserConnection connection, final boolean creativeMode) {
         final PacketWrapper wrapper = PacketWrapper.create(ClientboundPackets1_20_5.UPDATE_ATTRIBUTES, connection);
         wrapper.write(Types.VAR_INT, tracker(connection).clientEntityId());
-        wrapper.write(Types.VAR_INT, 2); // Number of attributes
-        writeAttribute(wrapper, "player.block_interaction_range", 4.5, creativeMode ? CREATIVE_BLOCK_INTERACTION_RANGE : null, 0.5);
-        writeAttribute(wrapper, "player.entity_interaction_range", 3.0, creativeMode ? CREATIVE_ENTITY_INTERACTION_RANGE : null, 2.0);
+        if (connection.getProtocolInfo().serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_7_6)) {
+            wrapper.write(Types.VAR_INT, 3); // Number of attributes
+            this.writeAttribute(wrapper, "generic.step_height", 0.5D, null, 0D);
+        } else {
+            wrapper.write(Types.VAR_INT, 2); // Number of attributes
+        }
+        this.writeAttribute(wrapper, "player.block_interaction_range", 4.5D, creativeMode ? CREATIVE_BLOCK_INTERACTION_RANGE : null, 0.5D);
+        if (connection.getProtocolInfo().serverProtocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_13_2)) {
+            this.writeAttribute(wrapper, "player.entity_interaction_range", 3D, creativeMode ? CREATIVE_ENTITY_INTERACTION_RANGE : null, 1D);
+        } else {
+            this.writeAttribute(wrapper, "player.entity_interaction_range", 3D, creativeMode ? CREATIVE_ENTITY_INTERACTION_RANGE : null, 2D);
+        }
         wrapper.scheduleSend(Protocol1_20_3To1_20_5.class);
     }
 


### PR DESCRIPTION
Fixes the attack range on 1.8 servers for 1.20.5+ clients. Also fixes step height on 1.7 servers for 1.20.5+ clients. Both fixes use attributes introduced in 1.20.5 and have previously been tested in ViaProxy and ViaFabricPlus (https://github.com/ViaVersion/ViaProxy/blob/8564f5e46bef54b40d3d11a52e19e7eca5944288/src/main/java/net/raphimc/viaproxy/injection/mixins/MixinEntityPacketRewriter1_20_5.java)