### PR TITLE
fix world border lerp size set in ticks instead of millis (#4755)

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/rewriter/BlockItemPacketRewriter1_21_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/rewriter/BlockItemPacketRewriter1_21_11.java
@@ -80,9 +80,6 @@ public final class BlockItemPacketRewriter1_21_11 extends StructuredItemRewriter
             wrapper.passthrough(Types.DOUBLE); // oldSize
             wrapper.passthrough(Types.DOUBLE); // newSize
             wrapper.write(Types.VAR_LONG, wrapper.read(Types.VAR_LONG) / 50); // lerpTime
-            wrapper.passthrough(Types.VAR_INT); // newAbsoluteMaxSize
-            wrapper.passthrough(Types.VAR_INT); // warningBlocks
-            wrapper.passthrough(Types.VAR_INT); // warningTime
         });
         protocol.registerClientbound(ClientboundPackets1_21_9.SET_TIME, wrapper -> {
             final long gameTime = wrapper.passthrough(Types.LONG);


### PR DESCRIPTION
This PR intends to fix #4755 by converting the world border lerp size from ms to ticks for 1.21.11.
This may not be enough for ViaBackwards as the lerp size is tick dependent with 1.21.11, but should be good enough for ViaVersion. I can do the same in reverse for ViaBackwards, but it may get out of sync for laggy servers (or maybe servers with non-default tick rates), but still it would be an improvement imo.