### PR TITLE
Use instanceof check in ConfigSection#getSerializedComponent

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/util/ConfigSection.java
+++ b/common/src/main/java/com/viaversion/viaversion/util/ConfigSection.java
@@ -117,12 +117,10 @@ public class ConfigSection {
     }
 
     public @Nullable JsonElement getSerializedComponent(final String key) {
-        final Object o = this.values.get(key);
-        if (o != null && !((String) o).isEmpty()) {
-            return ComponentUtil.legacyToJson((String) o);
-        } else {
-            return null;
+        if (this.values.get(key) instanceof final String s && !s.isEmpty()) {
+            return ComponentUtil.legacyToJson(s);
         }
+        return null;
     }
 
     public @Nullable ConfigSection getSection(final String key) {


### PR DESCRIPTION
`getSerializedComponent` casts the value to `String` directly without checking the type. Other getter methods in the same class (`getString`, `getInt`, etc.) already use `instanceof` to guard against wrong types.

If a config has a non-String value for the key, this method would throw `ClassCastException`. Aligned it with the pattern used by the other getters.