### PR TITLE
Use BlockRewriter1_21_5 in 1.21.7->1.21.9 & 1.21.9->1.21.11

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_7to1_21_9/rewriter/BlockItemPacketRewriter1_21_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_7to1_21_9/rewriter/BlockItemPacketRewriter1_21_9.java
@@ -40,6 +40,7 @@ import com.viaversion.viaversion.protocols.v1_21_7to1_21_9.storage.DimensionScal
 import com.viaversion.viaversion.rewriter.BlockRewriter;
 import com.viaversion.viaversion.rewriter.RecipeDisplayRewriter;
 import com.viaversion.viaversion.rewriter.StructuredItemRewriter;
+import com.viaversion.viaversion.rewriter.block.BlockRewriter1_21_5;
 
 public final class BlockItemPacketRewriter1_21_9 extends StructuredItemRewriter<ClientboundPacket1_21_6, ServerboundPacket1_21_9, Protocol1_21_7To1_21_9> {
 
@@ -49,7 +50,7 @@ public final class BlockItemPacketRewriter1_21_9 extends StructuredItemRewriter<
 
     @Override
     public void registerPackets() {
-        final BlockRewriter<ClientboundPacket1_21_6> blockRewriter = BlockRewriter.for1_20_2(protocol);
+        final BlockRewriter<ClientboundPacket1_21_6> blockRewriter = new BlockRewriter1_21_5<>(protocol);
         blockRewriter.registerBlockEvent(ClientboundPackets1_21_6.BLOCK_EVENT);
         blockRewriter.registerBlockUpdate(ClientboundPackets1_21_6.BLOCK_UPDATE);
         blockRewriter.registerSectionBlocksUpdate1_20(ClientboundPackets1_21_6.SECTION_BLOCKS_UPDATE);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/rewriter/BlockItemPacketRewriter1_21_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/rewriter/BlockItemPacketRewriter1_21_11.java
@@ -36,6 +36,7 @@ import com.viaversion.viaversion.protocols.v1_21_9to1_21_11.storage.GameTimeStor
 import com.viaversion.viaversion.rewriter.BlockRewriter;
 import com.viaversion.viaversion.rewriter.RecipeDisplayRewriter;
 import com.viaversion.viaversion.rewriter.StructuredItemRewriter;
+import com.viaversion.viaversion.rewriter.block.BlockRewriter1_21_5;
 
 public final class BlockItemPacketRewriter1_21_11 extends StructuredItemRewriter<ClientboundPacket1_21_9, ServerboundPacket1_21_9, Protocol1_21_9To1_21_11> {
 
@@ -45,7 +46,7 @@ public final class BlockItemPacketRewriter1_21_11 extends StructuredItemRewriter
 
     @Override
     public void registerPackets() {
-        final BlockRewriter<ClientboundPacket1_21_9> blockRewriter = BlockRewriter.for1_20_2(protocol);
+        final BlockRewriter<ClientboundPacket1_21_9> blockRewriter = new BlockRewriter1_21_5<>(protocol);
         blockRewriter.registerBlockEvent(ClientboundPackets1_21_9.BLOCK_EVENT);
         blockRewriter.registerBlockUpdate(ClientboundPackets1_21_9.BLOCK_UPDATE);
         blockRewriter.registerSectionBlocksUpdate1_20(ClientboundPackets1_21_9.SECTION_BLOCKS_UPDATE);


### PR DESCRIPTION
Required since they override component rewriters and have changes in component structures.