### PR TITLE
Preserve legacy stained glass pane falling dust appearance

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/ParticleIdMappings1_13.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_12_2to1_13/data/ParticleIdMappings1_13.java
@@ -87,7 +87,7 @@ public class ParticleIdMappings1_13 {
         add(16); // (43->16) endrod -> minecraft:end_rod
         add(7); // (44->7) damageindicator -> minecraft:damage_indicator
         add(40); // (45->40) sweepattack -> minecraft:sweep_attack
-        add(20, blockHandler()); // (46->20) fallingdust -> minecraft:falling_dust
+        add(20, blockHandler(160, 95)); // (46->20) fallingdust -> minecraft:falling_dust
         // BlockState	VarInt	The ID of the block state.
         add(41); // (47->41) totem -> minecraft:totem_of_undying
         add(38); // (48->38) spit -> minecraft:spit
@@ -148,8 +148,15 @@ public class ParticleIdMappings1_13 {
 
     // Handle (id+(data<<12)) encoded blocks
     private static ParticleDataHandler blockHandler() {
+        return blockHandler(-1, -1);
+    }
+
+    private static ParticleDataHandler blockHandler(int fromBlockId, int toBlockId) {
         return (particle, data) -> {
             int value = data[0];
+            if ((value & 4095) == fromBlockId) {
+                value = value & ~4095 | toBlockId;
+            }
             int combined = (((value & 4095) << 4) | (value >> 12 & 15));
             int newId = WorldPacketRewriter1_13.toNewId(combined);
 


### PR DESCRIPTION
## Description
Fixes #4306 

Maps legacy stained glass pane `fallingdust` particles to the corresponding stained glass block state during the 1.12.2 to 1.13 translation.

On 1.12.2 clients, stained glass and stained glass pane `fallingdust` particles render identically. On modern clients, stained glass pane `falling_dust` particles render with an incorrect dark tint, while the corresponding stained glass particles retain the expected color.

The substitution is limited to legacy `fallingdust` particles. It preserves metadata for all sixteen colors and does not affect actual blocks, `blockcrack`, `blockdust`, or native 1.13+ server behavior.

## Screenshots
1.12.2 client connected to a 1.12.2 server:
<img width="2560" height="1440" alt="2026-05-31_16 24 04" src="https://github.com/user-attachments/assets/520f637e-eeb8-43e8-bd15-288c3d1e92df" />

1.13+ client connected to the same server before this patch: 
<img width="2560" height="1440" alt="2026-05-31_16 25 35" src="https://github.com/user-attachments/assets/c460598e-7113-4ea8-8911-36c62e9712a8" />

1.13+ client connected to the same server after this patch:
<img width="2560" height="1440" alt="2026-05-31_16 26 35" src="https://github.com/user-attachments/assets/fc16bdd1-2b17-4df1-96da-11e7c9841c58" />

1.13+ client connected to a 1.13 server (behavior unchanged):
<img width="2560" height="1440" alt="2026-05-31_16 32 06" src="https://github.com/user-attachments/assets/488adb97-0d64-469f-b6ee-5e3f28f905a9" />


## Testing

Tested the translated particles in-game with a 1.12.2 server, 1.13 server, and a modern client through ViaFabricPlus.

The command used to test is `/particle fallingdust ~ ~1 ~ 10 10 10 0.001 50 force @a 160`

#### AI was used to help investigate the issue and prepare the patch. The behavior was reproduced and the resulting change was manually tested.