### PR TITLE
Fix possible NPE in `ItemPacketRewriter1_9$8`

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/ItemPacketRewriter1_9.java
@@ -61,7 +61,7 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
                     final short property = wrapper.get(Types.SHORT, 0);
                     short value = wrapper.get(Types.SHORT, 1);
                     InventoryTracker inventoryTracker = wrapper.user().get(InventoryTracker.class);
-                    if (inventoryTracker.getInventory() != null && inventoryTracker.getInventory().equalsIgnoreCase("minecraft:enchanting_table")) {
+                    if (inventoryTracker != null && inventoryTracker.getInventory() != null && inventoryTracker.getInventory().equalsIgnoreCase("minecraft:enchanting_table")) {
                         if (property > 3 && property < 7) {
                             // Send 2 properties, splitting it into enchantID & level
                             final short level = (short) (value >> 8);
@@ -92,7 +92,9 @@ public class ItemPacketRewriter1_9 extends ItemRewriter<ClientboundPackets1_8, S
                 handler(wrapper -> {
                     String inventory = wrapper.get(Types.STRING, 0);
                     InventoryTracker inventoryTracker = wrapper.user().get(InventoryTracker.class);
-                    inventoryTracker.setInventory(inventory);
+                    if (inventoryTracker != null) {
+                        inventoryTracker.setInventory(inventory);
+                    }
                 });
                 // Brewing patch
                 handler(wrapper -> {


### PR DESCRIPTION
```
[22:45:44] [Netty NIO IO #2/WARN] (ViaVersion) ERROR IN Protocol1_8To1_9 IN REMAP OF CONTAINER_CLICK (0x07)
[22:45:44] [Netty NIO IO #2/WARN] (AbstractEventExecutor) A task raised an exception. Task: com.viaversion.viaversion.protocol.packet.PacketWrapperImpl$$Lambda/0x000001aa9a261c68@6c5b8d27

com.viaversion.viaversion.exception.InformativeException: Please report this on the Via support Discord or open an issue on the relevant GitHub repository
Source 0: com.viaversion.viaversion.protocols.v1_8to1_9.rewriter.ItemPacketRewriter1_9$8 (Anonymous)
Caused by: java.lang.NullPointerException
```
This made my client freeze (VFP 4.4.4/1.21.11->1.8.x)