### PR TITLE
Produce inlined string in 1.8->1.9 sign update

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/WorldPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/WorldPacketRewriter1_9.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.v1_8to1_9.rewriter;
 
+import com.google.gson.JsonPrimitive;
 import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.nbt.tag.StringTag;
 import com.viaversion.viaversion.api.Via;
@@ -279,7 +280,7 @@ public class WorldPacketRewriter1_9 {
                 handler(wrapper -> {
                     for (int i = 0; i < 4; i++) {
                         final String line = wrapper.read(Types.STRING);
-                        wrapper.write(Types.COMPONENT, ComponentUtil.plainToJson(line));
+                        wrapper.write(Types.COMPONENT, new JsonPrimitive(line));
                     }
                 });
             }


### PR DESCRIPTION
As per vanilla client behavior, fixes false flags on anti cheats/crash plugins