### PR TITLE
Error on absent artifacts, Set CI timeout to 30 mins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     # Only run on PRs if the source branch is on a different repo. We do not need to run everything twice.
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
     - name: Checkout Repository
       uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
@@ -30,3 +31,4 @@ jobs:
       with:
         name: Artifacts
         path: build/libs/
+        if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
   publish:
     if: github.repository_owner == 'ViaVersion'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0


### PR DESCRIPTION
Title says it all - But to explain:

1. Adds the `timeout-minutes` to the job(s) section so that the CI doesn't take 6 hours straight to get aborted in case something is causing the CI to suddenly stall or become unresponsive, *(this can be adjusted if 30 mins is too short or too long)*
2. Sets the `if-no-files-found` to error by default in case artifacts are absent.