### PR TITLE
Fix 1.21.10 servers and below not being able to detect 26.2 players left-clicking in spectator mode

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v26_1to26_2/rewriter/EntityPacketRewriter26_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v26_1to26_2/rewriter/EntityPacketRewriter26_2.java
@@ -43,7 +43,9 @@ public final class EntityPacketRewriter26_2 extends EntityRewriter<ClientboundPa
             if (entityId != null) {
                 wrapper.write(Types.VAR_INT, entityId);
             } else {
-                wrapper.cancel();
+                // if entity id is null, they just left-clicked the air, which used to be handled by the swing packet in 1.21.10 and below (1.21.11 and 26.1.X does not send spectator left clicks at all)
+                wrapper.setPacketType(ServerboundPackets26_1.SWING);
+                wrapper.write(Types.VAR_INT, 0); // Hand to Swing, 0 = Main Hand
             }
         });
 


### PR DESCRIPTION
From 1.8 until 1.21.10, left clicking while in spectator mode would send a serverbound SWING packet

In 1.21.11 they changed it to not send anything at all when in spectator mode

This was reported as a bug with MC-307272, and was fixed in 26.2 Snapshot 7 by changing serverbound SPECTATE_ENTITY packet to have the entity id be optional and have the optional be empty if left clicking while not looking at an entity

I have made this PR so that if a 26.2 client is left clicking, the server receives the old packet and is able to detect spectators on 26.2 left clicking