### PR TITLE
Fix NPE in container click of item with the 'blocks_attacks' attribute

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/BlocksAttacks.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/minecraft/item/data/BlocksAttacks.java
@@ -82,7 +82,13 @@ public record BlocksAttacks(
                 .writeOptional("disable_cooldown_scale", Types.FLOAT, value.disableCooldownScale(), 1F)
                 .writeOptional("damage_reductions", DamageReduction.ARRAY_TYPE, value.damageReductions(), defaultDamageReductions)
                 .writeOptional("item_damage", ItemDamageFunction.TYPE, value.itemDamage(), defaultItemDamage)
-                .writeOptional("bypassed_by", Types.TAG_KEY, value.bypassedBy() != null ? Key.of(value.bypassedBy().tagKey()) : null)
+                .writeOptional(
+                    "bypassed_by",
+                    Types.TAG_KEY,
+                    (value.bypassedBy() != null && value.bypassedBy().tagKey() != null)
+                        ? Key.of(value.bypassedBy().tagKey())
+                        : null
+                )
                 .writeOptional("block_sound", Types.SOUND_EVENT, value.blockSound())
                 .writeOptional("disabled_sound", Types.SOUND_EVENT, value.disableSound()));
         }


### PR DESCRIPTION
Handles the possibly null `tagKey` of optional `bypassed_by` in `BlocksAttacks`.

Fixes #4868