### PR TITLE
Don't require rewriter implementations in AbstractProtocol *API*

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/api/protocol/AbstractProtocol.java
+++ b/common/src/main/java/com/viaversion/viaversion/api/protocol/AbstractProtocol.java
@@ -526,31 +526,6 @@ public abstract class AbstractProtocol<CU extends ClientboundPacketType, CM exte
         return logger;
     }
 
-    @Override
-    public @Nullable TagRewriter<CU> getTagRewriter() {
-        return null;
-    }
-
-    @Override
-    public @Nullable ComponentRewriterBase<CU> getComponentRewriter() {
-        return null;
-    }
-
-    @Override
-    public com.viaversion.viaversion.rewriter.@Nullable ParticleRewriter<CU> getParticleRewriter() {
-        return null;
-    }
-
-    @Override
-    public com.viaversion.viaversion.rewriter.@Nullable EntityRewriter<CU, ?> getEntityRewriter() {
-        return null;
-    }
-
-    @Override
-    public com.viaversion.viaversion.rewriter.@Nullable ItemRewriter<CU, SU, ?> getItemRewriter() {
-        return null;
-    }
-
     public com.viaversion.viaversion.rewriter.@Nullable BlockRewriter<CU> getBlockRewriter() {
         return null;
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/EntityRegistrations.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/EntityRegistrations.java
@@ -91,6 +91,6 @@ final class EntityRegistrations {
 
 
     static @Nullable <CU extends ClientboundPacketType, SU extends ServerboundPacketType> EntityRewriter<CU, ?> entity(final RegistrationContext<CU, SU> ctx) {
-        return ctx.protocol().getEntityRewriter();
+        return (EntityRewriter<CU, ?>) ctx.protocol().getEntityRewriter();
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/ItemRegistrations.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/ItemRegistrations.java
@@ -176,7 +176,7 @@ final class ItemRegistrations {
     }
 
     static @Nullable <CU extends ClientboundPacketType, SU extends ServerboundPacketType> ItemRewriter<CU, SU, ?> item(final RegistrationContext<CU, SU> ctx) {
-        return ctx.protocol().getItemRewriter();
+        return (ItemRewriter<CU, SU, ?>) ctx.protocol().getItemRewriter();
     }
 
     static @Nullable <CU extends ClientboundPacketType, SU extends ServerboundPacketType> StructuredItemRewriter<CU, SU, ?> structuredItem(final RegistrationContext<CU, SU> ctx) {

--- a/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/ParticleRegistrations.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/ParticleRegistrations.java
@@ -69,6 +69,6 @@ final class ParticleRegistrations {
     }
 
     static @Nullable <CU extends ClientboundPacketType, SU extends ServerboundPacketType> ParticleRewriter<CU> particle(final RegistrationContext<CU, SU> ctx) {
-        return ctx.protocol().getParticleRewriter();
+        return (ParticleRewriter<CU>) ctx.protocol().getParticleRewriter();
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/RegistryRegistrations.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/RegistryRegistrations.java
@@ -36,18 +36,21 @@ import com.viaversion.viaversion.rewriter.AttributeRewriter;
 import com.viaversion.viaversion.rewriter.RecipeDisplayRewriter;
 import com.viaversion.viaversion.rewriter.SoundRewriter;
 import com.viaversion.viaversion.rewriter.StatisticsRewriter;
+import com.viaversion.viaversion.rewriter.TagRewriter;
 
 final class RegistryRegistrations {
 
     static <CU extends ClientboundPacketType> void registerTags1_17_1(final RegistrationContext<CU, ?> ctx) {
-        if (ctx.protocol().getTagRewriter() == null) return;
-        ctx.clientbound(ClientboundPackets1_17_1.UPDATE_TAGS, ctx.protocol().getTagRewriter()::registerGeneric);
+        if (ctx.protocol().getTagRewriter() instanceof final TagRewriter tagRewriter) {
+            ctx.clientbound(ClientboundPackets1_17_1.UPDATE_TAGS, tagRewriter::registerGeneric);
+        }
     }
 
     static <CU extends ClientboundPacketType> void registerTags1_20_2(final RegistrationContext<CU, ?> ctx) {
-        if (ctx.protocol().getTagRewriter() == null) return;
-        ctx.clientbound(ClientboundPackets1_20_2.UPDATE_TAGS, ctx.protocol().getTagRewriter()::registerGeneric);
-        ctx.clientbound(ClientboundConfigurationPackets1_20_2.UPDATE_TAGS, ctx.protocol().getTagRewriter()::registerGeneric, PacketBound.ADDED_AT_MIN);
+        if (ctx.protocol().getTagRewriter() instanceof final TagRewriter tagRewriter) {
+            ctx.clientbound(ClientboundPackets1_20_2.UPDATE_TAGS, tagRewriter::registerGeneric);
+            ctx.clientbound(ClientboundConfigurationPackets1_20_2.UPDATE_TAGS, tagRewriter::registerGeneric, PacketBound.ADDED_AT_MIN);
+        }
     }
 
 

--- a/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/TextComponentRegistrations.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocol/shared_registration/def/TextComponentRegistrations.java
@@ -184,7 +184,7 @@ final class TextComponentRegistrations {
     }
 
     static @Nullable <CU extends ClientboundPacketType, SU extends ServerboundPacketType> ComponentRewriterBase<CU> text(final RegistrationContext<CU, SU> ctx) {
-        return ctx.protocol().getComponentRewriter();
+        return (ComponentRewriterBase<CU>) ctx.protocol().getComponentRewriter();
     }
 
 


### PR DESCRIPTION
Fixes ViaLegacy not being able to pass its own item rewriter implementation to abstract protocols. See https://github.com/ViaVersion/ViaLegacy/blob/main/src/main/java/net/raphimc/vialegacy/api/remapper/LegacyItemRewriter.java#L38