### PR TITLE
Null check block entity tag in 1.20->1.20.2

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/rewriter/BlockRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20to1_20_2/rewriter/BlockRewriter1_20_2.java
@@ -40,6 +40,10 @@ public final class BlockRewriter1_20_2 extends BlockRewriter<ClientboundPackets1
     @Override
     public void handleBlockEntity(final UserConnection connection, final BlockEntity blockEntity) {
         final CompoundTag tag = blockEntity.tag();
+        if (tag == null) {
+            return;
+        }
+
         final Tag primaryEffect = tag.remove("Primary");
         if (primaryEffect instanceof NumberTag && ((NumberTag) primaryEffect).asInt() != 0) {
             tag.put("primary_effect", new StringTag(PotionEffects1_20_2.idToKeyOrLuck(((NumberTag) primaryEffect).asInt() - 1)));


### PR DESCRIPTION
This got lost during the rewriter registrations changes

Fixes https://github.com/ViaVersion/ViaVersion/issues/4866