### PR TITLE
Improve hide-scoreboard-numbers to only work for sidebar

### DIFF
--- a/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
+++ b/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java
@@ -508,7 +508,7 @@ public interface ViaVersionConfig extends Config {
     boolean cancelBlockSounds();
 
     /**
-     * Hides scoreboard numbers for 1.20.3+ clients on older server versions.
+     * Hides sidebar scoreboard numbers for 1.20.3+ clients on older server versions.
      *
      * @return true if enabled
      */

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viaversion.protocols.v1_20_2to1_20_3;
 
+import com.viaversion.nbt.tag.Tag;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.MappingData;
@@ -33,6 +34,7 @@ import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_20_2;
 import com.viaversion.viaversion.api.type.types.misc.ParticleType;
 import com.viaversion.viaversion.api.type.types.version.Types1_20_3;
+import com.viaversion.viaversion.connection.ProtocolStorablesBase;
 import com.viaversion.viaversion.data.entity.EntityTrackerBase;
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.packet.ClientboundConfigurationPackets1_20_3;
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.packet.ClientboundPacket1_20_3;
@@ -41,6 +43,8 @@ import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.packet.ServerboundPac
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.packet.ServerboundPackets1_20_3;
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.rewriter.BlockItemPacketRewriter1_20_3;
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.rewriter.EntityPacketRewriter1_20_3;
+import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.storage.ProtocolStorables1_20_3;
+import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.storage.ScoreboardStorage;
 import com.viaversion.viaversion.protocols.v1_20to1_20_2.packet.ClientboundConfigurationPackets1_20_2;
 import com.viaversion.viaversion.protocols.v1_20to1_20_2.packet.ClientboundPacket1_20_2;
 import com.viaversion.viaversion.protocols.v1_20to1_20_2.packet.ClientboundPackets1_20_2;
@@ -96,17 +100,28 @@ public final class Protocol1_20_2To1_20_3 extends AbstractProtocol<ClientboundPa
             wrapper.write(Types.BOOLEAN, false);
         });
         registerClientbound(ClientboundPackets1_20_2.SET_OBJECTIVE, wrapper -> {
-            wrapper.passthrough(Types.STRING); // Objective Name
+            final String objectiveName = wrapper.passthrough(Types.STRING); // Objective Name
             final byte action = wrapper.passthrough(Types.BYTE); // Method
+            final ScoreboardStorage scoreboard = wrapper.user().<ProtocolStorables1_20_3>storables(this).scoreboard();
             if (action == 0 || action == 2) {
-                convertComponent(wrapper); // Display Name
+                final Tag displayName = ComponentUtil.jsonToTag(wrapper.read(Types.COMPONENT));
+                wrapper.write(Types.TRUSTED_TAG, displayName); // Display Name
                 final int render = wrapper.passthrough(Types.VAR_INT); // Render type
-                if (render == 0 && Via.getConfig().hideScoreboardNumbers()) { // 0 = "integer", 1 = "hearts"
-                    wrapper.write(Types.BOOLEAN, true); // has number format
-                    wrapper.write(Types.VAR_INT, 0); // Blank format
-                } else {
-                    wrapper.write(Types.BOOLEAN, false); // has number format
-                }
+                final boolean hideNumberFormat = shouldHideNumberFormat(scoreboard, objectiveName, render);
+                writeNumberFormat(wrapper, hideNumberFormat);
+                scoreboard.putObjective(objectiveName, displayName.copy(), render, hideNumberFormat);
+            } else if (action == 1) {
+                scoreboard.removeObjective(objectiveName);
+            }
+        });
+        registerClientbound(ClientboundPackets1_20_2.SET_DISPLAY_OBJECTIVE, wrapper -> {
+            final int slot = wrapper.passthrough(Types.VAR_INT);
+            final String objectiveName = wrapper.passthrough(Types.STRING);
+            final ScoreboardStorage scoreboard = wrapper.user().<ProtocolStorables1_20_3>storables(this).scoreboard();
+            final String previousObjective = scoreboard.setDisplaySlot(slot, objectiveName);
+            updateNumberFormat(wrapper, scoreboard, previousObjective);
+            if (!objectiveName.equals(previousObjective)) {
+                updateNumberFormat(wrapper, scoreboard, objectiveName);
             }
         });
 
@@ -335,6 +350,42 @@ public final class Protocol1_20_2To1_20_3 extends AbstractProtocol<ClientboundPa
         wrapper.write(Types.TRUSTED_OPTIONAL_TAG, ComponentUtil.jsonToTag(wrapper.read(Types.OPTIONAL_COMPONENT)));
     }
 
+    private static boolean shouldHideNumberFormat(final ScoreboardStorage scoreboard, final String objectiveName, final int renderType) {
+        return renderType == 0 && Via.getConfig().hideScoreboardNumbers() && scoreboard.isSidebar(objectiveName);
+    }
+
+    private static void writeNumberFormat(final PacketWrapper wrapper, final boolean hideNumberFormat) {
+        wrapper.write(Types.BOOLEAN, hideNumberFormat); // Has number format
+        if (hideNumberFormat) {
+            wrapper.write(Types.VAR_INT, 0); // Blank format
+        }
+    }
+
+    private static void updateNumberFormat(final PacketWrapper wrapper, final ScoreboardStorage scoreboard, final String objectiveName) {
+        if (objectiveName == null || objectiveName.isEmpty()) {
+            return;
+        }
+
+        final ScoreboardStorage.Objective objective = scoreboard.objective(objectiveName);
+        if (objective == null) {
+            return;
+        }
+
+        final boolean hideNumberFormat = shouldHideNumberFormat(scoreboard, objectiveName, objective.renderType());
+        if (hideNumberFormat == objective.numberFormatHidden()) {
+            return;
+        }
+
+        final PacketWrapper objectivePacket = wrapper.create(ClientboundPackets1_20_3.SET_OBJECTIVE);
+        objectivePacket.write(Types.STRING, objectiveName);
+        objectivePacket.write(Types.BYTE, (byte) 2); // Update objective
+        objectivePacket.write(Types.TRUSTED_TAG, objective.displayName().copy());
+        objectivePacket.write(Types.VAR_INT, objective.renderType());
+        writeNumberFormat(objectivePacket, hideNumberFormat);
+        objectivePacket.send(Protocol1_20_2To1_20_3.class);
+        scoreboard.setNumberFormatHidden(objectiveName, hideNumberFormat);
+    }
+
     @Override
     protected void onMappingDataLoaded() {
         EntityTypes1_20_3.initialize(this);
@@ -345,6 +396,11 @@ public final class Protocol1_20_2To1_20_3 extends AbstractProtocol<ClientboundPa
     @Override
     public void init(final UserConnection connection) {
         addEntityTracker(connection, new EntityTrackerBase(connection, EntityTypes1_20_3.PLAYER));
+    }
+
+    @Override
+    public ProtocolStorablesBase createStorables() {
+        return new ProtocolStorables1_20_3();
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
@@ -100,21 +100,34 @@ public final class Protocol1_20_2To1_20_3 extends AbstractProtocol<ClientboundPa
             wrapper.write(Types.BOOLEAN, false);
         });
         registerClientbound(ClientboundPackets1_20_2.SET_OBJECTIVE, wrapper -> {
-            final String objectiveName = wrapper.passthrough(Types.STRING); // Objective Name
-            final byte action = wrapper.passthrough(Types.BYTE); // Method
-            final ScoreboardStorage scoreboard = wrapper.user().<ProtocolStorables1_20_3>storables(this).scoreboard();
+            final String objectiveName = wrapper.passthrough(Types.STRING);
+            final byte action = wrapper.passthrough(Types.BYTE);
             if (action == 0 || action == 2) {
+                if (!Via.getConfig().hideScoreboardNumbers()) {
+                    convertComponent(wrapper); // Display name
+                    wrapper.passthrough(Types.VAR_INT); // Render type
+                    wrapper.write(Types.BOOLEAN, false); // No number format
+                    return;
+                }
+
                 final Tag displayName = ComponentUtil.jsonToTag(wrapper.read(Types.COMPONENT));
-                wrapper.write(Types.TRUSTED_TAG, displayName); // Display Name
-                final int render = wrapper.passthrough(Types.VAR_INT); // Render type
+                wrapper.write(Types.TRUSTED_TAG, displayName);
+
+                final ScoreboardStorage scoreboard = wrapper.user().<ProtocolStorables1_20_3>storables(this).scoreboard();
+                final int render = wrapper.passthrough(Types.VAR_INT);
                 final boolean hideNumberFormat = shouldHideNumberFormat(scoreboard, objectiveName, render);
                 writeNumberFormat(wrapper, hideNumberFormat);
                 scoreboard.putObjective(objectiveName, displayName.copy(), render, hideNumberFormat);
-            } else if (action == 1) {
+            } else if (action == 1 && Via.getConfig().hideScoreboardNumbers()) {
+                final ScoreboardStorage scoreboard = wrapper.user().<ProtocolStorables1_20_3>storables(this).scoreboard();
                 scoreboard.removeObjective(objectiveName);
             }
         });
         registerClientbound(ClientboundPackets1_20_2.SET_DISPLAY_OBJECTIVE, wrapper -> {
+            if (!Via.getConfig().hideScoreboardNumbers()) {
+                return;
+            }
+
             final int slot = wrapper.passthrough(Types.VAR_INT);
             final String objectiveName = wrapper.passthrough(Types.STRING);
             final ScoreboardStorage scoreboard = wrapper.user().<ProtocolStorables1_20_3>storables(this).scoreboard();
@@ -351,7 +364,7 @@ public final class Protocol1_20_2To1_20_3 extends AbstractProtocol<ClientboundPa
     }
 
     private static boolean shouldHideNumberFormat(final ScoreboardStorage scoreboard, final String objectiveName, final int renderType) {
-        return renderType == 0 && Via.getConfig().hideScoreboardNumbers() && scoreboard.isSidebar(objectiveName);
+        return renderType == 0 && scoreboard.isSidebar(objectiveName);
     }
 
     private static void writeNumberFormat(final PacketWrapper wrapper, final boolean hideNumberFormat) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/storage/ProtocolStorables1_20_3.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/storage/ProtocolStorables1_20_3.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_20_2to1_20_3.storage;
+
+import com.viaversion.viaversion.connection.ProtocolStorablesBase;
+
+public final class ProtocolStorables1_20_3 extends ProtocolStorablesBase {
+
+    private final ScoreboardStorage scoreboard = new ScoreboardStorage();
+
+    public ScoreboardStorage scoreboard() {
+        return scoreboard;
+    }
+}

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/storage/ScoreboardStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/storage/ScoreboardStorage.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_20_2to1_20_3.storage;
+
+import com.viaversion.nbt.tag.Tag;
+import java.util.HashMap;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class ScoreboardStorage {
+
+    private static final int SIDEBAR_SLOT = 1;
+    private static final int FIRST_TEAM_SIDEBAR_SLOT = 3;
+    private static final int LAST_TEAM_SIDEBAR_SLOT = 18;
+    private final Map<String, Objective> objectives = new HashMap<>();
+    private final Map<Integer, String> displaySlots = new HashMap<>();
+
+    public void putObjective(final String name, final Tag displayName, final int renderType, final boolean numberFormatHidden) {
+        objectives.put(name, new Objective(displayName, renderType, numberFormatHidden));
+    }
+
+    public void removeObjective(final String name) {
+        objectives.remove(name);
+        displaySlots.values().removeIf(name::equals);
+    }
+
+    public @Nullable Objective objective(final String name) {
+        return objectives.get(name);
+    }
+
+    public void setNumberFormatHidden(final String name, final boolean numberFormatHidden) {
+        final Objective objective = objectives.get(name);
+        if (objective != null) {
+            objectives.put(name, new Objective(objective.displayName(), objective.renderType(), numberFormatHidden));
+        }
+    }
+
+    public @Nullable String setDisplaySlot(final int slot, final String objectiveName) {
+        if (objectiveName.isEmpty()) {
+            return displaySlots.remove(slot);
+        }
+        return displaySlots.put(slot, objectiveName);
+    }
+
+    public boolean isSidebar(final String objectiveName) {
+        for (final Map.Entry<Integer, String> entry : displaySlots.entrySet()) {
+            if (isSidebarSlot(entry.getKey()) && objectiveName.equals(entry.getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isSidebarSlot(final int slot) {
+        return slot == SIDEBAR_SLOT || slot >= FIRST_TEAM_SIDEBAR_SLOT && slot <= LAST_TEAM_SIDEBAR_SLOT;
+    }
+
+    public record Objective(Tag displayName, int renderType, boolean numberFormatHidden) {
+    }
+}

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/storage/ScoreboardStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_2to1_20_3/storage/ScoreboardStorage.java
@@ -18,6 +18,8 @@
 package com.viaversion.viaversion.protocols.v1_20_2to1_20_3.storage;
 
 import com.viaversion.nbt.tag.Tag;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.HashMap;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -28,7 +30,7 @@ public final class ScoreboardStorage {
     private static final int FIRST_TEAM_SIDEBAR_SLOT = 3;
     private static final int LAST_TEAM_SIDEBAR_SLOT = 18;
     private final Map<String, Objective> objectives = new HashMap<>();
-    private final Map<Integer, String> displaySlots = new HashMap<>();
+    private final Int2ObjectMap<String> displaySlots = new Int2ObjectOpenHashMap<>();
 
     public void putObjective(final String name, final Tag displayName, final int renderType, final boolean numberFormatHidden) {
         objectives.put(name, new Objective(displayName, renderType, numberFormatHidden));
@@ -58,8 +60,8 @@ public final class ScoreboardStorage {
     }
 
     public boolean isSidebar(final String objectiveName) {
-        for (final Map.Entry<Integer, String> entry : displaySlots.entrySet()) {
-            if (isSidebarSlot(entry.getKey()) && objectiveName.equals(entry.getValue())) {
+        for (final Int2ObjectMap.Entry<String> entry : displaySlots.int2ObjectEntrySet()) {
+            if (isSidebarSlot(entry.getIntKey()) && objectiveName.equals(entry.getValue())) {
                 return true;
             }
         }

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -194,7 +194,7 @@ enforce-secure-chat: false
 # Handles items with invalid count values (higher than max stack size) on 1.20.3 servers.
 handle-invalid-item-count: false
 #
-# Hides scoreboard numbers for 1.20.3+ clients on older server versions.
+# Hides sidebar scoreboard numbers for 1.20.3+ clients on older server versions.
 hide-scoreboard-numbers: false
 #
 # Fixes 1.21+ clients on 1.20.5 servers placing water/lava buckets at the wrong location when moving fast, NOTE: This may cause issues with anti-cheat plugins.


### PR DESCRIPTION
Right now if you enable the hide-scoreboard-numbers option it also breaks health below nametags and other scoreboard numbers. This patch only makes it hide numbers for sidebar.