### PR TITLE
Display infinite potion effect duration for 1.19.4+, if it would display infinite on 1.19.2 and below

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/Protocol1_19_3To1_19_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/Protocol1_19_3To1_19_4.java
@@ -73,6 +73,20 @@ public final class Protocol1_19_3To1_19_4 extends AbstractProtocol<ClientboundPa
         };
         replaceClientbound(ClientboundPackets1_19_3.COMMANDS, commandRewriter::handle1_19);
 
+        registerClientbound(ClientboundPackets1_19_3.UPDATE_MOB_EFFECT, wrapper -> {
+            wrapper.passthrough(Types.VAR_INT); // entity id
+            wrapper.passthrough(Types.VAR_INT); // effect id
+            wrapper.passthrough(Types.BYTE); // amplifier
+
+            int duration = wrapper.read(Types.VAR_INT);
+
+            if (duration >= 32767) { // Anything above this would display as infinite on 1.19.2 and below, and on 1.19.4+, infinite is -1
+                wrapper.write(Types.VAR_INT, -1);
+            } else {
+                wrapper.write(Types.VAR_INT, duration);
+            }
+        });
+
         registerClientbound(ClientboundPackets1_19_3.SERVER_DATA, wrapper -> {
             JsonElement element = wrapper.read(Types.OPTIONAL_COMPONENT);
             if (element != null) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/Protocol1_19_3To1_19_4.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_19_3to1_19_4/Protocol1_19_3To1_19_4.java
@@ -80,7 +80,7 @@ public final class Protocol1_19_3To1_19_4 extends AbstractProtocol<ClientboundPa
 
             int duration = wrapper.read(Types.VAR_INT);
 
-            if (duration >= 32767) { // Anything above this would display as infinite on 1.19.2 and below, and on 1.19.4+, infinite is -1
+            if (duration >= Short.MAX_VALUE) { // Anything at or above this would display as infinite on 1.19.2 and below, and on 1.19.4+, infinite is -1
                 wrapper.write(Types.VAR_INT, -1);
             } else {
                 wrapper.write(Types.VAR_INT, duration);


### PR DESCRIPTION
On 1.19.2 and below, if a potion effect was longer than 32767 ticks, it would display as infinite length for players

On 1.19.4, they made a more official way of setting infinite durations, which is to set it to -1 to be infinite

This PR makes it so for servers that run 1.19.2 or below, clients on 1.19.4 and higher will display infinite potion effects, like the clients on 1.19.2 and below on the server do

This is especially useful for some servers like mine, because some MC versions also capped the potion duration in the packet at 32767, making 1.19.4+ clients on the server, always see long potion effects maxxed at 27.3 minutes long, even if they had an effect much longer than that

1.19.3 has neither infinite potion display nor infinite potion duration, so I left it as is