### PR TITLE
Fix incorrect pre-size calculation in writeString

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/codec/hash/HashOps.java
+++ b/common/src/main/java/com/viaversion/viaversion/codec/hash/HashOps.java
@@ -90,7 +90,7 @@ public class HashOps extends OpsBase implements Hasher {
 
     @Override
     public void writeString(final CharSequence sequence) {
-        hashBuilder.preSize(sequence.length() + Byte.BYTES + Integer.BYTES)
+        hashBuilder.preSize((sequence.length() * Character.BYTES) + Byte.BYTES + Integer.BYTES)
             .writeByte(TAG_STRING)
             .writeInt(sequence.length())
             .writeString(sequence);


### PR DESCRIPTION
Problem: pre-sized buffer was calculated using 1 byte per character instead of 2 (Character.BYTES), causing a guaranteed second array copy inside HashBuilder#writeString.