### PR TITLE
Make UserConnectionViaVersionPlatform a proxy platform by default

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/platform/UserConnectionViaVersionPlatform.java
+++ b/common/src/main/java/com/viaversion/viaversion/platform/UserConnectionViaVersionPlatform.java
@@ -50,6 +50,11 @@ public abstract class UserConnectionViaVersionPlatform implements ViaPlatform<Us
     public abstract Logger createLogger(String name);
 
     @Override
+    public boolean isProxy() {
+        return true;
+    }
+
+    @Override
     public Logger getLogger() {
         return logger;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project properties - we put these here so they can be modified without causing a recompile of the build scripts
-projectVersion=5.7.1
+projectVersion=5.7.2-SNAPSHOT
 
 # Smile emoji (note that modrinth may not have added the version on release yet)
 mcVersions=1.21.11, 1.21.10, 1.21.9, 1.21.8, 1.21.7, 1.21.6, 1.21.5, 1.21.4, 1.21.3, 1.21.2, 1.21.1, 1.21, 1.20.6, 1.20.5, 1.20.4, 1.20.3, 1.20.2, 1.20.1, 1.20, 1.19.4, 1.19.3, 1.19.2, 1.19.1, 1.19, 1.18.2, 1.18.1, 1.18, 1.17.1, 1.17, 1.16.5, 1.16.4, 1.16.3, 1.16.2, 1.16.1, 1.16, 1.15.2, 1.15.1, 1.15, 1.14.4, 1.14.3, 1.14.2, 1.14.1, 1.14, 1.13.2, 1.13.1, 1.13, 1.12.2, 1.12.1, 1.12, 1.11.2, 1.11.1, 1.11, 1.10.2, 1.10.1, 1.10, 1.9.4, 1.9.3, 1.9.2, 1.9.1, 1.9, 1.8.9


### PR DESCRIPTION
Server platforms should directly use ViaPlatform with their player object as described in the documentation