### PR TITLE
Fix legacy nausea effect intensity on 1.21.5+ clients

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/EntityPacketRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/EntityPacketRewriter1_21_5.java
@@ -88,6 +88,18 @@ public final class EntityPacketRewriter1_21_5 extends EntityRewriter<Clientbound
             wrapper.user().get(MessageIndexStorage.class).setIndex(0);
         });
 
+        protocol.registerClientbound(ClientboundPackets1_21_2.UPDATE_MOB_EFFECT, ClientboundPackets1_21_5.UPDATE_MOB_EFFECT, wrapper -> {
+            wrapper.passthrough(Types.VAR_INT); // Entity ID
+            final int effectId = wrapper.passthrough(Types.VAR_INT); // Effect ID
+            wrapper.passthrough(Types.VAR_INT); // Amplifier
+            wrapper.passthrough(Types.VAR_INT); // Duration
+            byte flags = wrapper.read(Types.BYTE); // Flags
+            if (effectId == 9) { // Nausea
+                flags |= 0x08;
+            }
+            wrapper.write(Types.BYTE, flags);
+        });
+
         protocol.replaceClientbound(ClientboundPackets1_21_2.SET_PLAYER_TEAM, wrapper -> {
             wrapper.passthrough(Types.STRING); // Team Name
             final byte action = wrapper.passthrough(Types.BYTE); // Mode

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/EntityPacketRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/EntityPacketRewriter1_21_5.java
@@ -88,7 +88,7 @@ public final class EntityPacketRewriter1_21_5 extends EntityRewriter<Clientbound
             wrapper.user().get(MessageIndexStorage.class).setIndex(0);
         });
 
-        protocol.registerClientbound(ClientboundPackets1_21_2.UPDATE_MOB_EFFECT, ClientboundPackets1_21_5.UPDATE_MOB_EFFECT, wrapper -> {
+        protocol.registerClientbound(ClientboundPackets1_21_2.UPDATE_MOB_EFFECT, wrapper -> {
             // Add blending to nausea effect
             wrapper.passthrough(Types.VAR_INT); // Entity ID
             final int effectId = wrapper.passthrough(Types.VAR_INT); // Effect ID

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/EntityPacketRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/EntityPacketRewriter1_21_5.java
@@ -94,7 +94,7 @@ public final class EntityPacketRewriter1_21_5 extends EntityRewriter<Clientbound
             wrapper.passthrough(Types.VAR_INT); // Amplifier
             wrapper.passthrough(Types.VAR_INT); // Duration
             byte flags = wrapper.read(Types.BYTE); // Flags
-            if (effectId == 9) { // Nausea
+            if (effectId == 8) { // Nausea
                 flags |= 0x08;
             }
             wrapper.write(Types.BYTE, flags);

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/EntityPacketRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_4to1_21_5/rewriter/EntityPacketRewriter1_21_5.java
@@ -89,13 +89,14 @@ public final class EntityPacketRewriter1_21_5 extends EntityRewriter<Clientbound
         });
 
         protocol.registerClientbound(ClientboundPackets1_21_2.UPDATE_MOB_EFFECT, ClientboundPackets1_21_5.UPDATE_MOB_EFFECT, wrapper -> {
+            // Add blending to nausea effect
             wrapper.passthrough(Types.VAR_INT); // Entity ID
             final int effectId = wrapper.passthrough(Types.VAR_INT); // Effect ID
             wrapper.passthrough(Types.VAR_INT); // Amplifier
             wrapper.passthrough(Types.VAR_INT); // Duration
             byte flags = wrapper.read(Types.BYTE); // Flags
             if (effectId == 8) { // Nausea
-                flags |= 0x08;
+                flags |= 0x08; // blend
             }
             wrapper.write(Types.BYTE, flags);
         });


### PR DESCRIPTION
### What changed
Sets the mob effect blend flag for nausea when translating `UPDATE_MOB_EFFECT` from 1.21.4 to 1.21.5.

### Why
Nausea has explicit blend timing in 1.21.5. Without the blend flag, modern clients skip the transition and short/low-intensity nausea effects can appear at full strength immediately.

This preserves all existing mob effect flags and only adds the blend flag for nausea.

### Testing
- Verified on a 1.12.2 server with a modern client that short nausea effects no longer render at full strength immediately.

#### AI was used to help investigate the issue and prepare the patch. The behavior was reproduced and the resulting change was manually tested.