### PR TITLE
Always send extra attributes in 1.20.5

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/EntityPacketRewriter1_20_5.java
@@ -279,11 +279,8 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
 
                     storage.clear();
 
-                    // Handle creative interaction range
                     final byte gamemode = wrapper.get(Types.BYTE, 0);
-                    if (gamemode == GameMode.CREATIVE.id()) {
-                        sendRangeAttributes(wrapper.user(), true);
-                    }
+                    sendRangeAttributes(wrapper.user(), gamemode == GameMode.CREATIVE.id());
                 });
             }
         });


### PR DESCRIPTION
Always send the extra attributes in 1.20.5, now that there is more than just creative range fixes in ViaVersion (Also needed for ViaProxy and ViaFabricPlus, which need to modify the base attribute in survival for <=1.6.4)