### PR TITLE
Handle single item component -> multi item component empty translation

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredDataContainer.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/data/StructuredDataContainer.java
@@ -177,11 +177,10 @@ public final class StructuredDataContainer implements Copyable {
                 set(toKey, replacement);
             }
         } else {
+            // Also replace the key for empty data
+            setEmpty(toKey);
             if (emptyValueHandler != null) {
                 emptyValueHandler.run();
-            } else {
-                // Also replace the key for empty data
-                setEmpty(toKey);
             }
         }
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -568,7 +568,6 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
             }
             return new FoodProperties1_21_2(food.nutrition(), food.saturationModifier(), food.canAlwaysEat());
         }, () -> {
-            dataContainer.setEmpty(StructuredDataKey.FOOD1_21_2);
             dataContainer.setEmpty(StructuredDataKey.CONSUMABLE1_21_2);
             dataContainer.setEmpty(StructuredDataKey.V1_21_2.useRemainder);
         });


### PR DESCRIPTION
The 1.21 food component got replaced by 3 components. This PR adds handling for when the food component was empty and sets the other 3 also to empty