### PR TITLE
Send empty tags packet in 1.21.11->26.1

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/Protocol1_21_11To26_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/Protocol1_21_11To26_1.java
@@ -47,6 +47,7 @@ import com.viaversion.viaversion.protocols.v1_21_11to26_1.packet.ServerboundPack
 import com.viaversion.viaversion.protocols.v1_21_11to26_1.rewriter.BlockItemPacketRewriter26_1;
 import com.viaversion.viaversion.protocols.v1_21_11to26_1.rewriter.ComponentRewriter26_1;
 import com.viaversion.viaversion.protocols.v1_21_11to26_1.rewriter.EntityPacketRewriter26_1;
+import com.viaversion.viaversion.protocols.v1_21_11to26_1.storage.TagsSent;
 import com.viaversion.viaversion.protocols.v1_21_5to1_21_6.packet.ServerboundPackets1_21_6;
 import com.viaversion.viaversion.protocols.v1_21_7to1_21_9.packet.ClientboundConfigurationPackets1_21_9;
 import com.viaversion.viaversion.protocols.v1_21_7to1_21_9.packet.ServerboundConfigurationPackets1_21_9;
@@ -95,9 +96,11 @@ public final class Protocol1_21_11To26_1 extends AbstractProtocol<ClientboundPac
             sendSoundVariants(wrapper, "chicken_sound_variant", MAPPINGS.chickenSoundVariants());
 
             // Make sure the client gets damage types and banner patterns, even if the server doesn't send tags
-            final PacketWrapper tagsPacket = wrapper.create(ClientboundConfigurationPackets1_21_9.UPDATE_TAGS);
-            tagsPacket.write(Types.VAR_INT, 0);
-            tagsPacket.send(Protocol1_21_11To26_1.class, false);
+            if (!wrapper.user().has(TagsSent.class)) {
+                final PacketWrapper tagsPacket = wrapper.create(ClientboundConfigurationPackets1_21_9.UPDATE_TAGS);
+                tagsPacket.write(Types.VAR_INT, 0);
+                tagsPacket.send(Protocol1_21_11To26_1.class, false);
+            }
         });
 
         addRequiredRegistryEntries();
@@ -141,8 +144,8 @@ public final class Protocol1_21_11To26_1 extends AbstractProtocol<ClientboundPac
         });
         registerClientbound(ClientboundConfigurationPackets1_21_9.REGISTRY_DATA, registryDataRewriter::handle);
 
-        tagRewriter.registerGeneric(ClientboundPackets1_21_11.UPDATE_TAGS);
-        tagRewriter.registerGeneric(ClientboundConfigurationPackets1_21_9.UPDATE_TAGS);
+        registerClientbound(ClientboundPackets1_21_11.UPDATE_TAGS, this::handleTags);
+        registerClientbound(ClientboundConfigurationPackets1_21_9.UPDATE_TAGS, this::handleTags);
 
         componentRewriter.registerOpenScreen1_14(ClientboundPackets1_21_11.OPEN_SCREEN);
         componentRewriter.registerComponentPacket(ClientboundPackets1_21_11.SET_ACTION_BAR_TEXT);
@@ -182,6 +185,11 @@ public final class Protocol1_21_11To26_1 extends AbstractProtocol<ClientboundPac
             wrapper.write(Types.FLOAT, tickDayTime ? 1F : 0F); // Tick rate
         });
         cancelServerbound(ServerboundPackets26_1.SET_GAME_RULE);
+    }
+
+    private void handleTags(final PacketWrapper wrapper) {
+        tagRewriter.handleGeneric(wrapper);
+        wrapper.user().put(new TagsSent());
     }
 
     private void sendSoundVariants(final PacketWrapper wrapper, final String key, final CompoundTag tag) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/storage/TagsSent.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/storage/TagsSent.java
@@ -1,0 +1,23 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_21_11to26_1.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+
+public final class TagsSent implements StorableObject {
+}


### PR DESCRIPTION
Make sure damage type / banner pattern tags get received by the client for delayed item creation, even when an older server doesn't send it (as previously not required). I'm quite sure we can revert the changes in 1.20->1.20.2 now, but wasn't sure.

Fixes https://github.com/ViaVersion/ViaFabricPlus/issues/1111