### PR TITLE
fix chest_minecart rotation on Minecraft 26+

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -545,6 +545,20 @@ public interface ViaVersionConfig extends Config {
     boolean use1_8HitboxMargin();
 
     /**
+     * If enabled, players on 26+ clients will see correct rotation of chest minecarts
+     *
+     * @return true if enabled
+     */
+    boolean isCorrectChestMinecartYaw();
+
+    /**
+     * Returns the rotation offset applied to chest minecarts for 26+ clients on older-version servers.
+     *
+     * @return yaw offset in degrees
+     */
+    float getChestMinecartYawOffset();
+
+    /**
      * If enabled, ViaVersion will send the native client version to the server on connect via a plugin message.
      *
      * @return true if enabled

--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -552,13 +552,6 @@ public interface ViaVersionConfig extends Config {
     boolean isCorrectChestMinecartYaw();
 
     /**
-     * Returns the rotation offset applied to chest minecarts for 26+ clients on older-version servers.
-     *
-     * @return yaw offset in degrees
-     */
-    float getChestMinecartYawOffset();
-
-    /**
      * If enabled, ViaVersion will send the native client version to the server on connect via a plugin message.
      *
      * @return true if enabled

--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -545,11 +545,11 @@ public interface ViaVersionConfig extends Config {
     boolean use1_8HitboxMargin();
 
     /**
-     * If enabled, players on 26+ clients will see correct rotation of chest minecarts
+     * If enabled, players on 26+ clients will see correct rotation of chests within chest minecarts
      *
      * @return true if enabled
      */
-    boolean isCorrectChestMinecartYaw();
+    boolean isCorrectChestMinecartOrientation();
 
     /**
      * If enabled, ViaVersion will send the native client version to the server on connect via a plugin message.

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -102,7 +102,6 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     private int maxErrorLength;
     private boolean use1_8HitboxMargin;
     private boolean correctChestMinecartYaw;
-    private float chestMinecartYawOffset;
 
     private boolean sendPlayerDetails;
     private boolean sendServerDetails;
@@ -181,7 +180,6 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
         cancelSwingInInventory = getBoolean("cancel-swing-in-inventory", true);
         use1_8HitboxMargin = getBoolean("use-1_8-hitbox-margin", true);
         correctChestMinecartYaw = getBoolean("correct-chest-minecart-yaw", true);
-        chestMinecartYawOffset = getFloat("chest-minecart-rotation-offset", 180.0f);
 
         sendPlayerDetails = getBoolean("send-player-details", true);
         sendServerDetails = getBoolean("send-server-details", true);
@@ -661,11 +659,6 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     @Override
     public boolean isCorrectChestMinecartYaw() {
         return correctChestMinecartYaw;
-    }
-
-    @Override
-    public float getChestMinecartYawOffset() {
-        return chestMinecartYawOffset;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -101,7 +101,7 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     private boolean cancelSwingInInventory;
     private int maxErrorLength;
     private boolean use1_8HitboxMargin;
-    private boolean correctChestMinecartYaw;
+    private boolean correctChestMinecartOrientation;
 
     private boolean sendPlayerDetails;
     private boolean sendServerDetails;
@@ -179,7 +179,7 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
         fix1_21PlacementRotation = getBoolean("fix-1_21-placement-rotation", true);
         cancelSwingInInventory = getBoolean("cancel-swing-in-inventory", true);
         use1_8HitboxMargin = getBoolean("use-1_8-hitbox-margin", true);
-        correctChestMinecartYaw = getBoolean("correct-chest-minecart-yaw", true);
+        correctChestMinecartOrientation = getBoolean("correct-chest-minecart-orientation", true);
 
         sendPlayerDetails = getBoolean("send-player-details", true);
         sendServerDetails = getBoolean("send-server-details", true);
@@ -657,8 +657,8 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     }
 
     @Override
-    public boolean isCorrectChestMinecartYaw() {
-        return correctChestMinecartYaw;
+    public boolean isCorrectChestMinecartOrientation() {
+        return correctChestMinecartOrientation;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -101,6 +101,9 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     private boolean cancelSwingInInventory;
     private int maxErrorLength;
     private boolean use1_8HitboxMargin;
+    private boolean correctChestMinecartYaw;
+    private float chestMinecartYawOffset;
+
     private boolean sendPlayerDetails;
     private boolean sendServerDetails;
 
@@ -177,6 +180,9 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
         fix1_21PlacementRotation = getBoolean("fix-1_21-placement-rotation", true);
         cancelSwingInInventory = getBoolean("cancel-swing-in-inventory", true);
         use1_8HitboxMargin = getBoolean("use-1_8-hitbox-margin", true);
+        correctChestMinecartYaw = getBoolean("correct-chest-minecart-yaw", true);
+        chestMinecartYawOffset = getFloat("chest-minecart-rotation-offset", 180.0f);
+
         sendPlayerDetails = getBoolean("send-player-details", true);
         sendServerDetails = getBoolean("send-server-details", true);
         packetTrackerConfig = loadRateLimitConfig(getSection("packet-limiter"), "%pps", 1);
@@ -650,6 +656,16 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     @Override
     public boolean use1_8HitboxMargin() {
         return use1_8HitboxMargin;
+    }
+
+    @Override
+    public boolean isCorrectChestMinecartYaw() {
+        return correctChestMinecartYaw;
+    }
+
+    @Override
+    public float getChestMinecartYawOffset() {
+        return chestMinecartYawOffset;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/rewriter/EntityPacketRewriter26_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/rewriter/EntityPacketRewriter26_1.java
@@ -50,9 +50,9 @@ public final class EntityPacketRewriter26_1 extends EntityRewriter<ClientboundPa
             wrapper.user().get(PlayerSneaking.class).setSneaking(pressingShift);
         });
 
-        // fixes chest_minecart rotation on Minecraft 26+
+        // Chests in minecarts are oriented the opposite direction now, 'fix' this by changing the yaw
         protocol.appendClientbound(ClientboundPackets1_21_11.ADD_ENTITY, wrapper -> {
-            if (!Via.getConfig().isCorrectChestMinecartYaw()) {
+            if (!Via.getConfig().isCorrectChestMinecartOrientation()) {
                 return;
             }
 
@@ -64,20 +64,23 @@ public final class EntityPacketRewriter26_1 extends EntityRewriter<ClientboundPa
             final byte yaw = wrapper.get(Types.BYTE, 1);
             wrapper.set(Types.BYTE, 1, (byte) (yaw + 128));
         });
-
-        // fixes chest_minecart rotation on Minecraft 26+ (position update)
         protocol.registerClientbound(ClientboundPackets1_21_11.ENTITY_POSITION_SYNC, wrapper -> {
-            final int entityId = wrapper.passthrough(Types.VAR_INT);
+            if (!Via.getConfig().isCorrectChestMinecartOrientation()) {
+                return;
+            }
 
+            final int entityId = wrapper.passthrough(Types.VAR_INT);
+            if (tracker(wrapper.user()).entityType(entityId) != EntityTypes1_21_11.CHEST_MINECART) {
+                return;
+            }
+
+            // Position and delta movement
             for (int i = 0; i < 6; i++) {
                 wrapper.passthrough(Types.DOUBLE);
             }
 
             float yaw = wrapper.read(Types.FLOAT);
-            if (Via.getConfig().isCorrectChestMinecartYaw() &&
-                tracker(wrapper.user()).entityType(entityId) == EntityTypes1_21_11.CHEST_MINECART) {
-                yaw += 180.0f;
-            }
+            yaw += 180.0f;
             wrapper.write(Types.FLOAT, yaw);
         });
 

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/rewriter/EntityPacketRewriter26_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/rewriter/EntityPacketRewriter26_1.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.v1_21_11to26_1.rewriter;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.minecraft.Vector3d;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_21_11;
@@ -51,13 +52,20 @@ public final class EntityPacketRewriter26_1 extends EntityRewriter<ClientboundPa
 
         // fixes chest_minecart rotation on Minecraft 26+
         protocol.appendClientbound(ClientboundPackets1_21_11.ADD_ENTITY, wrapper -> {
-            final int entityTypeId = wrapper.get(Types.VAR_INT, 1);
-
-            if (entityTypeId == EntityTypes1_21_11.CHEST_MINECART.getId()) {
-                final byte yaw = wrapper.get(Types.BYTE, 1);
-                final byte fixedYaw = (byte) (yaw + 128);
-                wrapper.set(Types.BYTE, 1, fixedYaw);
+            if (!Via.getConfig().isCorrectChestMinecartYaw()) {
+                return;
             }
+
+            final int entityTypeId = wrapper.get(Types.VAR_INT, 1);
+            if (!(entityTypeId == EntityTypes1_21_11.CHEST_MINECART.getId())) {
+                return;
+            }
+
+            final float offsetDegrees = Via.getConfig().getChestMinecartYawOffset();
+            final byte byteOffset = (byte) Math.round(offsetDegrees * 256.0f / 360.0f);
+
+            final byte yaw = wrapper.get(Types.BYTE, 1);
+            wrapper.set(Types.BYTE, 1, (byte) (yaw + byteOffset));
         });
 
         // fixes chest_minecart rotation on Minecraft 26+ (position update)
@@ -69,12 +77,11 @@ public final class EntityPacketRewriter26_1 extends EntityRewriter<ClientboundPa
             }
 
             float yaw = wrapper.read(Types.FLOAT);
-            if (tracker(wrapper.user()).entityType(entityId) == EntityTypes1_21_11.CHEST_MINECART) {
-                yaw += 180f;
+            if (Via.getConfig().isCorrectChestMinecartYaw() &&
+                tracker(wrapper.user()).entityType(entityId) == EntityTypes1_21_11.CHEST_MINECART) {
+                yaw += Via.getConfig().getChestMinecartYawOffset();
             }
             wrapper.write(Types.FLOAT, yaw);
-            wrapper.passthrough(Types.FLOAT);
-            wrapper.passthrough(Types.BOOLEAN);
         });
 
         protocol.registerServerbound(ServerboundPackets26_1.INTERACT, wrapper -> {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/rewriter/EntityPacketRewriter26_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/rewriter/EntityPacketRewriter26_1.java
@@ -57,15 +57,12 @@ public final class EntityPacketRewriter26_1 extends EntityRewriter<ClientboundPa
             }
 
             final int entityTypeId = wrapper.get(Types.VAR_INT, 1);
-            if (!(entityTypeId == EntityTypes1_21_11.CHEST_MINECART.getId())) {
+            if (entityTypeId != EntityTypes1_21_11.CHEST_MINECART.getId()) {
                 return;
             }
 
-            final float offsetDegrees = Via.getConfig().getChestMinecartYawOffset();
-            final byte byteOffset = (byte) Math.round(offsetDegrees * 256.0f / 360.0f);
-
             final byte yaw = wrapper.get(Types.BYTE, 1);
-            wrapper.set(Types.BYTE, 1, (byte) (yaw + byteOffset));
+            wrapper.set(Types.BYTE, 1, (byte) (yaw + 128));
         });
 
         // fixes chest_minecart rotation on Minecraft 26+ (position update)
@@ -79,7 +76,7 @@ public final class EntityPacketRewriter26_1 extends EntityRewriter<ClientboundPa
             float yaw = wrapper.read(Types.FLOAT);
             if (Via.getConfig().isCorrectChestMinecartYaw() &&
                 tracker(wrapper.user()).entityType(entityId) == EntityTypes1_21_11.CHEST_MINECART) {
-                yaw += Via.getConfig().getChestMinecartYawOffset();
+                yaw += 180.0f;
             }
             wrapper.write(Types.FLOAT, yaw);
         });

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/rewriter/EntityPacketRewriter26_1.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_11to26_1/rewriter/EntityPacketRewriter26_1.java
@@ -48,6 +48,35 @@ public final class EntityPacketRewriter26_1 extends EntityRewriter<ClientboundPa
             final boolean pressingShift = (flags & 1 << 5) != 0;
             wrapper.user().get(PlayerSneaking.class).setSneaking(pressingShift);
         });
+
+        // fixes chest_minecart rotation on Minecraft 26+
+        protocol.appendClientbound(ClientboundPackets1_21_11.ADD_ENTITY, wrapper -> {
+            final int entityTypeId = wrapper.get(Types.VAR_INT, 1);
+
+            if (entityTypeId == EntityTypes1_21_11.CHEST_MINECART.getId()) {
+                final byte yaw = wrapper.get(Types.BYTE, 1);
+                final byte fixedYaw = (byte) (yaw + 128);
+                wrapper.set(Types.BYTE, 1, fixedYaw);
+            }
+        });
+
+        // fixes chest_minecart rotation on Minecraft 26+ (position update)
+        protocol.registerClientbound(ClientboundPackets1_21_11.ENTITY_POSITION_SYNC, wrapper -> {
+            final int entityId = wrapper.passthrough(Types.VAR_INT);
+
+            for (int i = 0; i < 6; i++) {
+                wrapper.passthrough(Types.DOUBLE);
+            }
+
+            float yaw = wrapper.read(Types.FLOAT);
+            if (tracker(wrapper.user()).entityType(entityId) == EntityTypes1_21_11.CHEST_MINECART) {
+                yaw += 180f;
+            }
+            wrapper.write(Types.FLOAT, yaw);
+            wrapper.passthrough(Types.FLOAT);
+            wrapper.passthrough(Types.BOOLEAN);
+        });
+
         protocol.registerServerbound(ServerboundPackets26_1.INTERACT, wrapper -> {
             final int entityId = wrapper.passthrough(Types.VAR_INT);
             wrapper.write(Types.VAR_INT, 0); // Interact

--- a/common/src/main/java/com/viaversion/viaversion/util/ConfigSection.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ConfigSection.java
@@ -90,10 +90,6 @@ public class ConfigSection {
         return this.values.get(key) instanceof final Number num ? num.doubleValue() : def;
     }
 
-    public float getFloat(final String key, final float def) {
-        return this.values.get(key) instanceof final Number num ? num.floatValue() : def;
-    }
-
     public List<Integer> getIntegerList(final String key) {
         final Object o = this.values.get(key);
         return o != null ? (List<Integer>) o : new ArrayList<>();

--- a/common/src/main/java/com/viaversion/viaversion/util/ConfigSection.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ConfigSection.java
@@ -90,6 +90,10 @@ public class ConfigSection {
         return this.values.get(key) instanceof final Number num ? num.doubleValue() : def;
     }
 
+    public float getFloat(final String key, final float def) {
+        return this.values.get(key) instanceof final Number num ? num.floatValue() : def;
+    }
+
     public List<Integer> getIntegerList(final String key) {
         final Object o = this.values.get(key);
         return o != null ? (List<Integer>) o : new ArrayList<>();

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -250,5 +250,3 @@ cancel-block-sounds: true
 use-1_8-hitbox-margin: true
 # If enabled, chest minecart rotation will be corrected for 26+ clients on older-version servers.
 correct-chest-minecart-yaw: true
-# Rotation offset in degrees applied to chest minecarts when the fix above is enabled (180 matches the vanilla rendering offset)
-chest-minecart-rotation-offset: 180.0

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -248,3 +248,7 @@ left-handed-handling: true
 cancel-block-sounds: true
 # If enabled, 1.21.11+ clients on 1.8 servers will get wider entity hitboxes when attacking with items
 use-1_8-hitbox-margin: true
+# If enabled, chest minecart rotation will be corrected for 26+ clients on older-version servers.
+correct-chest-minecart-yaw: true
+# Rotation offset in degrees applied to chest minecarts when the fix above is enabled (180 matches the vanilla rendering offset)
+chest-minecart-rotation-offset: 180.0

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -203,6 +203,9 @@ fix-1_21-placement-rotation: true
 # If enabled, cancel swing packets sent while having an inventory opened on 1.15.2 and below servers. This can cause false positives with anti-cheat plugins.
 cancel-swing-in-inventory: true
 #
+# If enabled, chest minecart rotation will be corrected for 26+ clients on older servers.
+correct-chest-minecart-orientation: true
+#
 #----------------------------------------------------------#
 #             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #
 #----------------------------------------------------------#
@@ -248,5 +251,3 @@ left-handed-handling: true
 cancel-block-sounds: true
 # If enabled, 1.21.11+ clients on 1.8 servers will get wider entity hitboxes when attacking with items
 use-1_8-hitbox-margin: true
-# If enabled, chest minecart rotation will be corrected for 26+ clients on older-version servers.
-correct-chest-minecart-yaw: true


### PR DESCRIPTION
After the 1.21.11 version, there was an issue with chest minecarts' rotation. Now the rotation is applied correctly according to the entity's actual position. This visual bug affected **only chest minecarts**. 

The yaw was always off by 180° - represented as +128 (byte angle) in ADD_ENTITY and +180f (float degrees) in ENTITY_POSITION_SYNC.

The fix was made by adding 2 packets into EntityPacketRewriter26_1.java:
**ADD_ENTITY** - corrects the initial rotation when the minecart is spawned.
**ENTITY_POSITION_SYNC** - corrects the rotation on every position update


**Comparison** 
without my fix:
<img width="1422" height="945" alt="1" src="https://github.com/user-attachments/assets/f1ea987a-bd03-47d1-a2d4-7f88e3322ab7" />

with fix:
<img width="1580" height="978" alt="2" src="https://github.com/user-attachments/assets/f3976e02-f73c-4a9b-90cd-2da185769e01" />


