### PR TITLE
Synchronize EntityTrackerBase entity map to prevent concurrent-access crash

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/data/entity/EntityTrackerBase.java
+++ b/common/src/main/java/com/viaversion/viaversion/data/entity/EntityTrackerBase.java
@@ -30,6 +30,7 @@ import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.util.Key;
 import com.viaversion.viaversion.util.KeyMappings;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,7 +38,8 @@ import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class EntityTrackerBase implements EntityTracker, ClientEntityIdChangeListener {
-    protected final Int2ObjectMap<TrackedEntity> entities = new Int2ObjectOpenHashMap<>();
+    // Synchronized as the tracker may be accessed concurrently from multiple threads
+    protected final Int2ObjectMap<TrackedEntity> entities = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
     private final Map<String, KeyMappings> registryKeyMappings = new HashMap<>();
     private final UserConnection connection;
     private final EntityType playerType;


### PR DESCRIPTION
Ran into a crash where the `entities` map in `EntityTrackerBase` gets touched from more than one thread and corrupts during a rehash. It throws an out of bounds exception that turns into an `EncoderException` and kicks the player.

```
java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 65
    at it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap...
    at ...EntityTrackerBase...
    (becomes) io.netty.handler.codec.EncoderException
```

It showed up for me running Via alongside GrimAC, since it bundles PacketEvents which can hit the tracker off the main packet thread. In my case only the older (pre-26.2) clients going through translation got kicked.

The fix just wraps the map with `Int2ObjectMaps.synchronize(...)` so access is serialized. I know the tracker is normally treated as single threaded, so this might be considered the other plugin's problem, but a synchronized wrapper is cheap and it kills a crash that was a pain to track down.
