### PR TITLE
Rewrite teleport reply position to fix riding teleport loop on 1.8 servers

### DIFF
--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/Protocol1_8To1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/Protocol1_8To1_9.java
@@ -47,6 +47,7 @@ import com.viaversion.viaversion.protocols.v1_8to1_9.storage.CommandBlockStorage
 import com.viaversion.viaversion.protocols.v1_8to1_9.storage.EntityTracker1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.storage.InventoryTracker;
 import com.viaversion.viaversion.protocols.v1_8to1_9.storage.MovementTracker;
+import com.viaversion.viaversion.protocols.v1_8to1_9.storage.TeleportPositionStorage;
 import com.viaversion.viaversion.util.ComponentUtil;
 import com.viaversion.viaversion.util.SerializerVersion;
 
@@ -107,6 +108,7 @@ public class Protocol1_8To1_9 extends AbstractProtocol<ClientboundPackets1_8, Cl
         userConnection.storables(this).setClientWorld(new ClientWorld1_9());
 
         userConnection.put(new MovementTracker());
+        userConnection.put(new TeleportPositionStorage());
         userConnection.put(new InventoryTracker());
         userConnection.put(new CommandBlockStorage());
     }

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/PlayerPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/rewriter/PlayerPacketRewriter1_9.java
@@ -25,6 +25,7 @@ import com.viaversion.nbt.tag.StringTag;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.minecraft.ClientWorld;
 import com.viaversion.viaversion.api.minecraft.GameMode;
+import com.viaversion.viaversion.api.minecraft.Vector3d;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_9;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
@@ -39,6 +40,7 @@ import com.viaversion.viaversion.protocols.v1_8to1_9.provider.MainHandProvider;
 import com.viaversion.viaversion.protocols.v1_8to1_9.storage.ClientWorld1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.storage.EntityTracker1_9;
 import com.viaversion.viaversion.protocols.v1_8to1_9.storage.MovementTracker;
+import com.viaversion.viaversion.protocols.v1_8to1_9.storage.TeleportPositionStorage;
 import com.viaversion.viaversion.util.ComponentUtil;
 
 public class PlayerPacketRewriter1_9 {
@@ -112,6 +114,12 @@ public class PlayerPacketRewriter1_9 {
                 map(Types.BYTE); // 5 - Player Flags
 
                 create(Types.VAR_INT, 0); // 6 - Teleport ID was added
+
+                handler(wrapper -> {
+                    // Remember the teleport position so the client's reply can be rewritten to it
+                    final TeleportPositionStorage teleportPositions = wrapper.user().get(TeleportPositionStorage.class);
+                    teleportPositions.addPendingPosition(new Vector3d(wrapper.get(Types.DOUBLE, 0), wrapper.get(Types.DOUBLE, 1), wrapper.get(Types.DOUBLE, 2)));
+                });
             }
         });
 
@@ -449,6 +457,16 @@ public class PlayerPacketRewriter1_9 {
             tracker.incrementIdlePacket();
             tracker.setGround(wrapper.get(Types.BOOLEAN, 0));
         };
+        // 1.21.2+ clients reply to teleports with their own (e.g. mounted) position instead of the
+        // teleport position; rewrite it so the 1.8 server recognizes the teleport as confirmed.
+        final PacketHandler teleportPositionHandler = wrapper -> {
+            final Vector3d position = wrapper.user().get(TeleportPositionStorage.class).pollPendingPosition();
+            if (position != null) {
+                wrapper.set(Types.DOUBLE, 0, position.x());
+                wrapper.set(Types.DOUBLE, 1, position.y());
+                wrapper.set(Types.DOUBLE, 2, position.z());
+            }
+        };
         protocol.registerServerbound(ServerboundPackets1_9.MOVE_PLAYER_POS, new PacketHandlers() {
             @Override
             public void register() {
@@ -457,6 +475,7 @@ public class PlayerPacketRewriter1_9 {
                 map(Types.DOUBLE); // 2 - Z
                 map(Types.BOOLEAN); // 3 - Ground
                 handler(onGroundHandler);
+                handler(teleportPositionHandler);
             }
         });
         protocol.registerServerbound(ServerboundPackets1_9.MOVE_PLAYER_POS_ROT, new PacketHandlers() {
@@ -469,6 +488,7 @@ public class PlayerPacketRewriter1_9 {
                 map(Types.FLOAT); // 4 - Pitch
                 map(Types.BOOLEAN); // 5 - Ground
                 handler(onGroundHandler);
+                handler(teleportPositionHandler);
             }
         });
         protocol.registerServerbound(ServerboundPackets1_9.MOVE_PLAYER_ROT, new PacketHandlers() {

--- a/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/TeleportPositionStorage.java
+++ b/common/src/main/java/com/viaversion/viaversion/protocols/v1_8to1_9/storage/TeleportPositionStorage.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.protocols.v1_8to1_9.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.minecraft.Vector3d;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Positions of the teleports most recently sent to the client.
+ * Since 1.21.2, clients keep their own position when receiving a teleport while riding and reply
+ * with that instead of the teleport position. A 1.8 server expects the reply at the teleport
+ * position, treats anything else as an illegal move, and endlessly corrects the player.
+ * See https://github.com/ViaVersion/ViaVersion/issues/4748
+ */
+public class TeleportPositionStorage implements StorableObject {
+    private static final int MAX_PENDING_POSITIONS = 64;
+
+    private final Deque<Vector3d> pendingPositions = new ArrayDeque<>();
+
+    public void addPendingPosition(Vector3d position) {
+        if (this.pendingPositions.size() >= MAX_PENDING_POSITIONS) {
+            this.pendingPositions.poll();
+        }
+        this.pendingPositions.add(position);
+    }
+
+    /**
+     * Returns and removes the oldest pending teleport position, or null if none is pending.
+     */
+    public Vector3d pollPendingPosition() {
+        return this.pendingPositions.poll();
+    }
+}

--- a/common/src/test/java/com/viaversion/viaversion/common/storage/TeleportPositionStorageTest.java
+++ b/common/src/test/java/com/viaversion/viaversion/common/storage/TeleportPositionStorageTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of ViaVersion - https://github.com/ViaVersion/ViaVersion
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viaversion.common.storage;
+
+import com.viaversion.viaversion.api.minecraft.Vector3d;
+import com.viaversion.viaversion.protocols.v1_8to1_9.storage.TeleportPositionStorage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TeleportPositionStorageTest {
+
+    @Test
+    void testPollEmpty() {
+        // Every position packet without a pending teleport polls the storage; must not throw
+        Assertions.assertNull(new TeleportPositionStorage().pollPendingPosition());
+    }
+
+    @Test
+    void testFifoOrder() {
+        // Replies must be paired with their own teleport, in send order
+        final TeleportPositionStorage storage = new TeleportPositionStorage();
+        storage.addPendingPosition(new Vector3d(1, 2, 3));
+        storage.addPendingPosition(new Vector3d(4, 5, 6));
+
+        final Vector3d first = storage.pollPendingPosition();
+        Assertions.assertEquals(1, first.x(), "oldest teleport should be polled first");
+        Assertions.assertEquals(2, first.y(), "oldest teleport should be polled first");
+        Assertions.assertEquals(3, first.z(), "oldest teleport should be polled first");
+
+        final Vector3d second = storage.pollPendingPosition();
+        Assertions.assertEquals(4, second.x(), "second teleport should be polled second");
+        Assertions.assertEquals(5, second.y(), "second teleport should be polled second");
+        Assertions.assertEquals(6, second.z(), "second teleport should be polled second");
+
+        Assertions.assertNull(storage.pollPendingPosition());
+    }
+
+    @Test
+    void testInterleavedAddAndPoll() {
+        // Mounts can queue two teleports before the first reply arrives; later teleports
+        // must still be paired correctly with their replies
+        final TeleportPositionStorage storage = new TeleportPositionStorage();
+        storage.addPendingPosition(new Vector3d(1, 0, 0));
+        storage.addPendingPosition(new Vector3d(2, 0, 0));
+
+        Assertions.assertEquals(1, storage.pollPendingPosition().x(), "first reply should get the first teleport");
+        storage.addPendingPosition(new Vector3d(3, 0, 0));
+        Assertions.assertEquals(2, storage.pollPendingPosition().x(), "second reply should get the second teleport");
+        Assertions.assertEquals(3, storage.pollPendingPosition().x(), "third reply should get the third teleport");
+        Assertions.assertNull(storage.pollPendingPosition());
+    }
+
+    @Test
+    void testOldestPositionDroppedAtLimit() {
+        // A server spamming teleports without replies must not grow the queue unboundedly
+        final TeleportPositionStorage storage = new TeleportPositionStorage();
+        final int overLimit = 6;
+        for (int i = 0; i < 64 + overLimit; i++) {
+            storage.addPendingPosition(new Vector3d(i, 0, 0));
+        }
+
+        Assertions.assertEquals(overLimit, storage.pollPendingPosition().x(), "oldest positions should have been dropped");
+    }
+}


### PR DESCRIPTION
Fixes #4748

Since 1.21.2, the client keeps its own position when it receives a teleport while riding and replies with that position instead of the teleport position. As from the  [protocol docs](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Synchronize_Player_Position):
> If the player is riding a vehicle, this packet has no effect, but both the [Confirm Teleportation](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Confirm_Teleportation) and [Set Player Position and Rotation](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Set_Player_Position_and_Rotation) packets are still sent.

An 1.8 server, however, expects the reply at the teleport position and treats anything else as an "illegal" move and endlessly corrects the player. Each correction is another teleport, so client and server ping-pong until the client is kicked ("You are sending too many packets"). Clients before 1.21.1 applied the teleport even while riding, so this never happened before.

This PR implements a fix by remembering the position of every teleport sent to the client and rewriting the client's reply to it. This matches pre-1.21.2 behavior of the client.

Reproduced on Paper 1.8.8 with a 26.2 client (packet capture + server-side teleport-event log showing ~250 corrections/s until the kick, see #4748). With this change the loop no longer occurs and mount/dismount behaves normally.

Disclosure: Part of the research and implementation of this PR were AI assisted. I've reviewed and verified the results and any changes made.