### PR TITLE
Don't register a cooldown rewriter in 1.17->1.17.1

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_17to1_17_1/rewriter/ItemPacketRewriter1_17_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_17to1_17_1/rewriter/ItemPacketRewriter1_17_1.java
@@ -42,7 +42,6 @@ public final class ItemPacketRewriter1_17_1 extends ItemRewriter<ClientboundPack
 
     @Override
     public void registerPackets() {
-        registerCooldown(ClientboundPackets1_17.COOLDOWN);
         registerMerchantOffers(ClientboundPackets1_17.MERCHANT_OFFERS);
         registerSetEquipment(ClientboundPackets1_17.SET_EQUIPMENT);
         registerAdvancements(ClientboundPackets1_17.UPDATE_ADVANCEMENTS);


### PR DESCRIPTION
Fixes an NPE caused by it because this protocol doesn't have any mapping data.