### PR TITLE
Fix JsonParseException when downgrading malformed LOCK component in 1…

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -588,16 +588,11 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
 
             // Back from json in the string tag to plain text
             final StringTag customName = TagUtil.getNamespacedStringTag(itemComponentsTag, "custom_name");
-            if (customName == null || customName.getValue() == null || customName.getValue().equals("null")) {
+            if (customName == null || customName.getValue().isEmpty() || customName.getValue().equals("null")) {
                 return null;
             }
 
-            try {
-                return new StringTag(SerializerVersion.V1_20_5.toComponent(customName.getValue()).asUnformattedString());
-            } catch (Exception e) {
-                // If it fails to parse (e.g., malformed JSON), return empty lock to prevent client disconnect
-                return new StringTag("");
-            }
+            return new StringTag(SerializerVersion.V1_20_5.toComponent(customName.getValue()).asUnformattedString());
         });
         dataContainer.replace(StructuredDataKey.INSTRUMENT1_21_2, StructuredDataKey.INSTRUMENT1_20_5, instrument -> {
             if (instrument.hasId()) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -588,11 +588,16 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
 
             // Back from json in the string tag to plain text
             final StringTag customName = TagUtil.getNamespacedStringTag(itemComponentsTag, "custom_name");
-            if (customName == null) {
+            if (customName == null || customName.getValue() == null || customName.getValue().equals("null")) {
                 return null;
             }
 
-            return new StringTag(SerializerVersion.V1_20_5.toComponent(customName.getValue()).asUnformattedString());
+            try {
+                return new StringTag(SerializerVersion.V1_20_5.toComponent(customName.getValue()).asUnformattedString());
+            } catch (Exception e) {
+                // If it fails to parse (e.g., malformed JSON), return empty lock to prevent client disconnect
+                return new StringTag("");
+            }
         });
         dataContainer.replace(StructuredDataKey.INSTRUMENT1_21_2, StructuredDataKey.INSTRUMENT1_20_5, instrument -> {
             if (instrument.hasId()) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -588,7 +588,7 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
 
             // Back from json in the string tag to plain text
             final StringTag customName = TagUtil.getNamespacedStringTag(itemComponentsTag, "custom_name");
-            if (customName == null || customName.getValue().isEmpty() || customName.getValue().equals("null")) {
+            if (customName == null || customName.getValue().equals("null")) {
                 return null;
             }
 


### PR DESCRIPTION
….21.2

When a 1.21.2 client sends a `CONTAINER_CLICK` packet for an item (like a Shulker Box) that contains a `minecraft:lock` component with a null or empty name (often used by GUI plugins to lock containers), `customName.getValue()` can be the exact string `"null"`.

During the downgrade process in `BlockItemPacketRewriter1_21_2#downgradeItemData`, `SerializerVersion.V1_20_5.toComponent()` attempts to parse `"null"` as JSON, which Gson evaluates to `JsonNull`. This throws a `MergedCodecException` (`JsonParseException`) because the text component codec expects a String, Object, or Array. This exception drops the server connection with a `DecoderException`.

This commit adds a safeguard to explicitly check for `"null"` strings and wraps the component deserialization in a `try-catch` block to gracefully handle malformed JSON strings. It returns an empty lock tag instead of crashing the client connection.