### PR TITLE
Migrate chunk-key maps to fast util

### DIFF
--- a/build-logic/src/main/kotlin/via.shadow-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/via.shadow-conventions.gradle.kts
@@ -49,7 +49,7 @@ fun ShadowJar.configureRelocations() {
 }
 
 fun ShadowJar.configureExcludes() {
-    // FastUtil - we only want object, int, and certain reference maps
+    // FastUtil - we only want object, int, long-to-object, and certain reference maps
     // Object types
     exclude("it/unimi/dsi/fastutil/*/*2Reference*")
     exclude("it/unimi/dsi/fastutil/*/*Reference2Int*")
@@ -58,13 +58,17 @@ fun ShadowJar.configureExcludes() {
     exclude("it/unimi/dsi/fastutil/*/*Short*")
     exclude("it/unimi/dsi/fastutil/*/*Float*")
     exclude("it/unimi/dsi/fastutil/*/*Double*")
-    exclude("it/unimi/dsi/fastutil/*/*Long*")
+    exclude("it/unimi/dsi/fastutil/*/*2Long*")
     exclude("it/unimi/dsi/fastutil/*/*Char*")
     // Map types
     exclude("it/unimi/dsi/fastutil/*/*Custom*")
     exclude("it/unimi/dsi/fastutil/*/*Tree*")
     exclude("it/unimi/dsi/fastutil/*/*Heap*")
     exclude("it/unimi/dsi/fastutil/*/*Queue*")
+    exclude("it/unimi/dsi/fastutil/longs/*2Int*")
+    exclude("it/unimi/dsi/fastutil/longs/*ArrayMap*")
+    exclude("it/unimi/dsi/fastutil/longs/*LinkedOpenHashMap*")
+    exclude("it/unimi/dsi/fastutil/longs/*SortedMap*")
     // Crossing fingers
     exclude("it/unimi/dsi/fastutil/*/*Big*")
     exclude("it/unimi/dsi/fastutil/*/*Synchronized*")

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/storage/BlockConnectionStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/storage/BlockConnectionStorage.java
@@ -18,36 +18,21 @@
 package com.viaversion.viaversion.protocols.v1_12_2to1_13.storage;
 
 import com.google.common.collect.EvictingQueue;
-import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.StorableObject;
 import com.viaversion.viaversion.api.minecraft.BlockPosition;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class BlockConnectionStorage implements StorableObject {
-    private static Constructor<?> fastUtilLongObjectHashMap;
-
-    private final Map<Long, SectionData> blockStorage = createLongObjectMap();
+    private final Map<Long, SectionData> blockStorage = new Long2ObjectOpenHashMap<>();
     @SuppressWarnings("UnstableApiUsage")
     private final Queue<BlockPosition> modified = EvictingQueue.create(5);
 
     // Cache to retrieve section quicker
     private long lastIndex = -1;
     private SectionData lastSection;
-
-    static {
-        try {
-            //noinspection StringBufferReplaceableByString - prevent relocation
-            String className = new StringBuilder("it").append(".unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap").toString();
-            fastUtilLongObjectHashMap = Class.forName(className).getConstructor();
-            Via.getPlatform().getLogger().info("Using FastUtil Long2ObjectOpenHashMap for block connections");
-        } catch (ClassNotFoundException | NoSuchMethodException ignored) {
-        }
-    }
 
     public static void init() {
     }
@@ -144,18 +129,6 @@ public class BlockConnectionStorage implements StorableObject {
 
     private static long getChunkSectionIndex(int x, int y, int z) {
         return (((x >> 4) & 0x3FFFFFFL) << 38) | (((y >> 4) & 0xFFFL) << 26) | ((z >> 4) & 0x3FFFFFFL);
-    }
-
-    private <T> Map<Long, T> createLongObjectMap() {
-        if (fastUtilLongObjectHashMap != null) {
-            try {
-                //noinspection unchecked
-                return (Map<Long, T>) fastUtilLongObjectHashMap.newInstance();
-            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
-                e.printStackTrace();
-            }
-        }
-        return new HashMap<>();
     }
 
     private static final class SectionData {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/storage/BlockStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/storage/BlockStorage.java
@@ -22,12 +22,13 @@ import com.viaversion.viaversion.api.minecraft.BlockPosition;
 import com.viaversion.viaversion.api.minecraft.ChunkPosition;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.HashMap;
 import java.util.Map;
 
 public class BlockStorage implements StorableObject {
     private static final IntSet WHITELIST = new IntOpenHashSet(46);
-    private final Map<Long, Map<BlockPosition, ReplacementData>> blocks = new HashMap<>();
+    private final Map<Long, Map<BlockPosition, ReplacementData>> blocks = new Long2ObjectOpenHashMap<>();
 
     static {
         // Flower pots

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_17_1to1_18/storage/ChunkLightStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_17_1to1_18/storage/ChunkLightStorage.java
@@ -23,12 +23,14 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class ChunkLightStorage implements StorableObject {
 
-    private final Map<Long, ChunkLight> lightPackets = new HashMap<>();
-    private final Set<Long> loadedChunks = new HashSet<>();
+    private final Map<Long, ChunkLight> lightPackets = new Long2ObjectOpenHashMap<>();
+    private final Set<Long> loadedChunks = new LongOpenHashSet();
 
     public void storeLight(final int x, final int z, final ChunkLight chunkLight) {
         lightPackets.put(ChunkPosition.chunkKey(x, z), chunkLight);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/ChunkLoadTracker.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/storage/ChunkLoadTracker.java
@@ -19,12 +19,13 @@ package com.viaversion.viaversion.protocols.v1_21to1_21_2.storage;
 
 import com.viaversion.viaversion.api.connection.StorableObject;
 import com.viaversion.viaversion.api.minecraft.ChunkPosition;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import java.util.HashSet;
 import java.util.Set;
 
 public class ChunkLoadTracker implements StorableObject {
 
-    private final Set<Long> loadedChunks = new HashSet<>();
+    private final Set<Long> loadedChunks = new LongOpenHashSet();
 
     public void addChunk(final int x, final int z) {
         this.loadedChunks.add(ChunkPosition.chunkKey(x, z));

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/ClientWorld1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/ClientWorld1_9.java
@@ -18,12 +18,13 @@
 package com.viaversion.viaversion.protocols.v1_8to1_9.storage;
 
 import com.viaversion.viaversion.api.minecraft.ClientWorld;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import java.util.HashSet;
 import java.util.Set;
 
 public class ClientWorld1_9 extends ClientWorld {
 
-    private final Set<Long> loadedChunks = new HashSet<>();
+    private final Set<Long> loadedChunks = new LongOpenHashSet();
 
     public Set<Long> getLoadedChunks() {
         return loadedChunks;

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/CommandBlockStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/CommandBlockStorage.java
@@ -22,12 +22,13 @@ import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.viaversion.api.connection.StorableObject;
 import com.viaversion.viaversion.api.minecraft.BlockPosition;
 import com.viaversion.viaversion.api.minecraft.ChunkPosition;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 public class CommandBlockStorage implements StorableObject {
-    private final Map<Long, Map<BlockPosition, CompoundTag>> storedCommandBlocks = new HashMap<>();
+    private final Map<Long, Map<BlockPosition, CompoundTag>> storedCommandBlocks = new Long2ObjectOpenHashMap<>();
     private boolean permissions;
 
     public void unloadChunk(int x, int z) {


### PR DESCRIPTION
I found these mostly by accident when investigating a heap dump for an unrelated issue, but java `HashMap`s get terrible hashing for these `long` based chunk keys, causing most of the nodes in the map not to be `o(1)` direct nodes, but instead be either linear searches or binary maps for keys. This is the result of how the keys are constructed and "mixed".

The chunk keys are one long with 32 bits for chunkX, and 32 bits for chunkZ. when these get hashed, java's default hashCode for longs is `value ^ (value >>> 32)`, which effectively xors x and z directions, this is further aggravated by the "mixing" of the key done in hashmap, which then does `hash ^ (hash >>> 16)`. Given *most* chunks are mostly in the small number rage (eg: -128 to +128 range), this repeated shifting of values ends up with very, very little usable keys.


### Verifying/Testing:
I've created a test where i hashed all chunks between -128 and +128 for x and z directions, in a table size of 1024 (note the table size of 1024 chunks is reasonable, every single chunk between -128 and +128 isn't, but the point is to see how they'd spread across the space).
Java's HashMap only uses 32 buckets with 512 each, leaving empty the other ~1000 buckets. FastUtil's impl's top 32 buckets hold 88 to 77 (best case would be 16 per bucket)
Source and result can be found at https://gist.github.com/Pablete1234/47fc7561ece621aca7b054b80d77264c


