### PR TITLE
fix(protocol): sort stonecutter recipes by output registry key

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/RecipeRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/RecipeRewriter1_21_2.java
@@ -18,6 +18,7 @@
 package com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter;
 
 import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.data.FullMappings;
 import com.viaversion.viaversion.api.minecraft.HolderSet;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.Protocol;
@@ -187,8 +188,18 @@ final class RecipeRewriter1_21_2 extends RecipeRewriter1_20_3<ClientboundPacket1
     }
 
     public void finalizeRecipes() {
-        // Need to be sorted alphabetically
-        stoneCutterRecipes.sort(Comparator.comparing(recipe -> recipe.identifier));
+        // Fix #4242: Vanilla sorts stonecutter recipes by the output item's translation key (description ID), 
+        // not by the recipe key. Since we don't have translation keys on the proxy, we sort by the output's 
+        // registry key instead. Because vanilla stonecutter outputs are blocks ("block.minecraft.<path>"), 
+        // this registry-key sort perfectly matches vanilla's alphabetical translation-key order.
+        //
+        // Note: This only breaks if a recipe outputs a non-block item alongside block outputs for the same 
+        // input (which doesn't exist in Vanilla). A perfect fix would require shipping item translation data.
+        final FullMappings itemMappings = protocol.getMappingData().getFullItemMappings();
+        stoneCutterRecipes.sort(Comparator.comparing(recipe -> {
+            final String identifier = itemMappings.mappedIdentifier(recipe.result.identifier());
+            return identifier != null ? identifier : "";
+        }));
     }
 
     public void writeUpdateRecipeInputs(final PacketWrapper wrapper) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/RecipeRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/RecipeRewriter1_21_2.java
@@ -188,17 +188,17 @@ final class RecipeRewriter1_21_2 extends RecipeRewriter1_20_3<ClientboundPacket1
     }
 
     public void finalizeRecipes() {
-        // Fix #4242: Vanilla sorts stonecutter recipes by the output item's translation key (description ID), 
-        // not by the recipe key. Since we don't have translation keys on the proxy, we sort by the output's 
-        // registry key instead. Because vanilla stonecutter outputs are blocks ("block.minecraft.<path>"), 
-        // this registry-key sort perfectly matches vanilla's alphabetical translation-key order.
-        //
-        // Note: This only breaks if a recipe outputs a non-block item alongside block outputs for the same 
-        // input (which doesn't exist in Vanilla). A perfect fix would require shipping item translation data.
+        // Now sorted by the output's description translation key (block.minecraft.<block>).
+        // We get the same result by sorting via the item identifier and separating blocks and items,
+        // though Vanilla will always exclusively send blocks for stonecutter recipes
         final FullMappings itemMappings = protocol.getMappingData().getFullItemMappings();
+        final FullMappings blockMappings = protocol.getMappingData().getFullBlockMappings();
         stoneCutterRecipes.sort(Comparator.comparing(recipe -> {
             final String identifier = itemMappings.mappedIdentifier(recipe.result.identifier());
-            return identifier != null ? identifier : "";
+            if (blockMappings.mappedId(identifier) == -1) {
+                return "|" + identifier; // Sort after blocks
+            }
+            return identifier;
         }));
     }
 


### PR DESCRIPTION
Vanilla sorts stonecutter recipes alphabetically by the output item's 
translation key (description ID), rather than the recipe key. This mismatch 
previously caused incorrect item icons to display in the UI.

Since the proxy lacks client-side translation data, we now sort by the 
output item's registry key instead. Because all vanilla stonecutter outputs 
are block items ("block.minecraft.<path>"), sorting by registry path yields 
the exact same alphabetical order.

Tested and verified working properly on a Paper 1.21.1 server with 
1.21.2 to 1.21.4 clients.

Fixes #4242

Before repair
<img width="1304" height="549" alt="image" src="https://github.com/user-attachments/assets/44f5d8c5-2e73-4393-aa62-d573db291ee6" />

After repair
<img width="1919" height="562" alt="image" src="https://github.com/user-attachments/assets/dffa4d3c-d62c-4497-a911-d8e7ce1b3114" />
