### PR TITLE
fix: skip empty items in convertItemList to prevent air serialization…

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_3to1_20_5/rewriter/StructuredDataConverter.java
@@ -798,6 +798,9 @@ public final class StructuredDataConverter {
         final ListTag<CompoundTag> itemsTag = new ListTag<>(CompoundTag.class);
         for (int i = 0; i < items.length; i++) {
             final Item item = items[i];
+            if (item == null || item.isEmpty()) {
+                continue;
+            }
             final CompoundTag savedItem = itemToTag(connection, item);
             // 1.20.4 clients need the Slot to display the item correctly
             if (backupInconvertibleData) {


### PR DESCRIPTION
… errors

Previously, convertItemList wrote all slots including null/empty items to NBT as "minecraft:air" with a Slot tag. On 1.21+ servers, this caused TypedEntityData serialization errors because air is no longer valid in item compound data. Empty items are already filtered out when reading back via itemFromTag (returns empty → filtered by isEmpty check), so skipping them during write is safe and changes no behavior.