### PR TITLE
Make OptionalType non-abstract

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/type/OptionalType.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/type/OptionalType.java
@@ -26,10 +26,10 @@ import com.viaversion.viaversion.api.minecraft.codec.Ops;
 import io.netty.buffer.ByteBuf;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public abstract class OptionalType<T> extends Type<T> {
+public class OptionalType<T> extends Type<T> {
     private final Type<T> type;
 
-    protected OptionalType(final Type<T> type) {
+    public OptionalType(final Type<T> type) {
         super(type.getOutputClass());
         this.type = type;
     }


### PR DESCRIPTION
This allows it to be used like ArrayType without having to create new classes