### PR TITLE
Fix synthetic timeline tag bindings

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/Protocol1_21_9To1_21_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/Protocol1_21_9To1_21_11.java
@@ -66,6 +66,7 @@ import com.viaversion.viaversion.rewriter.TagRewriter;
 import com.viaversion.viaversion.rewriter.block.BlockRewriter1_21_5;
 import com.viaversion.viaversion.rewriter.text.NBTComponentRewriter;
 import com.viaversion.viaversion.util.Key;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -96,6 +97,13 @@ public final class Protocol1_21_9To1_21_11 extends AbstractProtocol<ClientboundP
         super.registerPackets();
 
         appendClientbound(ClientboundConfigurationPackets1_21_9.FINISH_CONFIGURATION, wrapper -> {
+            final ProtocolStorables1_21_11 storables = wrapper.user().storables(this);
+            if (!storables.timelineTagsSent()) {
+                final PacketWrapper tagsPacket = wrapper.create(ClientboundConfigurationPackets1_21_9.UPDATE_TAGS);
+                tagsPacket.write(Types.VAR_INT, 0);
+                tagsPacket.send(Protocol1_21_9To1_21_11.class, false);
+            }
+
             final PacketWrapper zombieNautilusVariantsPacket = wrapper.create(ClientboundConfigurationPackets1_21_9.REGISTRY_DATA);
             zombieNautilusVariantsPacket.write(Types.STRING, "zombie_nautilus_variant");
             final CompoundTag temperateZombieNautilus = new CompoundTag();
@@ -113,7 +121,11 @@ public final class Protocol1_21_9To1_21_11 extends AbstractProtocol<ClientboundP
             }
             timelinePacket.write(Types.REGISTRY_ENTRY_ARRAY, timelineEntries);
             timelinePacket.send(Protocol1_21_9To1_21_11.class);
+            storables.setTimelineTagsSent(false);
         });
+
+        replaceClientbound(ClientboundPackets1_21_9.UPDATE_TAGS, this::handleTags);
+        replaceClientbound(ClientboundConfigurationPackets1_21_9.UPDATE_TAGS, this::handleTags);
 
         registryDataRewriter.addHandler("dimension_type", (key, tag) -> {
             final ByteTag trueTag = new ByteTag((byte) 1);
@@ -248,6 +260,49 @@ public final class Protocol1_21_9To1_21_11 extends AbstractProtocol<ClientboundP
                 attributes.put("visual/ambient_particles", ambientParticles);
             }
         });
+    }
+
+    private void handleTags(final PacketWrapper wrapper) {
+        tagRewriter.handleGeneric(wrapper);
+        appendTimelineTags(wrapper, timelineIds());
+
+        final ProtocolStorables1_21_11 storables = wrapper.user().storables(this);
+        storables.setTimelineTagsSent(true);
+    }
+
+    static void appendTimelineTags(final PacketWrapper wrapper, final Map<String, Integer> timelineIds) {
+        final int villagerSchedule = timelineId(timelineIds, "villager_schedule");
+
+        wrapper.set(Types.VAR_INT, 0, wrapper.get(Types.VAR_INT, 0) + 1);
+        wrapper.write(Types.STRING, "minecraft:timeline");
+        wrapper.write(Types.VAR_INT, 4);
+        writeTag(wrapper, "minecraft:universal", villagerSchedule);
+        writeTag(wrapper, "minecraft:in_overworld", villagerSchedule, timelineId(timelineIds, "day"),
+            timelineId(timelineIds, "moon"), timelineId(timelineIds, "early_game"));
+        writeTag(wrapper, "minecraft:in_nether", villagerSchedule);
+        writeTag(wrapper, "minecraft:in_end", villagerSchedule);
+    }
+
+    private static Map<String, Integer> timelineIds() {
+        final Map<String, Integer> timelineIds = new HashMap<>(MAPPINGS.timelineRegistry().size());
+        int index = 0;
+        for (final String key : MAPPINGS.timelineRegistry().keySet()) {
+            timelineIds.put(Key.stripMinecraftNamespace(key), index++);
+        }
+        return timelineIds;
+    }
+
+    private static int timelineId(final Map<String, Integer> timelineIds, final String key) {
+        final Integer id = timelineIds.get(key);
+        if (id == null) {
+            throw new IllegalStateException("Missing synthetic timeline entry: " + key);
+        }
+        return id;
+    }
+
+    private static void writeTag(final PacketWrapper wrapper, final String key, final int... entries) {
+        wrapper.write(Types.STRING, key);
+        wrapper.write(Types.VAR_INT_ARRAY_PRIMITIVE, entries);
     }
 
     private void addAmbientCaveSound(final CompoundTag attributes) {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/storage/ProtocolStorables1_21_11.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/storage/ProtocolStorables1_21_11.java
@@ -22,8 +22,17 @@ import com.viaversion.viaversion.connection.ProtocolStorablesBase;
 public final class ProtocolStorables1_21_11 extends ProtocolStorablesBase {
 
     private final GameTimeStorage gameTimeStorage = new GameTimeStorage();
+    private boolean timelineTagsSent;
 
     public GameTimeStorage gameTimeStorage() {
         return gameTimeStorage;
+    }
+
+    public boolean timelineTagsSent() {
+        return timelineTagsSent;
+    }
+
+    public void setTimelineTagsSent(final boolean timelineTagsSent) {
+        this.timelineTagsSent = timelineTagsSent;
     }
 }

--- a/common/src/test/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/Protocol1_21_9To1_21_11Test.java
+++ b/common/src/test/java/com/viaversion/viaversion/protocols/v1_21_9to1_21_11/Protocol1_21_9To1_21_11Test.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_21_9to1_21_11;
+
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
+import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.protocol.packet.PacketWrapperImpl;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class Protocol1_21_9To1_21_11Test {
+
+    @Test
+    void appendsCompleteTimelineTagBindingsWithoutReplacingExistingRegistries() {
+        final PacketWrapper wrapper = new PacketWrapperImpl(0, null, null);
+        wrapper.write(Types.VAR_INT, 2);
+        wrapper.write(Types.STRING, "minecraft:item");
+        wrapper.write(Types.VAR_INT, 0);
+        wrapper.write(Types.STRING, "minecraft:block");
+        wrapper.write(Types.VAR_INT, 0);
+
+        Protocol1_21_9To1_21_11.appendTimelineTags(wrapper, Map.of(
+            "day", 5,
+            "early_game", 9,
+            "moon", 7,
+            "villager_schedule", 3
+        ));
+
+        assertEquals(3, wrapper.get(Types.VAR_INT, 0));
+        assertEquals("minecraft:item", wrapper.get(Types.STRING, 0));
+        assertEquals("minecraft:block", wrapper.get(Types.STRING, 1));
+        assertEquals("minecraft:timeline", wrapper.get(Types.STRING, 2));
+        assertEquals(4, wrapper.get(Types.VAR_INT, 3));
+        assertEquals("minecraft:universal", wrapper.get(Types.STRING, 3));
+        assertArrayEquals(new int[]{3}, wrapper.get(Types.VAR_INT_ARRAY_PRIMITIVE, 0));
+        assertEquals("minecraft:in_overworld", wrapper.get(Types.STRING, 4));
+        assertArrayEquals(new int[]{3, 5, 7, 9}, wrapper.get(Types.VAR_INT_ARRAY_PRIMITIVE, 1));
+        assertEquals("minecraft:in_nether", wrapper.get(Types.STRING, 5));
+        assertArrayEquals(new int[]{3}, wrapper.get(Types.VAR_INT_ARRAY_PRIMITIVE, 2));
+        assertEquals("minecraft:in_end", wrapper.get(Types.STRING, 6));
+        assertArrayEquals(new int[]{3}, wrapper.get(Types.VAR_INT_ARRAY_PRIMITIVE, 3));
+    }
+}


### PR DESCRIPTION
Adds the missing timeline tag bindings when translating 1.21.9 configuration data to 1.21.11.

Bindings are appended to existing tag packets, or synthesized before `finish_configuration` when a server sends none.