### PR TITLE
Allow servers predating data components to declare them via legacy nbt

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -550,7 +550,7 @@ public interface ViaVersionConfig extends Config {
      *
      * @return true if enabled
      */
-    boolean convertLegacyComponentNbt();
+default boolean convertLegacyComponentNbt() { return false; }
 
     /**
      * If enabled, ViaVersion will send the native client version to the server on connect via a plugin message.

--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -545,6 +545,14 @@ public interface ViaVersionConfig extends Config {
     boolean use1_8HitboxMargin();
 
     /**
+     * If enabled, data components declared by servers older than the version that added them are read from a
+     * {@code VV|components} sub-tag of the item's legacy nbt and sent to the client.
+     *
+     * @return true if enabled
+     */
+    boolean convertLegacyComponentNbt();
+
+    /**
      * If enabled, ViaVersion will send the native client version to the server on connect via a plugin message.
      *
      * @return true if enabled

--- a/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
+++ b/common/src/main/java/com/viaversion/viaversion/configuration/AbstractViaConfig.java
@@ -101,6 +101,7 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     private boolean cancelSwingInInventory;
     private int maxErrorLength;
     private boolean use1_8HitboxMargin;
+    private boolean convertLegacyComponentNbt;
     private boolean sendPlayerDetails;
     private boolean sendServerDetails;
 
@@ -177,6 +178,7 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
         fix1_21PlacementRotation = getBoolean("fix-1_21-placement-rotation", true);
         cancelSwingInInventory = getBoolean("cancel-swing-in-inventory", true);
         use1_8HitboxMargin = getBoolean("use-1_8-hitbox-margin", true);
+        convertLegacyComponentNbt = getBoolean("convert-legacy-component-nbt", false);
         sendPlayerDetails = getBoolean("send-player-details", true);
         sendServerDetails = getBoolean("send-server-details", true);
         packetTrackerConfig = loadRateLimitConfig(getSection("packet-limiter"), "%pps", 1);
@@ -650,6 +652,11 @@ public class AbstractViaConfig extends Config implements ViaVersionConfig {
     @Override
     public boolean use1_8HitboxMargin() {
         return use1_8HitboxMargin;
+    }
+
+    @Override
+    public boolean convertLegacyComponentNbt() {
+        return convertLegacyComponentNbt;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/BlockItemPacketRewriter1_21_2.java
@@ -23,6 +23,7 @@ import com.viaversion.nbt.tag.IntArrayTag;
 import com.viaversion.nbt.tag.ListTag;
 import com.viaversion.nbt.tag.StringTag;
 import com.viaversion.nbt.tag.Tag;
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.FullMappings;
 import com.viaversion.viaversion.api.data.MappingData;
@@ -471,6 +472,11 @@ public final class BlockItemPacketRewriter1_21_2 extends StructuredItemRewriter<
                 data.set(StructuredDataKey.CUSTOM_NAME, name);
                 saveTag(createCustomTag(item), new ByteTag(true), "remove_custom_name");
             }
+        }
+
+        // Data components declared as legacy nbt by servers that predate them
+        if (Via.getConfig().convertLegacyComponentNbt()) {
+            LegacyComponentConverter.convertLegacyComponents(item);
         }
         return item;
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/LegacyComponentConverter.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21to1_21_2/rewriter/LegacyComponentConverter.java
@@ -1,0 +1,152 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter;
+
+import com.viaversion.nbt.tag.CompoundTag;
+import com.viaversion.nbt.tag.NumberTag;
+import com.viaversion.nbt.tag.Tag;
+import com.viaversion.viaversion.api.minecraft.Holder;
+import com.viaversion.viaversion.api.minecraft.SoundEvent;
+import com.viaversion.viaversion.api.minecraft.data.StructuredDataContainer;
+import com.viaversion.viaversion.api.minecraft.data.StructuredDataKey;
+import com.viaversion.viaversion.api.minecraft.item.Item;
+import com.viaversion.viaversion.api.minecraft.item.data.EnumTypes;
+import com.viaversion.viaversion.api.minecraft.item.data.Equippable;
+import com.viaversion.viaversion.util.Key;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Converts data components declared as legacy nbt by servers older than the version that added them.
+ * <p>
+ * {@link com.viaversion.viaversion.protocols.v1_20_3to1_20_5.rewriter.BlockItemPacketRewriter1_20_5} converts
+ * legacy nbt into the data components that have a legacy equivalent. Components added afterwards have none, so
+ * servers predating them cannot express them at all. This reads them from a {@value #COMPONENTS_TAG} sub-tag of
+ * the item's legacy nbt instead, using the same field names as the vanilla component definitions.
+ * <p>
+ * This is the inverse of {@link com.viaversion.viaversion.protocols.v1_20_3to1_20_5.rewriter.StructuredDataConverter},
+ * and belongs in the protocol that first supports the components it converts.
+ */
+public final class LegacyComponentConverter {
+
+    /**
+     * Sub-tag of the item's legacy nbt holding data components, keyed by their vanilla identifier.
+     */
+    public static final String COMPONENTS_TAG = "VV|components";
+
+    private static final Holder<SoundEvent> DEFAULT_EQUIP_SOUND = Holder.of(new SoundEvent("minecraft:item.armor.equip_generic", null));
+    private static final Holder<SoundEvent> DEFAULT_SHEARING_SOUND = Holder.of(new SoundEvent("minecraft:item.shears.snip", null));
+
+    private static final Map<String, BiConsumer<CompoundTag, StructuredDataContainer>> CONVERTERS = new HashMap<>();
+
+    static {
+        register("equippable", LegacyComponentConverter::convertEquippable);
+    }
+
+    private LegacyComponentConverter() {
+    }
+
+    /**
+     * Adds data components declared in the item's legacy nbt. Unknown or malformed entries are ignored.
+     *
+     * @param item non-empty item, already converted to data components
+     */
+    public static void convertLegacyComponents(final Item item) {
+        final StructuredDataContainer container = item.dataContainer();
+        final CompoundTag customData = container.get(StructuredDataKey.CUSTOM_DATA);
+        if (customData == null) {
+            return;
+        }
+
+        final CompoundTag components = customData.getCompoundTag(COMPONENTS_TAG);
+        if (components == null) {
+            return;
+        }
+
+        // Note that the tag is deliberately left in custom_data: it holds the original legacy nbt, which is
+        // handed back to the backend server as-is in serverbound item packets. Removing it here would make
+        // the server see the item lose data as soon as the client moves it.
+        for (final Map.Entry<String, Tag> entry : components.entrySet()) {
+            if (!(entry.getValue() instanceof CompoundTag componentTag)) {
+                continue;
+            }
+
+            final BiConsumer<CompoundTag, StructuredDataContainer> converter = CONVERTERS.get(Key.stripMinecraftNamespace(entry.getKey()));
+            if (converter != null) {
+                converter.accept(componentTag, container);
+            }
+        }
+    }
+
+    private static void convertEquippable(final CompoundTag tag, final StructuredDataContainer container) {
+        final String slotName = tag.getString("slot");
+        if (slotName == null) {
+            return;
+        }
+
+        // idFromName falls back to the first entry for unknown names, so check the slot actually exists
+        final int slot = EnumTypes.EQUIPMENT_SLOT.idFromName(slotName);
+        if (!EnumTypes.EQUIPMENT_SLOT.nameFromId(slot).equals(slotName)) {
+            return;
+        }
+
+        final String assetId = tag.getString("asset_id");
+        if (assetId != null && !Key.isValid(assetId)) {
+            // Would throw in the 1.21.5+ hash codec, which is far away from here
+            return;
+        }
+
+        final String cameraOverlay = tag.getString("camera_overlay");
+        if (cameraOverlay != null && !Key.isValid(cameraOverlay)) {
+            return;
+        }
+
+        // allowed_entities is not supported; it would need entity registry resolution at this point
+        container.set(StructuredDataKey.EQUIPPABLE1_21_2, new Equippable(
+            slot,
+            soundEvent(tag.getString("equip_sound"), DEFAULT_EQUIP_SOUND),
+            assetId,
+            cameraOverlay,
+            null,
+            getBoolean(tag, "dispensable", true),
+            getBoolean(tag, "swappable", true),
+            getBoolean(tag, "damage_on_hurt", true),
+            getBoolean(tag, "equip_on_interact", false),
+            getBoolean(tag, "can_be_sheared", false),
+            soundEvent(tag.getString("shearing_sound"), DEFAULT_SHEARING_SOUND)
+        ));
+    }
+
+    private static void register(final String identifier, final BiConsumer<CompoundTag, StructuredDataContainer> converter) {
+        CONVERTERS.put(identifier, converter);
+    }
+
+    /**
+     * Direct holders pass through the sound rewriting of later protocols untouched, unlike registry ids, which
+     * would have to be in this protocol's mapped sound id space.
+     */
+    private static Holder<SoundEvent> soundEvent(final String identifier, final Holder<SoundEvent> defaultValue) {
+        return identifier != null && Key.isValid(identifier) ? Holder.of(new SoundEvent(identifier, null)) : defaultValue;
+    }
+
+    private static boolean getBoolean(final CompoundTag tag, final String key, final boolean defaultValue) {
+        final NumberTag value = tag.getNumberTag(key);
+        return value != null ? value.asInt() != 0 : defaultValue;
+    }
+}

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -248,3 +248,7 @@ left-handed-handling: true
 cancel-block-sounds: true
 # If enabled, 1.21.11+ clients on 1.8 servers will get wider entity hitboxes when attacking with items
 use-1_8-hitbox-margin: true
+# Lets servers older than 1.21.2 declare data components that have no legacy nbt equivalent, by writing them to a
+# "VV|components" sub-tag of the item's nbt using the vanilla component field names. Only minecraft:equippable is
+# supported so far. The tag is left untouched on its way back to the server.
+convert-legacy-component-nbt: false

--- a/common/src/test/java/com/viaversion/viaversion/common/item/LegacyComponentConverterTest.java
+++ b/common/src/test/java/com/viaversion/viaversion/common/item/LegacyComponentConverterTest.java
@@ -1,0 +1,176 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.common.item;
+
+import com.viaversion.nbt.tag.CompoundTag;
+import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.minecraft.data.StructuredDataKey;
+import com.viaversion.viaversion.api.minecraft.item.Item;
+import com.viaversion.viaversion.api.minecraft.item.StructuredItem;
+import com.viaversion.viaversion.api.minecraft.item.data.Equippable;
+import com.viaversion.viaversion.api.protocol.Protocol;
+import com.viaversion.viaversion.common.PlatformTestBase;
+import com.viaversion.viaversion.protocols.v1_21to1_21_2.Protocol1_21To1_21_2;
+import com.viaversion.viaversion.protocols.v1_21to1_21_2.rewriter.LegacyComponentConverter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class LegacyComponentConverterTest extends PlatformTestBase {
+
+    private static Protocol<?, ?, ?, ?> protocol;
+
+    @BeforeAll
+    static void loadProtocol() {
+        protocol = Via.getManager().getProtocolManager().getProtocol(Protocol1_21To1_21_2.class);
+    }
+
+    private static Item itemWithComponentNbt(final CompoundTag components) {
+        final Item item = new StructuredItem(1, 1);
+        item.dataContainer().setIdLookup(protocol, true);
+
+        final CompoundTag customData = new CompoundTag();
+        customData.put(LegacyComponentConverter.COMPONENTS_TAG, components);
+        item.dataContainer().set(StructuredDataKey.CUSTOM_DATA, customData);
+        return item;
+    }
+
+    private static CompoundTag equippableTag(final String slot, final String assetId) {
+        final CompoundTag equippable = new CompoundTag();
+        if (slot != null) {
+            equippable.putString("slot", slot);
+        }
+        if (assetId != null) {
+            equippable.putString("asset_id", assetId);
+        }
+
+        final CompoundTag components = new CompoundTag();
+        components.put("equippable", equippable);
+        return components;
+    }
+
+    @Test
+    void testEquippableDefaults() {
+        final Item item = itemWithComponentNbt(equippableTag("chest", "example:test_armor"));
+        LegacyComponentConverter.convertLegacyComponents(item);
+
+        final Equippable equippable = item.dataContainer().get(StructuredDataKey.EQUIPPABLE1_21_2);
+        Assertions.assertNotNull(equippable, "equippable was not converted");
+        Assertions.assertEquals(3, equippable.equipmentSlot(), "chest should map to slot 3");
+        Assertions.assertEquals("example:test_armor", equippable.model(), "asset_id mismatch");
+        Assertions.assertTrue(equippable.dispensable());
+        Assertions.assertTrue(equippable.swappable());
+        Assertions.assertTrue(equippable.damageOnHurt());
+        Assertions.assertFalse(equippable.equipOnInteract());
+        Assertions.assertFalse(equippable.canBeSheared());
+        Assertions.assertTrue(equippable.soundEvent().isDirect(), "equip sound should be a direct holder");
+        Assertions.assertEquals("minecraft:item.armor.equip_generic", equippable.soundEvent().value().identifier());
+    }
+
+    @Test
+    void testExplicitFields() {
+        final CompoundTag components = equippableTag("head", "example:test_helmet");
+        final CompoundTag equippableTag = components.getCompoundTag("equippable");
+        equippableTag.putBoolean("dispensable", false);
+        equippableTag.putBoolean("equip_on_interact", true);
+        equippableTag.putString("equip_sound", "minecraft:item.armor.equip_iron");
+        equippableTag.putString("camera_overlay", "example:overlay");
+
+        final Item item = itemWithComponentNbt(components);
+        LegacyComponentConverter.convertLegacyComponents(item);
+
+        final Equippable equippable = item.dataContainer().get(StructuredDataKey.EQUIPPABLE1_21_2);
+        Assertions.assertNotNull(equippable);
+        Assertions.assertEquals(4, equippable.equipmentSlot(), "head should map to slot 4");
+        Assertions.assertFalse(equippable.dispensable());
+        Assertions.assertTrue(equippable.equipOnInteract());
+        Assertions.assertEquals("minecraft:item.armor.equip_iron", equippable.soundEvent().value().identifier());
+        Assertions.assertEquals("example:overlay", equippable.cameraOverlay());
+    }
+
+    @Test
+    void testUnknownSlotIsIgnored() {
+        // idFromName falls back to the first entry, so an unknown slot must not silently become mainhand
+        final Item item = itemWithComponentNbt(equippableTag("definitely_not_a_slot", "example:test_armor"));
+        LegacyComponentConverter.convertLegacyComponents(item);
+
+        Assertions.assertNull(item.dataContainer().get(StructuredDataKey.EQUIPPABLE1_21_2), "unknown slot should be ignored");
+    }
+
+    @Test
+    void testInvalidAssetIdIsIgnored() {
+        final Item item = itemWithComponentNbt(equippableTag("chest", "Not A Valid Key"));
+        LegacyComponentConverter.convertLegacyComponents(item);
+
+        Assertions.assertNull(item.dataContainer().get(StructuredDataKey.EQUIPPABLE1_21_2), "invalid asset_id should be ignored");
+    }
+
+    @Test
+    void testMissingSlotIsIgnored() {
+        final Item item = itemWithComponentNbt(equippableTag(null, "example:test_armor"));
+        LegacyComponentConverter.convertLegacyComponents(item);
+
+        Assertions.assertNull(item.dataContainer().get(StructuredDataKey.EQUIPPABLE1_21_2), "missing slot should be ignored");
+    }
+
+    @Test
+    void testUnknownComponentIsIgnored() {
+        final CompoundTag components = new CompoundTag();
+        components.put("definitely_not_a_component", new CompoundTag());
+
+        final Item item = itemWithComponentNbt(components);
+        Assertions.assertDoesNotThrow(() -> LegacyComponentConverter.convertLegacyComponents(item));
+    }
+
+    @Test
+    void testUnnamespacedTagIsIgnored() {
+        // Only the namespaced key is read; a plain "components" tag is not part of the contract
+        final Item item = new StructuredItem(1, 1);
+        item.dataContainer().setIdLookup(protocol, true);
+
+        final CompoundTag customData = new CompoundTag();
+        customData.put("components", equippableTag("chest", "example:test_armor"));
+        item.dataContainer().set(StructuredDataKey.CUSTOM_DATA, customData);
+
+        LegacyComponentConverter.convertLegacyComponents(item);
+
+        Assertions.assertNull(item.dataContainer().get(StructuredDataKey.EQUIPPABLE1_21_2),
+            "only " + LegacyComponentConverter.COMPONENTS_TAG + " should be read");
+    }
+
+    @Test
+    void testItemWithoutCustomDataIsUntouched() {
+        final Item item = new StructuredItem(1, 1);
+        item.dataContainer().setIdLookup(protocol, true);
+
+        Assertions.assertDoesNotThrow(() -> LegacyComponentConverter.convertLegacyComponents(item));
+        Assertions.assertNull(item.dataContainer().get(StructuredDataKey.EQUIPPABLE1_21_2));
+    }
+
+    @Test
+    void testComponentNbtIsLeftInCustomData() {
+        // The legacy nbt is handed back to the backend server as-is, so it must survive the conversion
+        final Item item = itemWithComponentNbt(equippableTag("legs", "example:test_leggings"));
+        LegacyComponentConverter.convertLegacyComponents(item);
+
+        final CompoundTag customData = item.dataContainer().get(StructuredDataKey.CUSTOM_DATA);
+        Assertions.assertNotNull(customData);
+        Assertions.assertNotNull(customData.getCompoundTag(LegacyComponentConverter.COMPONENTS_TAG),
+            "the component nbt must stay in custom_data for the serverbound path");
+    }
+}


### PR DESCRIPTION
Closes #5018

## Problem

`BlockItemPacketRewriter1_20_5#toStructuredItem` converts legacy item nbt into the data components that
have a legacy equivalent: `display.*`, `Damage`, `CustomModelData`, `Trim`, `SkullOwner`,
`AttributeModifiers` and so on. That conversion is complete for everything that ever existed as nbt.

Components introduced after 1.20.5 have no legacy ancestor, so servers older than that cannot express
them at all. There is no key to convert from, and unrecognised nbt ends up in `minecraft:custom_data`,
which the client only surfaces in tooltips.

## Solution

An opt-in `VV|components` sub-tag of the item's legacy nbt, holding data components keyed by their
vanilla identifier and using the vanilla field names:

```
tag: {
    "VV|components": {
        equippable: {
            slot: "chest",
            asset_id: "example:my_armor"
        }
    }
}
```

`LegacyComponentConverter` is the inverse of the existing `StructuredDataConverter` and lives in the
protocol that first supports the components it converts. That also gates it: `v1_21to1_21_2` only runs
for servers older than 1.21.2, so no explicit `serverProtocolVersion` check is needed.

Only `minecraft:equippable` is converted so far. The converters are a table, so supporting further
components is one line plus a parse method. I kept it to one rather than guessing which others are
wanted.

## Notes for review

- **Opt-in.** `convert-legacy-component-nbt` defaults to `false`. When disabled the cost is one boolean
  field read per item.
- **The serverbound path needs no new code.** `EQUIPPABLE1_21_2` is already in `NEW_DATA_TO_REMOVE`, so
  `downgradeItemData` strips it before the item reaches `toOldItem`. The backend server never sees the
  component.
- **The nbt is deliberately left in `custom_data`.** That tag is the original legacy nbt handed back to
  the server verbatim by `toOldItem`'s short-circuit. Removing it would make the server see the item
  lose data as soon as the client moved it. `testComponentNbtIsLeftInCustomData` covers this.
- **No per-version work.** The existing `replaceKey` chain carries `EQUIPPABLE1_21_2` to
  `EQUIPPABLE1_21_5` to `EQUIPPABLE1_21_6`.
- **Sounds use direct holders**, so later protocols' sound rewriting passes them through unchanged
  rather than remapping a numeric id out of this protocol's id space.
- `allowed_entities` is not supported, since it would need entity registry resolution at this point.

## Tests

9 tests in `LegacyComponentConverterTest`, covering the defaults, explicit fields, the nbt surviving in
`custom_data`, and the rejection paths:

- unknown slot, which matters because `EnumType#idFromName` falls back to the first entry, so a typo
  would otherwise silently equip to `mainhand`
- invalid `asset_id`, which would otherwise throw in the 1.21.5+ hash codec, far from where it was set
- missing slot, unknown component, unnamespaced tag, and items without `custom_data`

Also verified in-game on a 1.8.9 backend with a 1.21.11 client: the component reaches the client and
renders on the player model, using an `asset_id` from a resource pack that renders identically when
given directly on a vanilla 1.21.11 client.

## Alternatives considered

- **A `Provider` hook** so implementations supply the components themselves. Smaller in-tree, with
  precedent in `SignableCommandArgumentsProvider` (#3493), but it pushes the legacy nbt contract onto
  every consumer and adds API surface for a single caller.
- **Adding `equippable` to `toStructuredItem`'s allowlist.** Wrong layer: the key does not exist in the
  1.20.5 component set and the container's id lookup is in 1.20.5 space there.
- **Reusing `VV|DataComponents`.** That is ViaBackwards' backup format for data lost on the way down,
  with ad-hoc per-component shapes, and it is write-only in this repository since the restore lives in
  ViaBackwards. Conflating the two looked likely to collide when both are in the pipeline.
