### PR TITLE
Fix default color of legacy reddust particles

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -261,6 +261,8 @@ public interface ViaVersionConfig extends Config {
      */
     boolean isChunkBorderFix();
 
+    boolean isMultiReddustColorFix();
+
     /**
      * Should we make team colours based on the last colour in team prefix
      *

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -72,6 +72,7 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     private String reloadDisconnectMessage;
     private boolean logOtherConversionErrors;
     private boolean logTextComponentConversionErrors;
+    private boolean multiReddustColorFix;
     private boolean disable1_13TabComplete;
     private boolean teamColourFix;
     private boolean serversideBlockConnections;
@@ -146,6 +147,7 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
         blockedDisconnectMessage = getString("block-disconnect-msg", "You are using an unsupported Minecraft version!");
         reloadDisconnectMessage = getString("reload-disconnect-msg", "Server reload, please rejoin!");
         teamColourFix = getBoolean("team-colour-fix", true);
+        multiReddustColorFix = getBoolean("multi-reddust-color-fix", false);
         disable1_13TabComplete = getBoolean("disable-1_13-auto-complete", false);
         serversideBlockConnections = getBoolean("serverside-blockconnections", true);
         reduceBlockStorageMemory = getBoolean("reduce-blockstorage-memory", false);
@@ -473,6 +475,11 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     @Override
     public String getReloadDisconnectMsg() {
         return reloadDisconnectMessage;
+    }
+
+    @Override
+    public boolean isMultiReddustColorFix() {
+        return multiReddustColorFix;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/ParticleIdMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/ParticleIdMappings1_13.java
@@ -27,7 +27,6 @@ import com.viaversion.viaversion.protocols.v1_12_2to1_13.rewriter.WorldPacketRew
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ParticleIdMappings1_13 {
@@ -111,19 +110,14 @@ public class ParticleIdMappings1_13 {
         particles.add(new NewParticle(newId, dataHandler));
     }
 
-    // Randomized because the previous one was a lot of different colors at once! :)
     private static ParticleDataHandler reddustHandler() {
         return (particle, data) -> {
-            particle.add(Types.FLOAT, randomBool() ? 1f : 0f); // Red 0 - 1
+            particle.add(Types.FLOAT, 1f); // Red 0 - 1
             particle.add(Types.FLOAT, 0f); // Green 0 - 1
-            particle.add(Types.FLOAT, randomBool() ? 1f : 0f); // Blue 0 - 1
+            particle.add(Types.FLOAT, 0f); // Blue 0 - 1
             particle.add(Types.FLOAT, 1f);// Scale 0.01 - 4
             return particle;
         };
-    }
-
-    private static boolean randomBool() {
-        return ThreadLocalRandom.current().nextBoolean();
     }
 
     // Rewrite IconCrack items to new format :)

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/ParticleIdMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/ParticleIdMappings1_13.java
@@ -27,6 +27,7 @@ import com.viaversion.viaversion.protocols.v1_12_2to1_13.rewriter.WorldPacketRew
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ParticleIdMappings1_13 {
@@ -110,14 +111,19 @@ public class ParticleIdMappings1_13 {
         particles.add(new NewParticle(newId, dataHandler));
     }
 
+    // Randomized because the previous one was a lot of different colors at once! :)
     private static ParticleDataHandler reddustHandler() {
         return (particle, data) -> {
-            particle.add(Types.FLOAT, 1f); // Red 0 - 1
+            particle.add(Types.FLOAT, randomBool() ? 1f : 0f); // Red 0 - 1
             particle.add(Types.FLOAT, 0f); // Green 0 - 1
-            particle.add(Types.FLOAT, 0f); // Blue 0 - 1
+            particle.add(Types.FLOAT, randomBool() ? 1f : 0f); // Blue 0 - 1
             particle.add(Types.FLOAT, 1f);// Scale 0.01 - 4
             return particle;
         };
+    }
+
+    private static boolean randomBool() {
+        return ThreadLocalRandom.current().nextBoolean();
     }
 
     // Rewrite IconCrack items to new format :)

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/WorldPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/WorldPacketRewriter1_13.java
@@ -513,17 +513,18 @@ public class WorldPacketRewriter1_13 {
                         float speed = wrapper.get(Types.FLOAT, 6);
                         // Only handle for count = 0
                         if (count == 0) {
+                            // Change count and speed
                             wrapper.set(Types.INT, 1, 1);
                             wrapper.set(Types.FLOAT, 6, 0f);
 
                             for (int i = 0; i < 3; i++) {
-                                //RGB values are represented by the X/Y/Z offset
-                                float colorValue = wrapper.get(Types.FLOAT, i + 3) * speed;
-                                colorValue = redstoneDustColor(colorValue, i == 0);
+                                // RGB values are represented by the X/Y/Z offset
+                                float offset = wrapper.get(Types.FLOAT, i + 3);
+                                float colorValue = redstoneDustColor(speed, offset, i == 0);
                                 particle.<Float>getArgument(i).setValue(colorValue);
                                 wrapper.set(Types.FLOAT, i + 3, 0f);
                             }
-                        } else {
+                        } else if (Via.getConfig().isMultiReddustColorFix()) {
                             wrapper.cancel();
 
                             final boolean longDistance = wrapper.get(Types.BOOLEAN, 0);
@@ -543,9 +544,9 @@ public class WorldPacketRewriter1_13 {
                                     particleX,
                                     particleY,
                                     particleZ,
-                                    redstoneDustColor((float) (random.nextGaussian() * speed), true),
-                                    redstoneDustColor((float) (random.nextGaussian() * speed), false),
-                                    redstoneDustColor((float) (random.nextGaussian() * speed), false));
+                                    redstoneDustColor((float) random.nextGaussian(), speed, true),
+                                    redstoneDustColor((float) random.nextGaussian(), speed, false),
+                                    redstoneDustColor((float) random.nextGaussian(), speed, false));
                             }
                             return;
                         }
@@ -586,8 +587,9 @@ public class WorldPacketRewriter1_13 {
 
     }
 
-    private static float redstoneDustColor(float color, boolean red) {
-        // Vanilla 1.12 only substitutes red when the raw red value is exactly zero.
+    private static float redstoneDustColor(float speed, float offset, boolean red) {
+        // Vanilla 1.12 substitutes red when the raw red value is zero
+        float color = speed * offset;
         if (red && color == 0F) {
             return 1F;
         }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/WorldPacketRewriter1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/rewriter/WorldPacketRewriter1_13.java
@@ -51,6 +51,7 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class WorldPacketRewriter1_13 {
     private static final IntSet VALID_BIOMES = new IntOpenHashSet(70);
@@ -518,13 +519,35 @@ public class WorldPacketRewriter1_13 {
                             for (int i = 0; i < 3; i++) {
                                 //RGB values are represented by the X/Y/Z offset
                                 float colorValue = wrapper.get(Types.FLOAT, i + 3) * speed;
-                                if (colorValue == 0 && i == 0) {
-                                    // https://minecraft.gamepedia.com/User:Alphappy/reddust
-                                    colorValue = 1;
-                                }
+                                colorValue = redstoneDustColor(colorValue, i == 0);
                                 particle.<Float>getArgument(i).setValue(colorValue);
                                 wrapper.set(Types.FLOAT, i + 3, 0f);
                             }
+                        } else {
+                            wrapper.cancel();
+
+                            final boolean longDistance = wrapper.get(Types.BOOLEAN, 0);
+                            final float x = wrapper.get(Types.FLOAT, 0);
+                            final float y = wrapper.get(Types.FLOAT, 1);
+                            final float z = wrapper.get(Types.FLOAT, 2);
+                            final float offsetX = wrapper.get(Types.FLOAT, 3);
+                            final float offsetY = wrapper.get(Types.FLOAT, 4);
+                            final float offsetZ = wrapper.get(Types.FLOAT, 5);
+                            final ThreadLocalRandom random = ThreadLocalRandom.current();
+                            for (int i = 0; i < count; i++) {
+                                final float particleX = (float) (x + random.nextGaussian() * offsetX);
+                                final float particleY = (float) (y + random.nextGaussian() * offsetY);
+                                final float particleZ = (float) (z + random.nextGaussian() * offsetZ);
+                                sendRedstoneParticle(wrapper,
+                                    longDistance,
+                                    particleX,
+                                    particleY,
+                                    particleZ,
+                                    redstoneDustColor((float) (random.nextGaussian() * speed), true),
+                                    redstoneDustColor((float) (random.nextGaussian() * speed), false),
+                                    redstoneDustColor((float) (random.nextGaussian() * speed), false));
+                            }
+                            return;
                         }
                     }
 
@@ -561,6 +584,33 @@ public class WorldPacketRewriter1_13 {
             }
         });
 
+    }
+
+    private static float redstoneDustColor(float color, boolean red) {
+        // Vanilla 1.12 only substitutes red when the raw red value is exactly zero.
+        if (red && color == 0F) {
+            return 1F;
+        }
+        return ((int) (color * 255F) & 255) / 255F;
+    }
+
+    private static void sendRedstoneParticle(PacketWrapper wrapper, boolean longDistance, float x, float y, float z, float red, float green, float blue) {
+        final PacketWrapper particlePacket = wrapper.create(ClientboundPackets1_13.LEVEL_PARTICLES);
+        particlePacket.write(Types.INT, 11);
+        particlePacket.write(Types.BOOLEAN, longDistance);
+        particlePacket.write(Types.FLOAT, x);
+        particlePacket.write(Types.FLOAT, y);
+        particlePacket.write(Types.FLOAT, z);
+        particlePacket.write(Types.FLOAT, 0F);
+        particlePacket.write(Types.FLOAT, 0F);
+        particlePacket.write(Types.FLOAT, 0F);
+        particlePacket.write(Types.FLOAT, 0F);
+        particlePacket.write(Types.INT, 0);
+        particlePacket.write(Types.FLOAT, red);
+        particlePacket.write(Types.FLOAT, green);
+        particlePacket.write(Types.FLOAT, blue);
+        particlePacket.write(Types.FLOAT, 1F);
+        particlePacket.send(Protocol1_12_2To1_13.class);
     }
 
     public static int toNewId(int oldId) {

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -123,6 +123,8 @@ register-userconnections-on-join: true
 piston-animation-patch: false
 # Experimental - Should we fix shift quick move action for 1.12 clients (causes shift + double click not to work when moving items) (only works on 1.8-1.11.2 bukkit based servers)
 quick-move-action-fix: false
+# Should we fix the client-randomized reddust color for 1.13+ clients? This will result in an extra packet per count, so enabling this may spam clients.
+multi-reddust-color-fix: false
 # Should we use prefix for team color on 1.13 and above clients?
 team-colour-fix: true
 # 1.13 introduced new auto complete which can trigger "Kicked for spamming" for servers older than 1.13, the following option will disable it completely.


### PR DESCRIPTION
## Description

Fixes #3400

Uses red as the fallback color when converting legacy `reddust` particles from 1.12.2 to 1.13.

The existing fallback randomly selects red and blue channel values, which can cause particles to appear black, blue, or purple. This is particularly noticeable when a server sends `reddust` particles with a nonzero count.

Packets with a count of zero are unaffected. Their explicitly encoded RGB values continue to be preserved by the existing packet rewriter.

## Screenshots
1.12.2 client connected to a 1.12.2 server:
<img width="2560" height="1440" alt="2026-05-31_13 22 49" src="https://github.com/user-attachments/assets/f19a82c6-1b0d-42d1-a25d-99fa7342dfa7" />

1.13+ client connected to the same server before this patch:
<img width="2560" height="1440" alt="2026-05-31_13 24 15" src="https://github.com/user-attachments/assets/4365fb48-5383-4617-a220-e92693a74cdf" />

1.13+ client connected to the same server after this patch:
<img width="2560" height="1440" alt="2026-05-31_13 32 17" src="https://github.com/user-attachments/assets/01c7efc3-fb64-47d3-8ce8-08e49d84186b" />


## Testing

Tested with a 1.12.2 server and a modern client through ViaFabricPlus.

The command used to test is `/particle reddust ~0 ~2 ~0 0 0 1 1 0 normal`

Before:
- Legacy `reddust` particles with a nonzero count could appear black, blue, or purple.

After:
- Legacy `reddust` particles with a nonzero count consistently use the default red color.
- Explicitly colored `reddust` particles continue to display their specified color.


#### AI was used to help investigate the issue and prepare the patch. The behavior was reproduced and the resulting change was manually tested.