### PR TITLE
use java CRC32C impl to hash bytes instead of a custom one

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/codec/hash/CRC32C.java
+++ b/common/src/main/java/com/viaversion/viaversion/codec/hash/CRC32C.java
@@ -19,30 +19,10 @@ package com.viaversion.viaversion.codec.hash;
 
 final class CRC32C implements HashFunction {
 
-    private static final int[] CRC32C_TABLE = new int[256];
-
-    static {
-        for (int i = 0; i < 256; i++) {
-            int crc = i;
-            for (int j = 0; j < 8; j++) {
-                if ((crc & 1) == 1) {
-                    crc = (crc >>> 1) ^ 0x82F63B78;
-                } else {
-                    crc >>>= 1;
-                }
-            }
-            CRC32C_TABLE[i] = crc;
-        }
-    }
-
     @Override
     public int hashBytes(final byte[] data, final int length) {
-        int crc = ~0;
-        for (int i = 0; i < length; i++) {
-            final byte b = data[i];
-            final int index = (crc ^ b) & 0xFF;
-            crc = (crc >>> 8) ^ CRC32C_TABLE[index];
-        }
-        return ~crc;
+        java.util.zip.CRC32C crc = new java.util.zip.CRC32C();
+        crc.update(data, 0, length);
+        return (int) crc.getValue();
     }
 }

--- a/common/src/main/java/com/viaversion/viaversion/codec/hash/CRC32C.java
+++ b/common/src/main/java/com/viaversion/viaversion/codec/hash/CRC32C.java
@@ -17,12 +17,134 @@
  */
 package com.viaversion.viaversion.codec.hash;
 
+import sun.misc.Unsafe;
+import java.lang.reflect.Field;
+import java.nio.ByteOrder;
+
 final class CRC32C implements HashFunction {
+
+    private static final int REVERSED_CRC32C_POLY = 0x82F63B78; // Integer.reverse(0x1EDC6F41)
+
+    private static final Unsafe UNSAFE;
+    private static final int BYTE_BASE;
+    private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+    private static final boolean ADDRESS_64;
+
+    private static final int[][] byteTables = new int[8][256];
+    private static final int[] byteTable0 = byteTables[0];
+    private static final int[] byteTable1 = byteTables[1];
+    private static final int[] byteTable2 = byteTables[2];
+    private static final int[] byteTable3 = byteTables[3];
+    private static final int[] byteTable4 = byteTables[4];
+    private static final int[] byteTable5 = byteTables[5];
+    private static final int[] byteTable6 = byteTables[6];
+    private static final int[] byteTable7 = byteTables[7];
+    private static final int[] byteTable;
+
+    static {
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            UNSAFE = (Unsafe) f.get(null);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+        BYTE_BASE = UNSAFE.arrayBaseOffset(byte[].class);
+        ADDRESS_64 = UNSAFE.addressSize() == 8;
+
+        for (int index = 0; index < 256; index++) {
+            int r = index;
+            for (int i = 0; i < 8; i++) {
+                if ((r & 1) != 0) {
+                    r = (r >>> 1) ^ REVERSED_CRC32C_POLY;
+                } else {
+                    r >>>= 1;
+                }
+            }
+            byteTables[0][index] = r;
+        }
+        for (int index = 0; index < 256; index++) {
+            int r = byteTables[0][index];
+            for (int k = 1; k < 8; k++) {
+                r = byteTables[0][r & 0xFF] ^ (r >>> 8);
+                byteTables[k][index] = r;
+            }
+        }
+        if (LITTLE_ENDIAN) {
+            byteTable = byteTables[0];
+        } else {
+            byteTable = new int[byteTable0.length];
+            System.arraycopy(byteTable0, 0, byteTable, 0, byteTable0.length);
+            for (int[] table : byteTables) {
+                for (int index = 0; index < table.length; index++) {
+                    table[index] = Integer.reverseBytes(table[index]);
+                }
+            }
+        }
+    }
 
     @Override
     public int hashBytes(final byte[] data, final int length) {
-        java.util.zip.CRC32C crc = new java.util.zip.CRC32C();
-        crc.update(data, 0, length);
-        return (int) crc.getValue();
+        int crc = 0xFFFFFFFF;
+        int off = 0;
+
+        if (length - off >= 8) {
+            int alignLength = (8 - ((BYTE_BASE + off) & 0x7)) & 0x7;
+            for (int alignEnd = off + alignLength; off < alignEnd; off++) {
+                crc = (crc >>> 8) ^ byteTable[(crc ^ data[off]) & 0xFF];
+            }
+
+            if (!LITTLE_ENDIAN) {
+                crc = Integer.reverseBytes(crc);
+            }
+
+            for (; off < (length - 8); off += 8) {
+                int firstHalf;
+                int secondHalf;
+                if (!ADDRESS_64) {
+                    firstHalf = UNSAFE.getInt(data, (long) BYTE_BASE + off);
+                    secondHalf = UNSAFE.getInt(data, (long) BYTE_BASE + off + 4);
+                } else {
+                    long value = UNSAFE.getLong(data, (long) BYTE_BASE + off);
+                    if (LITTLE_ENDIAN) {
+                        firstHalf = (int) value;
+                        secondHalf = (int) (value >>> 32);
+                    } else {
+                        firstHalf = (int) (value >>> 32);
+                        secondHalf = (int) value;
+                    }
+                }
+                crc ^= firstHalf;
+                if (LITTLE_ENDIAN) {
+                    crc = byteTable7[crc & 0xFF]
+                        ^ byteTable6[(crc >>> 8) & 0xFF]
+                        ^ byteTable5[(crc >>> 16) & 0xFF]
+                        ^ byteTable4[crc >>> 24]
+                        ^ byteTable3[secondHalf & 0xFF]
+                        ^ byteTable2[(secondHalf >>> 8) & 0xFF]
+                        ^ byteTable1[(secondHalf >>> 16) & 0xFF]
+                        ^ byteTable0[secondHalf >>> 24];
+                } else {
+                    crc = byteTable0[secondHalf & 0xFF]
+                        ^ byteTable1[(secondHalf >>> 8) & 0xFF]
+                        ^ byteTable2[(secondHalf >>> 16) & 0xFF]
+                        ^ byteTable3[secondHalf >>> 24]
+                        ^ byteTable4[crc & 0xFF]
+                        ^ byteTable5[(crc >>> 8) & 0xFF]
+                        ^ byteTable6[(crc >>> 16) & 0xFF]
+                        ^ byteTable7[crc >>> 24];
+                }
+            }
+
+            if (!LITTLE_ENDIAN) {
+                crc = Integer.reverseBytes(crc);
+            }
+        }
+
+        for (; off < length; off++) {
+            crc = (crc >>> 8) ^ byteTable[(crc ^ data[off]) & 0xFF];
+        }
+
+        return ~crc;
     }
 }


### PR DESCRIPTION
Motivation:

This approach is simply more optimized.
Based on the basic JMH test, this approach is approximately 40 times faster.

```
Benchmark          (size)  Mode  Cnt     Score     Error  Units
Main.testJava        1024  avgt    3    47,200 ±  21,505  ns/op
Main.testOriginal    1024  avgt    3  1791,135 ± 141,751  ns/op
```